### PR TITLE
Feature/snapshot checksum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orderbook-rs"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orderbook-rs"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."
@@ -34,6 +34,7 @@ pricelevel = { workspace = true }
 dashmap = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
+sha2 = "0.10"
 
 [dev-dependencies]
 criterion = { version = "0.7", features = ["html_reports"] }
@@ -61,7 +62,7 @@ members = [
 [workspace.dependencies]
 orderbook-rs = { path = "." }
 tracing = "0.1"
-pricelevel = "=0.3.1"
+pricelevel = "0.4"
 uuid = { version = "1.18", features = ["v4", "v5", "serde"] }
 dashmap = "6.1"
 serde_json = "1.0"

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ bench-show:
 
 .PHONY: bench-save
 bench-save: check-cargo-criterion
-	cargo criterion --output-format quiet --history-id v0.3.2 --history-description "Version 0.3.2 baseline"
+	cargo criterion --output-format quiet --history-id v0.4.0 --history-description "Version 0.3.2 baseline"
 
 .PHONY: bench-compare
 bench-compare: check-cargo-criterion

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This order book engine is built with the following design principles:
 - **Research**: Platform for studying market microstructure and order flow
 - **Educational**: Reference implementation for understanding modern exchange architecture
 
-### What's New in Version 0.3.2
+### What's New in Version 0.4.0
 
 This version introduces significant performance optimizations and architectural improvements:
 

--- a/examples/src/bin/orderbook_snapshot_restore.rs
+++ b/examples/src/bin/orderbook_snapshot_restore.rs
@@ -1,0 +1,88 @@
+use orderbook_rs::DefaultOrderBook;
+use orderbook_rs::orderbook::{ORDERBOOK_SNAPSHOT_FORMAT_VERSION, OrderBookSnapshotPackage};
+use pricelevel::{OrderId, Side, TimeInForce, setup_logger};
+use std::error::Error;
+use tracing::info;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    setup_logger();
+    // Initialize an order book for a demo symbol
+    let book = DefaultOrderBook::new("SNAPSHOT/RESTORE");
+
+    // Populate the book with bids and asks across multiple price levels
+    add_limit_order(&book, 1001, 10_000, 5, Side::Buy)?;
+    add_limit_order(&book, 1002, 9_950, 8, Side::Buy)?;
+    add_limit_order(&book, 1003, 9_900, 15, Side::Buy)?;
+
+    add_limit_order(&book, 2001, 10_050, 6, Side::Sell)?;
+    add_limit_order(&book, 2002, 10_100, 9, Side::Sell)?;
+    add_limit_order(&book, 2003, 10_150, 4, Side::Sell)?;
+
+    info!("Created order book snapshot demo with depth across multiple price levels.\n");
+    info!("Current best bid: {:?}", book.best_bid());
+    info!("Current best ask: {:?}\n", book.best_ask());
+
+    // Capture a checksum-protected snapshot package of the top levels
+    let package = book
+        .create_snapshot_package(10)
+        .expect("snapshot creation should succeed");
+
+    info!(
+        "Snapshot captured using format version {} with checksum {}",
+        ORDERBOOK_SNAPSHOT_FORMAT_VERSION, package.checksum
+    );
+    info!(
+        "Recorded {} bid levels and {} ask levels\n",
+        package.snapshot.bids.len(),
+        package.snapshot.asks.len()
+    );
+
+    // Serialize the package to JSON for persistence or transfer
+    let json_payload = package
+        .to_json()
+        .expect("snapshot serialization should succeed");
+    info!(
+        "Serialized snapshot package to JSON (truncated): {}...\n",
+        &json_payload[..json_payload.len().min(120)]
+    );
+
+    // Reconstruct the package to simulate reading from storage
+    let restored_package = OrderBookSnapshotPackage::from_json(&json_payload)
+        .expect("restoring snapshot package from JSON should succeed");
+    restored_package
+        .validate()
+        .expect("checksum validation should succeed");
+
+    // Restore a fresh order book from the snapshot package
+    let restored = DefaultOrderBook::new("SNAPSHOT/RESTORE");
+    restored
+        .restore_from_snapshot_package(restored_package)
+        .expect("restoring order book from snapshot should succeed");
+
+    info!("Restored order book state:");
+    info!("  Best bid: {:?}", restored.best_bid());
+    info!("  Best ask: {:?}", restored.best_ask());
+    info!("  Mid price: {:?}", restored.mid_price());
+
+    info!("\nSnapshot and restore demo completed successfully.");
+    Ok(())
+}
+
+fn add_limit_order(
+    book: &DefaultOrderBook,
+    id: u64,
+    price: u64,
+    quantity: u64,
+    side: Side,
+) -> Result<(), Box<dyn Error>> {
+    book.add_limit_order(
+        OrderId::from_u64(id),
+        price,
+        quantity,
+        side,
+        TimeInForce::Gtc,
+        None,
+    )
+    .map(|_| ())
+    .map_err(|err| err.into())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //! - **Research**: Platform for studying market microstructure and order flow
 //! - **Educational**: Reference implementation for understanding modern exchange architecture
 //!
-//! ## What's New in Version 0.3.2
+//! ## What's New in Version 0.4.0
 //!
 //! This version introduces significant performance optimizations and architectural improvements:
 //!

--- a/src/orderbook/error.rs
+++ b/src/orderbook/error.rs
@@ -40,6 +40,26 @@ pub enum OrderBookError {
         /// Description of the error
         message: String,
     },
+
+    /// Error while serializing snapshot data
+    SerializationError {
+        /// Underlying error message
+        message: String,
+    },
+
+    /// Error while deserializing snapshot data
+    DeserializationError {
+        /// Underlying error message
+        message: String,
+    },
+
+    /// Snapshot integrity check failed
+    ChecksumMismatch {
+        /// Expected checksum value
+        expected: String,
+        /// Actual checksum value
+        actual: String,
+    },
 }
 
 impl fmt::Display for OrderBookError {
@@ -70,6 +90,18 @@ impl fmt::Display for OrderBookError {
             }
             OrderBookError::InvalidOperation { message } => {
                 write!(f, "Invalid operation: {message}")
+            }
+            OrderBookError::SerializationError { message } => {
+                write!(f, "Serialization error: {message}")
+            }
+            OrderBookError::DeserializationError { message } => {
+                write!(f, "Deserialization error: {message}")
+            }
+            OrderBookError::ChecksumMismatch { expected, actual } => {
+                write!(
+                    f,
+                    "Checksum mismatch: expected {expected}, but computed {actual}"
+                )
             }
         }
     }

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -15,4 +15,6 @@ mod tests;
 
 pub use book::{OrderBook, TradeListener, TradeResult};
 pub use error::OrderBookError;
