### PR TITLE
Bump version to `0.4.1` in `Cargo.toml`, `README.md`, `lib.rs`, and `…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orderbook-rs"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."
@@ -61,8 +61,7 @@ members = [
 
 [workspace.dependencies]
 orderbook-rs = { path = "." }
-pricelevel = "0.4.1"
-#pricelevel = { path = "../PriceLevel"}
+pricelevel = "0.4.2"
 tracing = "0.1"
 uuid = { version = "1.18", features = ["v4", "v5", "serde"] }
 dashmap = "6.1"

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ bench-show:
 
 .PHONY: bench-save
 bench-save: check-cargo-criterion
-	cargo criterion --output-format quiet --history-id v0.4.0 --history-description "Version 0.3.2 baseline"
+	cargo criterion --output-format quiet --history-id v0.4.1 --history-description "Version 0.3.2 baseline"
 
 .PHONY: bench-compare
 bench-compare: check-cargo-criterion

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This order book engine is built with the following design principles:
 - **Research**: Platform for studying market microstructure and order flow
 - **Educational**: Reference implementation for understanding modern exchange architecture
 
-### What's New in Version 0.4.0
+### What's New in Version 0.4.1
 
 This version introduces significant performance optimizations and architectural improvements:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //! - **Research**: Platform for studying market microstructure and order flow
 //! - **Educational**: Reference implementation for understanding modern exchange architecture
 //!
-//! ## What's New in Version 0.4.0
+//! ## What's New in Version 0.4.1
 //!
 //! This version introduces significant performance optimizations and architectural improvements:
 //!


### PR DESCRIPTION
…Makefile`. Update `pricelevel` dependency to `0.4.2`. Adjust benchmarks history for version alignment.