### PR TITLE
Bump version to `0.4.5` in `Cargo.toml`, `README.md`, `lib.rs`, and `…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orderbook-rs"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ bench-show:
 
 .PHONY: bench-save
 bench-save: check-cargo-criterion
-	cargo criterion --output-format quiet --history-id v0.4.4 --history-description "Version 0.3.2 baseline"
+	cargo criterion --output-format quiet --history-id v0.4.5 --history-description "Version 0.3.2 baseline"
 
 .PHONY: bench-compare
 bench-compare: check-cargo-criterion

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This order book engine is built with the following design principles:
 - **Research**: Platform for studying market microstructure and order flow
 - **Educational**: Reference implementation for understanding modern exchange architecture
 
-### What's New in Version 0.4.4
+### What's New in Version 0.4.5
 
 This version introduces significant performance optimizations and architectural improvements:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //! - **Research**: Platform for studying market microstructure and order flow
 //! - **Educational**: Reference implementation for understanding modern exchange architecture
 //!
-//! ## What's New in Version 0.4.4
+//! ## What's New in Version 0.4.5
 //!
 //! This version introduces significant performance optimizations and architectural improvements:
 //!

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -8,7 +8,7 @@ use crate::utils::current_time_millis;
 use dashmap::DashMap;
 use pricelevel::{MatchResult, OrderId, OrderType, PriceLevel, Side, UuidGenerator};
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -706,5 +706,46 @@ where
         }
 
         (bid_volumes, ask_volumes)
+    }
+
+    /// Get an Arc reference to the bids DashMap
+    pub fn get_bids(&self) -> Arc<DashMap<u64, Arc<PriceLevel>>> {
+        Arc::new(self.bids.clone())
+    }
+
+    /// Get an Arc reference to the asks DashMap
+    pub fn get_asks(&self) -> Arc<DashMap<u64, Arc<PriceLevel>>> {
+        Arc::new(self.asks.clone())
+    }
+
+    /// Get a BTreeMap of bids with price as key and PriceLevel as value
+    pub fn get_bt_bids(&self) -> BTreeMap<u64, PriceLevel> {
+        self.bids
+            .iter()
+            .map(|entry| {
+                let price = *entry.key();
+                let snapshot = entry.value().snapshot();
+                let price_level = PriceLevel::from(&snapshot);
+                (price, price_level)
+            })
+            .collect()
+    }
+
+    /// Get a BTreeMap of asks with price as key and PriceLevel as value
+    pub fn get_bt_asks(&self) -> BTreeMap<u64, PriceLevel> {
+        self.asks
+            .iter()
+            .map(|entry| {
+                let price = *entry.key();
+                let snapshot = entry.value().snapshot();
+                let price_level = PriceLevel::from(&snapshot);
+                (price, price_level)
+            })
+            .collect()
+    }
+
+    /// Get an Arc reference to the order_locations DashMap
+    pub fn get_order_locations_arc(&self) -> Arc<DashMap<OrderId, (u64, Side)>> {
+        Arc::new(self.order_locations.clone())
     }
 }


### PR DESCRIPTION
…Makefile`. Update benchmarks history for version alignment and add utility methods for bid/ask data extraction in `orderbook`.