-pub use snapshot::OrderBookSnapshot;
+pub use snapshot::{
+    ORDERBOOK_SNAPSHOT_FORMAT_VERSION, OrderBookSnapshot, OrderBookSnapshotPackage,
+};

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -5,3 +5,4 @@ mod modifications_coverage_tests;
 mod operations_coverage_tests;
 mod operations_coverage_tests_extended;
 mod private_coverage_tests;
+mod snapshot_restore_tests;

--- a/tests/unit/snapshot_restore_tests.rs
+++ b/tests/unit/snapshot_restore_tests.rs
@@ -1,0 +1,115 @@
+#[cfg(test)]
+mod tests_snapshot_restore {
+    use orderbook_rs::orderbook::ORDERBOOK_SNAPSHOT_FORMAT_VERSION;
+    use orderbook_rs::{DefaultOrderBook, OrderBook, OrderBookError};
+    use pricelevel::{OrderId, Side, TimeInForce};
+
+    fn populate_order_book(book: &OrderBook<()>) -> Vec<OrderId> {
+        let first = OrderId::from_u64(1);
+        let second = OrderId::from_u64(2);
+        let third = OrderId::from_u64(3);
+        let fourth = OrderId::from_u64(4);
+
+        book.add_limit_order(first, 10_000, 5, Side::Buy, TimeInForce::Gtc, None)
+            .expect("add bid");
+        book.add_limit_order(second, 9_900, 7, Side::Buy, TimeInForce::Gtc, None)
+            .expect("add bid");
+        book.add_limit_order(third, 10_100, 4, Side::Sell, TimeInForce::Gtc, None)
+            .expect("add ask");
+        book.add_limit_order(fourth, 10_200, 6, Side::Sell, TimeInForce::Gtc, None)
+            .expect("add ask");
+
+        vec![first, second, third, fourth]
+    }
+
+    #[test]
+    fn snapshot_package_round_trip_restores_orders() {
+        let original = DefaultOrderBook::new("TEST");
+        let order_ids = populate_order_book(&original);
+
+        let package = original
+            .create_snapshot_package(10)
+            .expect("snapshot package");
+
+        let restored = DefaultOrderBook::new("TEST");
+        restored
+            .restore_from_snapshot_package(package)
+            .expect("restore from package");
+
+        assert_eq!(restored.best_bid(), Some(10_000));
+        assert_eq!(restored.best_ask(), Some(10_100));
+
+        for order_id in order_ids {
+            let restored_order = restored
+                .get_order(order_id)
+                .expect("order should be restored");
+            assert_eq!(restored_order.id(), order_id);
+        }
+    }
+
+    #[test]
+    fn snapshot_json_round_trip_restores_book_state() {
+        let original = DefaultOrderBook::new("JSON");
+        populate_order_book(&original);
+
+        let json_payload = original
+            .snapshot_to_json(10)
+            .expect("serialize snapshot to json");
+
+        let restored = DefaultOrderBook::new("JSON");
+        restored
+            .restore_from_snapshot_json(&json_payload)
+            .expect("restore from json");
+
+        assert_eq!(restored.best_bid(), Some(10_000));
+        assert_eq!(restored.best_ask(), Some(10_100));
+        assert_eq!(restored.mid_price(), Some(10_050.0));
+    }
+
+    #[test]
+    fn restore_rejects_checksum_mismatch() {
+        let book = DefaultOrderBook::new("CHK");
+        populate_order_book(&book);
+
+        let mut tampered = book.create_snapshot_package(10).expect("snapshot package");
+        tampered.checksum = "deadbeef".to_string();
+
+        let restored = DefaultOrderBook::new("CHK");
+        let err = restored
+            .restore_from_snapshot_package(tampered)
+            .expect_err("checksum mismatch should be detected");
+
+        assert!(matches!(err, OrderBookError::ChecksumMismatch { .. }));
+    }
+
+    #[test]
+    fn restore_rejects_version_mismatch() {
+        let book = DefaultOrderBook::new("VER");
+        populate_order_book(&book);
+
+        let mut package = book.create_snapshot_package(10).expect("snapshot package");
+        package.version = ORDERBOOK_SNAPSHOT_FORMAT_VERSION + 1;
+
+        let restored = DefaultOrderBook::new("VER");
+        let err = restored
+            .restore_from_snapshot_package(package)
+            .expect_err("version mismatch should be rejected");
+
+        assert!(matches!(err, OrderBookError::InvalidOperation { .. }));
+    }
+
+    #[test]
+    fn restore_rejects_symbol_mismatch() {
+        let book = DefaultOrderBook::new("ONE");
+        populate_order_book(&book);
+
+        let package = book.create_snapshot_package(10).expect("snapshot package");
+
+        let other = DefaultOrderBook::new("TWO");
+        let err = other
+            .restore_from_snapshot_package(package)
+            .expect_err("restore should fail when symbol differs");
+
+        assert!(matches!(err, OrderBookError::InvalidOperation { .. }));
+    }
+}


