### PR TITLE
Add depth analysis methods for cumulative depth calculations in Order…

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,554 @@
+# OrderBook-rs Examples
+
+This directory contains **13 comprehensive examples** demonstrating various features and use cases of the OrderBook-rs library. Each example is designed to showcase specific functionality and best practices for different use cases from beginner tutorials to advanced performance testing.
+
+## 📑 Quick Index
+
+| Example | Description | Level |
+|---------|-------------|-------|
+| `prelude_demo` | Quick start with simplified imports | 🎓 Beginner |
+| `basic_orderbook` | Comprehensive OrderBook introduction | 🎓 Beginner |
+| `market_trades_demo` | Market order execution and trades | 🎓 Beginner |
+| `depth_analysis` | ⭐ **New!** Market depth & liquidity analysis | 💡 Advanced |
+| `trade_listener_demo` | Real-time trade notifications | 💡 Advanced |
+| `trade_listener_channels` | Multi-book trade routing | 💡 Advanced |
+| `orderbook_snapshot_restore` | State persistence & recovery | 💡 Advanced |
+| `multi_threaded_orderbook` | Concurrent operations (8 threads) | 🚀 Performance |
+| `orderbook_hft_simulation` | HFT simulation (30 threads) | 🚀 Performance |
+| `orderbook_contention_test` | Advanced stress testing | 🚀 Performance |
+| `price_level_debug` | Low-level debugging | 🔧 Debug |
+| `price_level_transition` | State transition testing | 🔧 Debug |
+
+## Running Examples
+
+All examples can be run from the `examples` directory:
+
+```bash
+cd examples
+cargo run --bin <example_name>
+```
+
+For release mode (better performance):
+
+```bash
+cargo run --bin <example_name> --release
+```
+
+## Available Examples
+
+### 📊 Depth Analysis (`depth_analysis.rs`)
+
+**New!** Demonstrates the depth analysis methods for market making and liquidity analysis.
+
+```bash
+cargo run --bin depth_analysis
+```
+
+**Features demonstrated:**
+- `price_at_depth()` - Find price level where cumulative depth reaches a target
+- `cumulative_depth_to_target()` - Get both price and actual cumulative depth at target
+- `total_depth_at_levels()` - Calculate total depth in first N price levels
+- Market impact estimation for large orders
+- Liquidity distribution analysis across price levels
+
+**Use cases:**
+- Market making strategies
+- Order execution planning
+- Liquidity analysis
+- Price impact estimation
+
+---
+
+### 📘 Basic OrderBook (`basic_orderbook.rs`)
+
+Comprehensive introduction to the OrderBook API covering all fundamental operations. Perfect starting point for new users.
+
+```bash
+cargo run --bin basic_orderbook
+```
+
+**Features demonstrated:**
+- Creating an order book with market close timestamps
+- Adding various types of limit orders (buy and sell)
+- Adding iceberg orders with hidden quantities
+- Market order submission and execution
+- Limit order matching mechanics
+- Order lookup and retrieval by ID
+- Order cancellation
+- Displaying book state and statistics
+- Time-in-force order types (GTC, IOC, FOK)
+
+**What you'll learn:**
+- Basic OrderBook lifecycle
+- Order management fundamentals
+- How matching engine works
+- Error handling patterns
+
+---
+
+### 🔀 Multi-threaded OrderBook (`multi_threaded_orderbook.rs`)
+
+Performance test demonstrating the OrderBook's thread-safe operations and lock-free architecture under concurrent load.
+
+```bash
+cargo run --bin multi_threaded_orderbook
+```
+
+**Features demonstrated:**
+- Concurrent order insertion from multiple threads
+- Thread-safe order matching without locks
+- Real-time performance metrics (operations per second)
+- Synchronization using barriers
+- Pre-population strategies for realistic testing
+- Mixed workloads (adds, cancels, queries)
+
+**Configuration:**
+- 8 concurrent threads by default
+- 5-second test duration
+- 1000 pre-populated orders
+- Automatic performance reporting
+
+**What you'll learn:**
+- How the lock-free architecture handles contention
+- Thread-safe access patterns
+- Performance characteristics under load
+- Scalability across multiple cores
+
+---
+
+### ⚡ HFT Simulation (`orderbook_hft_simulation.rs`)
+
+Realistic high-frequency trading simulation modeling real exchange behavior with makers, takers, and cancellers.
+
+```bash
+cargo run --bin orderbook_hft_simulation
+```
+
+**Features demonstrated:**
+- 30 concurrent threads simulating HFT activity
+  - 10 maker threads (creating liquidity)
+  - 10 taker threads (consuming liquidity)
+  - 10 canceller threads (order management)
+- Custom order metadata with client/user/exchange IDs
+- Realistic price distributions across 20 levels
+- Order ID queue management for cancellations
+- Comprehensive performance statistics
+- Before/after OrderBook state comparison
+
+**Configuration:**
+- Symbol: BTC/USD
+- Duration: 5 seconds
+- Base bid: 9,900 | Base ask: 10,000
+- 20 price levels with 5-unit spreads
+- Pre-loaded with initial liquidity
+
+**Performance metrics:**
+- Orders added per second
+- Orders matched per second
+- Orders cancelled per second
+- Total operations per second
+- Final book state analysis
+
+**What you'll learn:**
+- Real-world exchange simulation
+- High-throughput order processing
+- Thread coordination in HFT scenarios
+- Performance benchmarking techniques
+
+---
+
+### 🔥 Contention Test (`orderbook_contention_test.rs`)
+
+Advanced stress testing analyzing OrderBook performance under various contention patterns and workload distributions.
+
+```bash
+cargo run --bin orderbook_contention_test
+```
+
+**Features demonstrated:**
+- **Read/Write Ratio Test**: Analyzes performance with different ratios (0%, 25%, 50%, 75%, 95% reads)
+- **Hot Spot Contention Test**: Measures performance when operations concentrate on specific price levels
+- **Price Level Distribution Test**: Tests with varying numbers of active price levels (1-1000)
+- Lock-free architecture benefits under extreme contention
+- Performance metrics across different access patterns
+- Scalability analysis with detailed statistics
+
+**Configuration:**
+- 12 concurrent threads
+- 3-second test duration per scenario
+- Pre-populated order books for each test
+- Comprehensive performance reporting
+
+**Test scenarios:**
+1. **Read/Write Patterns**: Understanding cache effects and contention
+2. **Hot Spots**: Performance when activity concentrates (0%-100% concentration)
+3. **Price Distribution**: How the number of levels affects throughput
+
+**What you'll learn:**
+- How lock-free data structures handle contention
+- Optimal workload distributions
+- Cache effects in concurrent systems
+- Performance tuning strategies
+
+---
+
+### 💹 Market Trades Demo (`market_trades_demo.rs`)
+
+Demonstrates market order execution, trade generation, and the TradeListener event system.
+
+```bash
+cargo run --bin market_trades_demo
+```
+
+**Features demonstrated:**
+- Creating OrderBook with TradeListener callback
+- Adding bid and ask limit orders to build liquidity
+- Executing market orders (buy and sell)
+- Real-time trade capture with TradeListener
+- Trade information extraction and display
+- Transaction details (price, quantity, timestamps)
+- Partial fills and complete fills
+- Order matching mechanics visualization
+
+**Step-by-step walkthrough:**
+1. Set up order book with trade listener
+2. Add bid orders (buy side liquidity)
+3. Add ask orders (sell side liquidity)
+4. Display initial book state
+5. Execute market orders
+6. Display all captured trades with details
+
+**What you'll learn:**
+- How market orders execute against the book
+- Trade event system integration
+- Best practices for trade tracking
+- Understanding the matching engine output
+
+---
+
+### 📸 Snapshot & Restore (`orderbook_snapshot_restore.rs`)
+
+Demonstrates OrderBook state persistence through snapshots with checksum validation and JSON serialization.
+
+```bash
+cargo run --bin orderbook_snapshot_restore
+```
+
+**Features demonstrated:**
+- Creating OrderBook snapshots with top N levels
+- Checksum-protected snapshot packages
+- JSON serialization and deserialization
+- Snapshot validation and integrity checking
+- Restoring OrderBook state from snapshots
+- Handling snapshot format versions
+- Error handling for corrupted snapshots
+
+**Snapshot features:**
+- Captures configurable number of price levels (default: top 10)
+- Includes format version for compatibility
+- SHA-256 checksum for data integrity
+- JSON format for easy storage/transmission
+- Complete bid and ask level preservation
+
+**What you'll learn:**
+- State persistence strategies
+- Data integrity with checksums
+- Serialization best practices
+- Disaster recovery patterns
+- Snapshot validation techniques
+
+---
+
+### 📻 Trade Listener Demo (`trade_listener_demo.rs`)
+
+Real-time trade monitoring using the TradeListener callback system for immediate trade notifications.
+
+```bash
+cargo run --bin trade_listener_demo
+```
+
+**Features demonstrated:**
+- Creating OrderBook with TradeListener callback
+- Real-time trade event notifications
+- Displaying trade information as matches occur
+- Crossing limit orders that generate trades
+- Trade details extraction (price, quantity, sides)
+- Multi-step order execution patterns
+
+**Walkthrough:**
+1. Set up order book with real-time trade listener
+2. Add initial liquidity (bids and asks)
+3. Execute crossing limit orders
+4. Watch trades display in real-time
+5. Final book state analysis
+
+**What you'll learn:**
+- Event-driven order book integration
+- Real-time trade monitoring patterns
+- Trade listener callback design
+- Immediate notification handling
+
+---
+
+### 📡 Trade Listener Channels (`trade_listener_channels.rs`)
+
+Advanced trade listener pattern using channels for multi-book management and async communication.
+
+```bash
+cargo run --bin trade_listener_channels
+```
+
+**Features demonstrated:**
+- TradeListener with channel-based communication
+- Multi-book management with `BookManager`
+- Symbol-aware trade routing
+- Async trade processing patterns
+- Managing multiple OrderBooks simultaneously
+- Real-world trading system architecture
+
+**Architecture:**
+- `BookManager` for centralized trade handling
+- Channel-based trade distribution
+- Symbol identification in trade events
+- Thread-safe multi-book operations
+
+**What you'll learn:**
+- Production-ready trade listener patterns
+- Multi-book trading system design
+- Channel-based event distribution
+- Scalable trade processing architecture
+
+---
+
+### 🔍 Price Level Debug (`price_level_debug.rs`)
+
+Low-level debugging tool for analyzing price level distribution and concurrent operations.
+
+```bash
+cargo run --bin price_level_debug
+```
+
+**Features demonstrated:**
+- Price level distribution analysis
+- Concurrent operations with 4 threads
+- Order pre-population strategies
+- Book state verification with snapshots
+- Memory usage patterns
+- Debug-level performance testing
+
+**Configuration:**
+- 4 threads (optimized for debugging)
+- 1-second test duration
+- 100 price levels
+- 10 orders per level minimum
+- Detailed state reporting
+
+**What you'll learn:**
+- Price level internal mechanics
+- Debugging concurrent issues
+- State inspection techniques
+- Performance analysis tools
+
+---
+
+### 🔄 Price Level Transition (`price_level_transition.rs`)
+
+Tests OrderBook behavior during price level transitions and varying distributions.
+
+```bash
+cargo run --bin price_level_transition
+```
+
+**Features demonstrated:**
+- Testing with multiple price level configurations (100, 5)
+- Transitioning between different distributions
+- Verifying state consistency across changes
+- Snapshot-based state validation
+- Concurrent operations during transitions
+- Performance across different scenarios
+
+**Test cases:**
+1. High distribution: 100 price levels
+2. Low distribution: 5 price levels
+3. Transition handling between configurations
+
+**What you'll learn:**
+- How OrderBook handles varying distributions
+- State consistency during changes
+- Performance characteristics at extremes
+- Debugging distribution-related issues
+
+---
+
+### 🎯 Prelude Demo (`prelude_demo.rs`)
+
+Demonstrates the convenience of the prelude module for streamlined imports and quick prototyping.
+
+```bash
+cargo run --bin prelude_demo
+```
+
+**Features demonstrated:**
+- Single-line import with `use orderbook_rs::prelude::*`
+- All commonly used types available immediately
+- Quick OrderBook creation and operations
+- `DefaultOrderBook` type alias usage
+- Utility functions from prelude (`current_time_millis`)
+- Clean, concise code without verbose imports
+
+**Types available via prelude:**
+- `OrderBook` - Main order book structure
+- `OrderId` - Order identifier
+- `Side` - Buy/Sell enum
+- `TimeInForce` - Order duration types
+- `DefaultOrderBook` - Type alias for `OrderBook<()>`
+- `TradeListener` - Trade event callback
+- `TradeResult` - Trade execution results
+- `current_time_millis` - Timestamp utility
+
+**What you'll learn:**
+- Prelude module best practices
+- Quick prototyping patterns
+- Reducing boilerplate imports
+- Type aliases for common use cases
+
+---
+
+## Example Categories
+
+### 🎓 For Beginners (Start Here!)
+1. **`prelude_demo.rs`** - Quick start with simplified imports
+2. **`basic_orderbook.rs`** - Comprehensive introduction to all core concepts
+3. **`market_trades_demo.rs`** - Understanding order execution and trades
+
+**Recommended order:** Start with `prelude_demo.rs` to understand the basics, then move to `basic_orderbook.rs` for a comprehensive overview, and finally `market_trades_demo.rs` to see trades in action.
+
+---
+
+### 🚀 For Performance Testing
+1. **`multi_threaded_orderbook.rs`** - Basic concurrent operations (8 threads)
+2. **`orderbook_hft_simulation.rs`** - Realistic HFT simulation (30 threads)
+3. **`orderbook_contention_test.rs`** - Advanced stress testing with multiple scenarios
+
+**Use these to:** Benchmark performance, test scalability, understand lock-free architecture benefits.
+
+---
+
+### 💡 For Advanced Features
+1. **`depth_analysis.rs`** - ⭐ **New!** Market depth and liquidity analysis
+2. **`trade_listener_demo.rs`** - Real-time event notifications
+3. **`trade_listener_channels.rs`** - Multi-book trade routing
+4. **`orderbook_snapshot_restore.rs`** - State persistence and recovery
+
+**Use these to:** Build market-making bots, implement advanced trading strategies, manage multiple order books.
+
+---
+
+### 🔧 For Debugging & Analysis
+1. **`price_level_debug.rs`** - Low-level price level inspection
+2. **`price_level_transition.rs`** - Testing state transitions
+
+**Use these to:** Debug issues, understand internals, analyze performance bottlenecks.
+
+---
+
+## Building All Examples
+
+Compile all examples at once:
+
+```bash
+cd examples
+cargo build --bins
+```
+
+For optimized release builds:
+
+```bash
+cargo build --bins --release
+```
+
+---
+
+## Running with Logging
+
+All examples support logging via the `tracing` framework. Log output is enabled by default with INFO level.
+
+To adjust log levels, set the `RUST_LOG` environment variable:
+
+```bash
+# Show only warnings and errors
+RUST_LOG=warn cargo run --bin depth_analysis
+
+# Show debug information
+RUST_LOG=debug cargo run --bin depth_analysis
+
+# Show everything including trace
+RUST_LOG=trace cargo run --bin depth_analysis
+```
+
+---
+
+## Helper Utilities (`helpers.rs`)
+
+The `helpers.rs` module provides common utilities shared across examples:
+
+**Functions available:**
+- `setup_orders_for_read_write_test()` - Pre-populate order book for testing
+- `setup_orders_for_test()` - Generic order setup with configurable levels
+- Order generation utilities
+- Random data creation helpers
+- Display formatting functions
+- Test data setup patterns
+
+These helpers reduce code duplication and provide consistent testing patterns across examples.
+
+## Requirements
+
+- Rust 1.70 or higher
+- Dependencies are managed via the workspace `Cargo.toml`
+
+## Documentation
+
+For detailed API documentation, see:
+- [OrderBook API docs](https://docs.rs/orderbook-rs)
+- [Main README](../README.md)
+
+## 💡 Tips for Learning
+
+**Recommended learning path:**
+1. Start with `prelude_demo` to understand the API basics
+2. Study `basic_orderbook` for comprehensive coverage
+3. Run `market_trades_demo` to see trades in action
+4. Explore `depth_analysis` for advanced market making
+5. Try `multi_threaded_orderbook` to understand concurrency
+6. Dive into `orderbook_hft_simulation` for realistic scenarios
+
+**Performance testing:**
+- Always use `--release` flag for accurate benchmarks
+- Start with `multi_threaded_orderbook` for baseline metrics
+- Use `orderbook_contention_test` to analyze bottlenecks
+- Compare results across different hardware
+
+**Debugging tips:**
+- Use `RUST_LOG=debug` for detailed logging
+- `price_level_debug` helps understand internal state
+- Check snapshots with `orderbook_snapshot_restore`
+
+## Contributing Examples
+
+When adding new examples:
+1. Place the file in `src/bin/`
+2. Add documentation comments at the top of the file
+3. Update this README with:
+   - Entry in Quick Index table
+   - Detailed section with features
+   - Category assignment
+4. Ensure it compiles without warnings (`cargo clippy`)
+5. Test with `cargo run --bin <name>`
+6. Add to appropriate category based on complexity
+
+## 📞 Need Help?
+
+- Check the [main documentation](https://docs.rs/orderbook-rs)
+- Read the [project README](../README.md)
+- Open an issue on [GitHub](https://github.com/joaquinbejar/OrderBook-rs/issues)

--- a/examples/src/bin/depth_analysis.rs
+++ b/examples/src/bin/depth_analysis.rs
@@ -1,0 +1,336 @@
+// examples/src/bin/depth_analysis.rs
+//
+// This example demonstrates the depth analysis methods available in the OrderBook.
+// These methods are useful for:
+// - Market making strategies
+// - Liquidity analysis
+// - Market impact estimation
+// - Order execution planning
+//
+// Methods demonstrated:
+// - `price_at_depth()`: Find the price level where cumulative depth reaches a target
+// - `cumulative_depth_to_target()`: Get both price and actual cumulative depth
+// - `total_depth_at_levels()`: Calculate total depth in the first N price levels
+//
+// Run this example with:
+//   cargo run --bin depth_analysis
+//   (from the examples directory)
+
+use orderbook_rs::OrderBook;
+use pricelevel::{OrderId, Side, TimeInForce, setup_logger};
+use tracing::info;
+
+fn main() {
+    // Set up logging
+    setup_logger();
+    info!("Depth Analysis Example");
+
+    // Create a new order book for a symbol
+    let book = create_orderbook_with_liquidity("ETH/USD");
+
+    // Display current book state
+    display_orderbook_state(&book);
+
+    // Demonstrate price_at_depth method
+    demo_price_at_depth(&book);
+
+    // Demonstrate cumulative_depth_to_target method
+    demo_cumulative_depth_to_target(&book);
+
+    // Demonstrate total_depth_at_levels method
+    demo_total_depth_at_levels(&book);
+
+    // Demonstrate practical use case: market impact estimation
+    demo_market_impact_estimation(&book);
+}
+
+fn create_orderbook_with_liquidity(symbol: &str) -> OrderBook {
+    info!("\n=== Creating OrderBook with Liquidity ===");
+    info!("Symbol: {}", symbol);
+
+    let book = OrderBook::new(symbol);
+
+    // Add buy orders (bids) at different price levels
+    info!("\nAdding buy orders (bids):");
+    let bid_orders = vec![
+        (2000, 10), // Price: 2000, Quantity: 10
+        (1999, 15),
+        (1998, 20),
+        (1997, 25),
+        (1996, 30),
+        (1995, 35),
+    ];
+
+    for (price, quantity) in bid_orders {
+        let order_id = OrderId::new();
+        let _ = book.add_limit_order(order_id, price, quantity, Side::Buy, TimeInForce::Gtc, None);
+        info!(
+            "  Added bid: {} @ {} (total: {})",
+            quantity, price, quantity
+        );
+    }
+
+    // Add sell orders (asks) at different price levels
+    info!("\nAdding sell orders (asks):");
+    let ask_orders = vec![
+        (2001, 12), // Price: 2001, Quantity: 12
+        (2002, 18),
+        (2003, 22),
+        (2004, 28),
+        (2005, 32),
+        (2006, 38),
+    ];
+
+    for (price, quantity) in ask_orders {
+        let order_id = OrderId::new();
+        let _ = book.add_limit_order(
+            order_id,
+            price,
+            quantity,
+            Side::Sell,
+            TimeInForce::Gtc,
+            None,
+        );
+        info!(
+            "  Added ask: {} @ {} (total: {})",
+            quantity, price, quantity
+        );
+    }
+
+    book
+}
+
+fn display_orderbook_state(book: &OrderBook) {
+    info!("\n=== OrderBook State ===");
+
+    // Display best bid and ask
+    if let Some(best_bid) = book.best_bid() {
+        info!("Best Bid: {}", best_bid);
+    }
+
+    if let Some(best_ask) = book.best_ask() {
+        info!("Best Ask: {}", best_ask);
+    }
+
+    if let (Some(bid), Some(ask)) = (book.best_bid(), book.best_ask()) {
+        let spread = ask.saturating_sub(bid);
+        info!("Spread: {}", spread);
+    }
+}
+
+fn demo_price_at_depth(book: &OrderBook) {
+    info!("\n=== price_at_depth() Demo ===");
+    info!("Finds the price level where cumulative depth reaches a target quantity");
+
+    // Test on buy side
+    info!("\nBuy side (bids - highest to lowest):");
+    let buy_targets = vec![10, 25, 50, 100, 200];
+
+    for target in buy_targets {
+        match book.price_at_depth(target, Side::Buy) {
+            Some(price) => info!("  Target depth {}: reached at price {}", target, price),
+            None => info!("  Target depth {}: insufficient liquidity", target),
+        }
+    }
+
+    // Test on sell side
+    info!("\nSell side (asks - lowest to highest):");
+    let sell_targets = vec![12, 30, 60, 120, 200];
+
+    for target in sell_targets {
+        match book.price_at_depth(target, Side::Sell) {
+            Some(price) => info!("  Target depth {}: reached at price {}", target, price),
+            None => info!("  Target depth {}: insufficient liquidity", target),
+        }
+    }
+}
+
+fn demo_cumulative_depth_to_target(book: &OrderBook) {
+    info!("\n=== cumulative_depth_to_target() Demo ===");
+    info!("Returns both the price and actual cumulative depth at target");
+
+    // Test on buy side
+    info!("\nBuy side (bids):");
+    let buy_targets = vec![10, 25, 50, 100];
+
+    for target in buy_targets {
+        match book.cumulative_depth_to_target(target, Side::Buy) {
+            Some((price, actual_depth)) => {
+                info!(
+                    "  Target {}: price={}, actual_depth={}",
+                    target, price, actual_depth
+                );
+                if actual_depth > target {
+                    info!(
+                        "    (Cumulative depth exceeded target by {})",
+                        actual_depth - target
+                    );
+                }
+            }
+            None => info!("  Target {}: insufficient liquidity", target),
+        }
+    }
+
+    // Test on sell side
+    info!("\nSell side (asks):");
+    let sell_targets = vec![12, 30, 60, 120];
+
+    for target in sell_targets {
+        match book.cumulative_depth_to_target(target, Side::Sell) {
+            Some((price, actual_depth)) => {
+                info!(
+                    "  Target {}: price={}, actual_depth={}",
+                    target, price, actual_depth
+                );
+                if actual_depth > target {
+                    info!(
+                        "    (Cumulative depth exceeded target by {})",
+                        actual_depth - target
+                    );
+                }
+            }
+            None => info!("  Target {}: insufficient liquidity", target),
+        }
+    }
+}
+
+fn demo_total_depth_at_levels(book: &OrderBook) {
+    info!("\n=== total_depth_at_levels() Demo ===");
+    info!("Calculates total depth available in the first N price levels");
+
+    // Test on buy side
+    info!("\nBuy side (bids):");
+    for levels in 1..=6 {
+        let depth = book.total_depth_at_levels(levels, Side::Buy);
+        info!("  Top {} level(s): total depth = {}", levels, depth);
+    }
+
+    // Test on sell side
+    info!("\nSell side (asks):");
+    for levels in 1..=6 {
+        let depth = book.total_depth_at_levels(levels, Side::Sell);
+        info!("  Top {} level(s): total depth = {}", levels, depth);
+    }
+
+    // Test edge cases
+    info!("\nEdge cases:");
+    let zero_depth = book.total_depth_at_levels(0, Side::Buy);
+    info!("  Zero levels: {}", zero_depth);
+
+    let excessive_depth = book.total_depth_at_levels(100, Side::Buy);
+    info!(
+        "  Excessive levels (100): {} (returns all available)",
+        excessive_depth
+    );
+}
+
+fn demo_market_impact_estimation(book: &OrderBook) {
+    info!("\n=== Practical Use Case: Market Impact Estimation ===");
+    info!("Estimating the impact of executing large market orders");
+
+    // Simulate large buy market order
+    let buy_quantity = 80;
+    info!("\nSimulating market BUY order of {} units:", buy_quantity);
+
+    if let Some((worst_price, total_filled)) =
+        book.cumulative_depth_to_target(buy_quantity, Side::Sell)
+    {
+        if let Some(best_price) = book.best_ask() {
+            let price_impact = worst_price.saturating_sub(best_price);
+            let price_impact_pct = (price_impact as f64 / best_price as f64) * 100.0;
+
+            info!("  Best ask price: {}", best_price);
+            info!("  Worst fill price: {}", worst_price);
+            info!(
+                "  Price impact: {} ({:.2}%)",
+                price_impact, price_impact_pct
+            );
+            info!("  Total filled: {}", total_filled);
+
+            if total_filled >= buy_quantity {
+                info!("  ✓ Order can be fully filled");
+            } else {
+                info!(
+                    "  ✗ Insufficient liquidity (only {} available)",
+                    total_filled
+                );
+            }
+
+            // Calculate average fill price (simplified)
+            let avg_price = (best_price + worst_price) / 2;
+            info!("  Estimated avg fill price: ~{}", avg_price);
+        }
+    } else {
+        info!("  ✗ Insufficient liquidity to fill order");
+    }
+
+    // Simulate large sell market order
+    let sell_quantity = 70;
+    info!("\nSimulating market SELL order of {} units:", sell_quantity);
+
+    if let Some((worst_price, total_filled)) =
+        book.cumulative_depth_to_target(sell_quantity, Side::Buy)
+    {
+        if let Some(best_price) = book.best_bid() {
+            let price_impact = best_price.saturating_sub(worst_price);
+            let price_impact_pct = (price_impact as f64 / best_price as f64) * 100.0;
+
+            info!("  Best bid price: {}", best_price);
+            info!("  Worst fill price: {}", worst_price);
+            info!(
+                "  Price impact: {} ({:.2}%)",
+                price_impact, price_impact_pct
+            );
+            info!("  Total filled: {}", total_filled);
+
+            if total_filled >= sell_quantity {
+                info!("  ✓ Order can be fully filled");
+            } else {
+                info!(
+                    "  ✗ Insufficient liquidity (only {} available)",
+                    total_filled
+                );
+            }
+
+            // Calculate average fill price (simplified)
+            let avg_price = (best_price + worst_price) / 2;
+            info!("  Estimated avg fill price: ~{}", avg_price);
+        }
+    } else {
+        info!("  ✗ Insufficient liquidity to fill order");
+    }
+
+    // Market depth analysis
+    info!("\n=== Market Depth Analysis ===");
+    info!("Analyzing liquidity distribution across price levels:");
+
+    info!("\nBid side depth distribution:");
+    for level in 1..=5 {
+        let depth = book.total_depth_at_levels(level, Side::Buy);
+        let prev_depth = if level > 1 {
+            book.total_depth_at_levels(level - 1, Side::Buy)
+        } else {
+            0
+        };
+        let level_depth = depth - prev_depth;
+        info!(
+            "  Level {}: {} units (cumulative: {})",
+            level, level_depth, depth
+        );
+    }
+
+    info!("\nAsk side depth distribution:");
+    for level in 1..=5 {
+        let depth = book.total_depth_at_levels(level, Side::Sell);
+        let prev_depth = if level > 1 {
+            book.total_depth_at_levels(level - 1, Side::Sell)
+        } else {
+            0
+        };
+        let level_depth = depth - prev_depth;
+        info!(
+            "  Level {}: {} units (cumulative: {})",
+            level, level_depth, depth
+        );
+    }
+}

--- a/src/orderbook/tests/depth_analysis.rs
+++ b/src/orderbook/tests/depth_analysis.rs
@@ -1,0 +1,258 @@
+//! Tests for depth analysis methods
+
+#[cfg(test)]
+mod tests {
+    use crate::OrderBook;
+    use pricelevel::{OrderId, Side, TimeInForce};
+
+    #[test]
+    fn test_price_at_depth_buy_side() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add bid orders at different price levels
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 99, 20, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 98, 30, Side::Buy, TimeInForce::Gtc, None);
+
+        // Target depth of 10 should be at price 100
+        assert_eq!(book.price_at_depth(10, Side::Buy), Some(100));
+
+        // Target depth of 25 should be at price 99 (10 + 20 >= 25)
+        assert_eq!(book.price_at_depth(25, Side::Buy), Some(99));
+
+        // Target depth of 60 should be at price 98 (10 + 20 + 30 = 60)
+        assert_eq!(book.price_at_depth(60, Side::Buy), Some(98));
+
+        // Target depth of 100 exceeds available liquidity
+        assert_eq!(book.price_at_depth(100, Side::Buy), None);
+    }
+
+    #[test]
+    fn test_price_at_depth_sell_side() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add ask orders at different price levels
+        let _ = book.add_limit_order(OrderId::new(), 101, 15, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 102, 25, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 103, 35, Side::Sell, TimeInForce::Gtc, None);
+
+        // Target depth of 15 should be at price 101
+        assert_eq!(book.price_at_depth(15, Side::Sell), Some(101));
+
+        // Target depth of 30 should be at price 102 (15 + 25 >= 30)
+        assert_eq!(book.price_at_depth(30, Side::Sell), Some(102));
+
+        // Target depth of 75 should be at price 103 (15 + 25 + 35 = 75)
+        assert_eq!(book.price_at_depth(75, Side::Sell), Some(103));
+
+        // Target depth of 100 exceeds available liquidity
+        assert_eq!(book.price_at_depth(100, Side::Sell), None);
+    }
+
+    #[test]
+    fn test_price_at_depth_empty_book() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Empty book should return None
+        assert_eq!(book.price_at_depth(10, Side::Buy), None);
+        assert_eq!(book.price_at_depth(10, Side::Sell), None);
+    }
+
+    #[test]
+    fn test_cumulative_depth_to_target_buy_side() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add bid orders at different price levels
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 99, 20, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 98, 30, Side::Buy, TimeInForce::Gtc, None);
+
+        // Target depth of 10 should return (100, 10)
+        assert_eq!(
+            book.cumulative_depth_to_target(10, Side::Buy),
+            Some((100, 10))
+        );
+
+        // Target depth of 25 should return (99, 30) - cumulative is 10 + 20 = 30
+        assert_eq!(
+            book.cumulative_depth_to_target(25, Side::Buy),
+            Some((99, 30))
+        );
+
+        // Target depth of 60 should return (98, 60) - cumulative is 10 + 20 + 30 = 60
+        assert_eq!(
+            book.cumulative_depth_to_target(60, Side::Buy),
+            Some((98, 60))
+        );
+
+        // Target depth of 100 exceeds available liquidity
+        assert_eq!(book.cumulative_depth_to_target(100, Side::Buy), None);
+    }
+
+    #[test]
+    fn test_cumulative_depth_to_target_sell_side() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add ask orders at different price levels
+        let _ = book.add_limit_order(OrderId::new(), 101, 15, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 102, 25, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 103, 35, Side::Sell, TimeInForce::Gtc, None);
+
+        // Target depth of 15 should return (101, 15)
+        assert_eq!(
+            book.cumulative_depth_to_target(15, Side::Sell),
+            Some((101, 15))
+        );
+
+        // Target depth of 30 should return (102, 40) - cumulative is 15 + 25 = 40
+        assert_eq!(
+            book.cumulative_depth_to_target(30, Side::Sell),
+            Some((102, 40))
+        );
+
+        // Target depth of 75 should return (103, 75) - cumulative is 15 + 25 + 35 = 75
+        assert_eq!(
+            book.cumulative_depth_to_target(75, Side::Sell),
+            Some((103, 75))
+        );
+
+        // Target depth of 100 exceeds available liquidity
+        assert_eq!(book.cumulative_depth_to_target(100, Side::Sell), None);
+    }
+
+    #[test]
+    fn test_cumulative_depth_to_target_empty_book() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Empty book should return None
+        assert_eq!(book.cumulative_depth_to_target(10, Side::Buy), None);
+        assert_eq!(book.cumulative_depth_to_target(10, Side::Sell), None);
+    }
+
+    #[test]
+    fn test_total_depth_at_levels_buy_side() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add bid orders at different price levels
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 99, 20, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 98, 30, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 97, 40, Side::Buy, TimeInForce::Gtc, None);
+
+        // Top 1 level should have depth of 10
+        assert_eq!(book.total_depth_at_levels(1, Side::Buy), 10);
+
+        // Top 2 levels should have depth of 30 (10 + 20)
+        assert_eq!(book.total_depth_at_levels(2, Side::Buy), 30);
+
+        // Top 3 levels should have depth of 60 (10 + 20 + 30)
+        assert_eq!(book.total_depth_at_levels(3, Side::Buy), 60);
+
+        // Top 4 levels should have depth of 100 (10 + 20 + 30 + 40)
+        assert_eq!(book.total_depth_at_levels(4, Side::Buy), 100);
+
+        // Requesting more levels than available should return all available
+        assert_eq!(book.total_depth_at_levels(10, Side::Buy), 100);
+    }
+
+    #[test]
+    fn test_total_depth_at_levels_sell_side() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add ask orders at different price levels
+        let _ = book.add_limit_order(OrderId::new(), 101, 15, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 102, 25, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 103, 35, Side::Sell, TimeInForce::Gtc, None);
+
+        // Top 1 level should have depth of 15
+        assert_eq!(book.total_depth_at_levels(1, Side::Sell), 15);
+
+        // Top 2 levels should have depth of 40 (15 + 25)
+        assert_eq!(book.total_depth_at_levels(2, Side::Sell), 40);
+
+        // Top 3 levels should have depth of 75 (15 + 25 + 35)
+        assert_eq!(book.total_depth_at_levels(3, Side::Sell), 75);
+
+        // Requesting more levels than available should return all available
+        assert_eq!(book.total_depth_at_levels(10, Side::Sell), 75);
+    }
+
+    #[test]
+    fn test_total_depth_at_levels_empty_book() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Empty book should return 0
+        assert_eq!(book.total_depth_at_levels(5, Side::Buy), 0);
+        assert_eq!(book.total_depth_at_levels(5, Side::Sell), 0);
+    }
+
+    #[test]
+    fn test_total_depth_at_levels_zero_levels() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add some orders
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+
+        // Zero levels should return 0
+        assert_eq!(book.total_depth_at_levels(0, Side::Buy), 0);
+        assert_eq!(book.total_depth_at_levels(0, Side::Sell), 0);
+    }
+
+    #[test]
+    fn test_depth_methods_with_multiple_orders_per_level() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add multiple orders at the same price level
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 100, 15, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 99, 20, Side::Buy, TimeInForce::Gtc, None);
+
+        // Total at price 100 should be 25 (10 + 15)
+        assert_eq!(book.price_at_depth(25, Side::Buy), Some(100));
+        assert_eq!(book.price_at_depth(30, Side::Buy), Some(99));
+
+        // Cumulative depth
+        assert_eq!(
+            book.cumulative_depth_to_target(25, Side::Buy),
+            Some((100, 25))
+        );
+        assert_eq!(
+            book.cumulative_depth_to_target(30, Side::Buy),
+            Some((99, 45))
+        );
+
+        // Total depth at levels
+        assert_eq!(book.total_depth_at_levels(1, Side::Buy), 25);
+        assert_eq!(book.total_depth_at_levels(2, Side::Buy), 45);
+    }
+
+    #[test]
+    fn test_depth_methods_priority_order_buy_side() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add bids in non-sequential order to ensure priority is correct
+        let _ = book.add_limit_order(OrderId::new(), 98, 30, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 99, 20, Side::Buy, TimeInForce::Gtc, None);
+
+        // Should iterate from highest to lowest (100, 99, 98)
+        assert_eq!(book.total_depth_at_levels(1, Side::Buy), 10); // 100
+        assert_eq!(book.total_depth_at_levels(2, Side::Buy), 30); // 100, 99
+        assert_eq!(book.total_depth_at_levels(3, Side::Buy), 60); // 100, 99, 98
+    }
+
+    #[test]
+    fn test_depth_methods_priority_order_sell_side() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add asks in non-sequential order to ensure priority is correct
+        let _ = book.add_limit_order(OrderId::new(), 103, 35, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 101, 15, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 102, 25, Side::Sell, TimeInForce::Gtc, None);
+
+        // Should iterate from lowest to highest (101, 102, 103)
+        assert_eq!(book.total_depth_at_levels(1, Side::Sell), 15); // 101
+        assert_eq!(book.total_depth_at_levels(2, Side::Sell), 40); // 101, 102
+        assert_eq!(book.total_depth_at_levels(3, Side::Sell), 75); // 101, 102, 103
+    }
+}

--- a/src/orderbook/tests/mod.rs
+++ b/src/orderbook/tests/mod.rs
@@ -1,4 +1,5 @@
 mod book;
+mod depth_analysis;
 mod error;
 mod matching;
 mod modifications;


### PR DESCRIPTION
…Book

- Implement `price_at_depth()` to find the price where cumulative depth reaches a target quantity.
- Add `cumulative_depth_to_target()` to return both price and actual cumulative depth when the target is reached.
- Introduce `total_depth_at_levels()` to calculate total depth available in the first N price levels.
- Create example in `depth_analysis.rs` to demonstrate new methods and their use cases.

#18 Add depth analysis methods for cumulative depth calculations