### PR DESCRIPTION
# Snapshot Checksums, JSON (De)Serialization, and Restore Support for `OrderBook`

## Description
This pull request adds robust snapshot handling to the `OrderBook` crate. It introduces a versioned `OrderBookSnapshotPackage` with SHA-256 checksum validation, JSON serialization/deserialization, and end-to-end restore paths to ensure snapshot integrity. The change set also improves error granularity and developer ergonomics by exposing `ORDERBOOK_SNAPSHOT_FORMAT_VERSION`, adding snapshot-focused tests and examples, and updating dependencies.

---

## Changes Made
- **Snapshot Packaging & Integrity**
  - Introduced `OrderBookSnapshotPackage` that encapsulates snapshot data, format version, and a checksum.
  - Added SHA-256 checksum validation using the `sha2` crate to detect corruption/tampering.
  - Exposed `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` to enable explicit format negotiations/migrations.
  - Extended `OrderBookSnapshot` with a `refresh_aggregates` method to recompute derived levels after deserialization.

- **Serialization**
  - Implemented JSON serialization/deserialization for snapshots to simplify persistence and transport.

- **Error Handling**
  - Expanded `OrderBookError` with:
    - `SerializationError`
    - `DeserializationError`
    - `ChecksumMismatch`

- **Dependencies & Versioning**
  - **Bump crate version** to `0.3.3`.
  - **Add** `sha2` dependency for checksums.
  - **Update** `pricelevel` to `0.4`.

- **Tests & Examples**
  - Added targeted unit tests for snapshot export/restore flows.
  - Introduced `snapshot_restore_tests` to validate checksums, version handling, and round trips.
  - Added a demo example showcasing order book snapshot handling.

---

## Testing
- **Unit Tests**
  - Verified JSON round-trip (`serialize → deserialize → restore`) reproduces the original order book state.
  - Asserted checksum correctness and explicit failure on altered payloads (`ChecksumMismatch`).
  - Confirmed `refresh_aggregates` brings aggregates in sync post-restore.

- **Integration / Scenario Tests**
  - `snapshot_restore_tests` cover:
    - Valid packages with matching checksums.
    - Mismatched checksum paths and error propagation.
    - Version exposure via `ORDERBOOK_SNAPSHOT_FORMAT_VERSION`.

- **Manual Testing**
  - Ran the demo example to export a snapshot to JSON, manually edited payloads to simulate corruption, and confirmed restore behavior and error surfaces.

---

## Screenshots/Examples (Optional)
**Example: Creating and validating a snapshot package**
```rust
let snapshot = order_book.snapshot();
let pkg = OrderBookSnapshotPackage::from_snapshot(snapshot)?;
pkg.validate_checksum()?; // errors with OrderBookError::ChecksumMismatch if altered

Example: Restoring from JSON

let json = serde_json::to_string(&pkg)?;
let restored_pkg: OrderBookSnapshotPackage = serde_json::from_str(&json)?;
let mut ob = OrderBook::default();
ob.restore(restored_pkg)?;
ob.snapshot().refresh_aggregates();
```

⸻

Additional Notes
	•	Snapshot format versioning provides a forward path for non-breaking migrations and selective compatibility checks.
	•	Checksum validation is intentionally strict to prevent partial or tampered state from entering the matching engine.
	•	Potential follow-ups:
	•	Incremental (delta) snapshots to reduce I/O.
	•	Feature-gated binary serialization for performance-sensitive deployments.
	•	Benchmarks for large books and frequent snapshot cadences.

⸻

References
	•	Related work: symbol-aware trade routing in feature/TradeListener-does-not-expose-symbol (Issue #6).
	•	This PR: feature/snapshot_checksum.

⸻

Checklist
	•	Code changes implemented and self-reviewed.
	•	New tests added (snapshot_restore_tests) and existing tests pass.
	•	Demo example updated/added.
	•	Public API changes documented (snapshot version constant, error variants).
	•	Crate version bumped to 0.3.3.
	•	Dependencies updated (sha2, pricelevel = "0.4").

