### PR TITLE
Add market metrics methods to OrderBook and corresponding tests, docu…

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # OrderBook-rs Examples
 
-This directory contains **13 comprehensive examples** demonstrating various features and use cases of the OrderBook-rs library. Each example is designed to showcase specific functionality and best practices for different use cases from beginner tutorials to advanced performance testing.
+This directory contains **14 comprehensive examples** demonstrating various features and use cases of the OrderBook-rs library. Each example is designed to showcase specific functionality and best practices for different use cases from beginner tutorials to advanced performance testing.
 
 ## 📑 Quick Index
 
@@ -9,7 +9,8 @@ This directory contains **13 comprehensive examples** demonstrating various feat
 | `prelude_demo` | Quick start with simplified imports | 🎓 Beginner |
 | `basic_orderbook` | Comprehensive OrderBook introduction | 🎓 Beginner |
 | `market_trades_demo` | Market order execution and trades | 🎓 Beginner |
-| `depth_analysis` | ⭐ **New!** Market depth & liquidity analysis | 💡 Advanced |
+| `depth_analysis` | Market depth & liquidity analysis | 💡 Advanced |
+| `market_metrics` | ⭐ **New!** Market metrics (VWAP, spread, imbalance) | 💡 Advanced |
 | `trade_listener_demo` | Real-time trade notifications | 💡 Advanced |
 | `trade_listener_channels` | Multi-book trade routing | 💡 Advanced |
 | `orderbook_snapshot_restore` | State persistence & recovery | 💡 Advanced |
@@ -56,6 +57,44 @@ cargo run --bin depth_analysis
 - Order execution planning
 - Liquidity analysis
 - Price impact estimation
+
+---
+
+### 📈 Market Metrics (`market_metrics.rs`)
+
+⭐ **New!** Comprehensive demonstration of market metrics for algorithmic trading and risk management.
+
+```bash
+cargo run --bin market_metrics
+```
+
+**Features demonstrated:**
+- `mid_price()` - Average of best bid and ask
+- `spread_absolute()` - Absolute spread in price units
+- `spread_bps(multiplier)` - Spread in basis points with optional custom multiplier
+- `vwap()` - Volume-Weighted Average Price for execution planning
+- `micro_price()` - Volume-weighted price at best levels
+- `order_book_imbalance()` - Buy/sell pressure indicator (-1.0 to 1.0)
+- Custom spread calculations (bps, percentage, pips)
+
+**Metrics explained:**
+- **Mid Price**: Simple average for quick reference
+- **Spread**: Measures liquidity cost (tight = good, wide = poor)
+- **VWAP**: Expected execution price including slippage
+- **Micro Price**: More accurate fair value than mid price
+- **Imbalance**: Directional pressure (positive = bullish, negative = bearish)
+
+**Practical applications:**
+- **Liquidity Assessment**: Using spread_bps to gauge market conditions
+- **Execution Planning**: VWAP calculation for optimal order sizing
+- **Signal Generation**: Combining imbalance and micro price for trading signals
+- **Risk Management**: Slippage estimation for position sizing
+
+**What you'll learn:**
+- Standard market microstructure metrics
+- How to assess market liquidity
+- Execution cost estimation techniques
+- Building trading signals from order book data
 
 ---
 
@@ -435,12 +474,13 @@ cargo run --bin prelude_demo
 ---
 
 ### 💡 For Advanced Features
-1. **`depth_analysis.rs`** - ⭐ **New!** Market depth and liquidity analysis
-2. **`trade_listener_demo.rs`** - Real-time event notifications
-3. **`trade_listener_channels.rs`** - Multi-book trade routing
-4. **`orderbook_snapshot_restore.rs`** - State persistence and recovery
+1. **`market_metrics.rs`** - ⭐ **New!** Market metrics (VWAP, spread, imbalance)
+2. **`depth_analysis.rs`** - Market depth and liquidity analysis
+3. **`trade_listener_demo.rs`** - Real-time event notifications
+4. **`trade_listener_channels.rs`** - Multi-book trade routing
+5. **`orderbook_snapshot_restore.rs`** - State persistence and recovery
 
-**Use these to:** Build market-making bots, implement advanced trading strategies, manage multiple order books.
+**Use these to:** Build market-making bots, implement advanced trading strategies, manage multiple order books, generate trading signals.
 
 ---
 
@@ -519,9 +559,10 @@ For detailed API documentation, see:
 1. Start with `prelude_demo` to understand the API basics
 2. Study `basic_orderbook` for comprehensive coverage
 3. Run `market_trades_demo` to see trades in action
-4. Explore `depth_analysis` for advanced market making
-5. Try `multi_threaded_orderbook` to understand concurrency
-6. Dive into `orderbook_hft_simulation` for realistic scenarios
+4. Learn `market_metrics` for trading signals and risk management
+5. Explore `depth_analysis` for advanced market making
+6. Try `multi_threaded_orderbook` to understand concurrency
+7. Dive into `orderbook_hft_simulation` for realistic scenarios
 
 **Performance testing:**
 - Always use `--release` flag for accurate benchmarks

--- a/examples/src/bin/market_metrics.rs
+++ b/examples/src/bin/market_metrics.rs
@@ -1,0 +1,326 @@
+// examples/src/bin/market_metrics.rs
+//
+// This example demonstrates the market metrics methods available in the OrderBook.
+// These metrics are essential for:
+// - Market making strategies
+// - Risk management
+// - Trading signal generation
+// - Order execution optimization
+//
+// Metrics demonstrated:
+// - `mid_price()`: Average of best bid and ask
+// - `spread_absolute()`: Absolute spread (ask - bid)
+// - `spread_bps()`: Spread in basis points
+// - `vwap()`: Volume-Weighted Average Price
+// - `micro_price()`: Weighted price by volume at best levels
+// - `order_book_imbalance()`: Buy/sell pressure indicator
+//
+// Run this example with:
+//   cargo run --bin market_metrics
+//   (from the examples directory)
+
+use orderbook_rs::OrderBook;
+use pricelevel::{OrderId, Side, TimeInForce, setup_logger};
+use tracing::info;
+
+fn main() {
+    // Set up logging
+    setup_logger();
+    info!("Market Metrics Example");
+
+    // Create a realistic order book with liquidity
+    let book = create_orderbook_with_liquidity("ETH/USD");
+
+    // Display current book state
+    display_orderbook_state(&book);
+
+    // Demonstrate basic price metrics
+    demo_price_metrics(&book);
+
+    // Demonstrate spread metrics
+    demo_spread_metrics(&book);
+
+    // Demonstrate VWAP calculations
+    demo_vwap_calculations(&book);
+
+    // Demonstrate micro price
+    demo_micro_price(&book);
+
+    // Demonstrate order book imbalance
+    demo_order_book_imbalance(&book);
+
+    // Practical use case: trading signals
+    demo_trading_signals(&book);
+}
+
+fn create_orderbook_with_liquidity(symbol: &str) -> OrderBook {
+    info!("\n=== Creating OrderBook with Realistic Liquidity ===");
+    info!("Symbol: {}", symbol);
+
+    let book = OrderBook::new(symbol);
+
+    // Add buy orders (bids) at different price levels
+    info!("\nAdding buy orders (bids):");
+    let bid_orders = vec![
+        (3000, 100), // Best bid
+        (2995, 150),
+        (2990, 200),
+        (2985, 250),
+        (2980, 300),
+    ];
+
+    for (price, quantity) in bid_orders {
+        let order_id = OrderId::new();
+        let _ = book.add_limit_order(order_id, price, quantity, Side::Buy, TimeInForce::Gtc, None);
+        info!("  Bid: {} @ {}", quantity, price);
+    }
+
+    // Add sell orders (asks) at different price levels
+    info!("\nAdding sell orders (asks):");
+    let ask_orders = vec![
+        (3010, 120), // Best ask
+        (3015, 180),
+        (3020, 220),
+        (3025, 280),
+        (3030, 320),
+    ];
+
+    for (price, quantity) in ask_orders {
+        let order_id = OrderId::new();
+        let _ = book.add_limit_order(
+            order_id,
+            price,
+            quantity,
+            Side::Sell,
+            TimeInForce::Gtc,
+            None,
+        );
+        info!("  Ask: {} @ {}", quantity, price);
+    }
+
+    book
+}
+
+fn display_orderbook_state(book: &OrderBook) {
+    info!("\n=== OrderBook State ===");
+
+    if let Some(best_bid) = book.best_bid() {
+        info!("Best Bid: {}", best_bid);
+    }
+
+    if let Some(best_ask) = book.best_ask() {
+        info!("Best Ask: {}", best_ask);
+    }
+
+    if let (Some(bid), Some(ask)) = (book.best_bid(), book.best_ask()) {
+        let spread = ask.saturating_sub(bid);
+        info!("Spread: {}", spread);
+    }
+}
+
+fn demo_price_metrics(book: &OrderBook) {
+    info!("\n=== Price Metrics ===");
+    info!("Basic price calculations from the order book");
+
+    if let Some(mid) = book.mid_price() {
+        info!("Mid Price: {:.2}", mid);
+        info!("  Formula: (best_bid + best_ask) / 2");
+    }
+
+    if let Some(last_trade) = book.last_trade_price() {
+        info!("Last Trade Price: {}", last_trade);
+    } else {
+        info!("Last Trade Price: None (no trades yet)");
+    }
+}
+
+fn demo_spread_metrics(book: &OrderBook) {
+    info!("\n=== Spread Metrics ===");
+    info!("Measuring the cost of immediate execution");
+
+    if let Some(spread_abs) = book.spread_absolute() {
+        info!("Absolute Spread: {} price units", spread_abs);
+        info!("  This is the difference between best ask and best bid");
+    }
+
+    if let Some(spread_bps) = book.spread_bps(None) {
+        info!("Spread in Basis Points: {:.2} bps", spread_bps);
+        info!("  Formula: ((ask - bid) / mid_price) * 10,000");
+        info!("  1 basis point = 0.01%");
+
+        if spread_bps < 5.0 {
+            info!("  ✓ Tight spread - highly liquid market");
+        } else if spread_bps < 20.0 {
+            info!("  • Normal spread - decent liquidity");
+        } else {
+            info!("  ⚠ Wide spread - low liquidity");
+        }
+    }
+
+    // Demonstrate custom multiplier (percentage)
+    if let Some(spread_pct) = book.spread_bps(Some(100.0)) {
+        info!("\nSpread as Percentage: {:.4}%", spread_pct);
+        info!("  Using custom multiplier of 100");
+    }
+}
+
+fn demo_vwap_calculations(book: &OrderBook) {
+    info!("\n=== VWAP (Volume-Weighted Average Price) ===");
+    info!("Calculating execution price for different order sizes");
+
+    // Test different buy order sizes
+    info!("\nBuying scenarios (executing against asks):");
+    let buy_quantities = vec![100, 200, 400];
+
+    for quantity in buy_quantities {
+        match book.vwap(quantity, Side::Buy) {
+            Some(vwap) => {
+                if let Some(best_ask) = book.best_ask() {
+                    let slippage = vwap - best_ask as f64;
+                    let slippage_bps = (slippage / best_ask as f64) * 10_000.0;
+                    info!("  Buy {} units:", quantity);
+                    info!("    VWAP: {:.2}", vwap);
+                    info!("    Slippage: {:.2} ({:.2} bps)", slippage, slippage_bps);
+                }
+            }
+            None => info!("  Buy {} units: Insufficient liquidity", quantity),
+        }
+    }
+
+    // Test different sell order sizes
+    info!("\nSelling scenarios (executing against bids):");
+    let sell_quantities = vec![100, 200, 400];
+
+    for quantity in sell_quantities {
+        match book.vwap(quantity, Side::Sell) {
+            Some(vwap) => {
+                if let Some(best_bid) = book.best_bid() {
+                    let slippage = best_bid as f64 - vwap;
+                    let slippage_bps = (slippage / best_bid as f64) * 10_000.0;
+                    info!("  Sell {} units:", quantity);
+                    info!("    VWAP: {:.2}", vwap);
+                    info!("    Slippage: {:.2} ({:.2} bps)", slippage, slippage_bps);
+                }
+            }
+            None => info!("  Sell {} units: Insufficient liquidity", quantity),
+        }
+    }
+}
+
+fn demo_micro_price(book: &OrderBook) {
+    info!("\n=== Micro Price ===");
+    info!("Volume-weighted price at best bid/ask levels");
+
+    if let (Some(mid), Some(micro)) = (book.mid_price(), book.micro_price()) {
+        info!("Mid Price:   {:.2}", mid);
+        info!("Micro Price: {:.2}", micro);
+
+        let diff = micro - mid;
+        if diff.abs() < 0.01 {
+            info!("  • Balanced market - similar volumes on both sides");
+        } else if diff > 0.0 {
+            info!("  • Micro price > Mid price");
+            info!("    More volume on bid side (buying pressure)");
+        } else {
+            info!("  • Micro price < Mid price");
+            info!("    More volume on ask side (selling pressure)");
+        }
+    }
+}
+
+fn demo_order_book_imbalance(book: &OrderBook) {
+    info!("\n=== Order Book Imbalance ===");
+    info!("Measuring buy/sell pressure across price levels");
+
+    let level_counts = vec![1, 3, 5];
+
+    for levels in level_counts {
+        let imbalance = book.order_book_imbalance(levels);
+        let bid_vol = book.total_depth_at_levels(levels, Side::Buy);
+        let ask_vol = book.total_depth_at_levels(levels, Side::Sell);
+
+        info!("\nTop {} level(s):", levels);
+        info!("  Bid volume: {}", bid_vol);
+        info!("  Ask volume: {}", ask_vol);
+        info!("  Imbalance: {:.3}", imbalance);
+
+        if imbalance > 0.2 {
+            info!("  ↗ Strong buy pressure");
+        } else if imbalance > 0.05 {
+            info!("  ↗ Moderate buy pressure");
+        } else if imbalance < -0.2 {
+            info!("  ↘ Strong sell pressure");
+        } else if imbalance < -0.05 {
+            info!("  ↘ Moderate sell pressure");
+        } else {
+            info!("  → Balanced market");
+        }
+    }
+}
+
+fn demo_trading_signals(book: &OrderBook) {
+    info!("\n=== Trading Signals Generation ===");
+    info!("Using metrics to generate actionable signals");
+
+    let spread_bps = book.spread_bps(None).unwrap_or(f64::MAX);
+    let imbalance = book.order_book_imbalance(3);
+    let micro = book.micro_price().unwrap_or(0.0);
+    let mid = book.mid_price().unwrap_or(0.0);
+
+    info!("\nSignal Analysis:");
+
+    // Liquidity signal
+    info!("\n1. Liquidity Signal:");
+    if spread_bps < 10.0 {
+        info!("   ✓ Good liquidity (spread < 10 bps)");
+        info!("   → Safe for large orders");
+    } else {
+        info!("   ⚠ Poor liquidity (spread >= 10 bps)");
+        info!("   → Use limit orders to avoid slippage");
+    }
+
+    // Directional signal
+    info!("\n2. Directional Signal:");
+    if imbalance > 0.15 {
+        info!("   ↗ Bullish imbalance ({:.2})", imbalance);
+        info!("   → Consider buying on dips");
+    } else if imbalance < -0.15 {
+        info!("   ↘ Bearish imbalance ({:.2})", imbalance);
+        info!("   → Consider selling rallies");
+    } else {
+        info!("   → Neutral ({:.2})", imbalance);
+        info!("   → Wait for clearer signal");
+    }
+
+    // Fair value signal
+    info!("\n3. Fair Value Signal:");
+    let micro_diff_bps = ((micro - mid) / mid) * 10_000.0;
+    info!("   Mid:   {:.2}", mid);
+    info!("   Micro: {:.2} ({:+.2} bps)", micro, micro_diff_bps);
+
+    if micro_diff_bps.abs() < 1.0 {
+        info!("   → Fair value close to mid price");
+    } else if micro_diff_bps > 0.0 {
+        info!("   → Buying pressure pushing price up");
+    } else {
+        info!("   → Selling pressure pushing price down");
+    }
+
+    // VWAP execution recommendation
+    info!("\n4. Execution Recommendation:");
+    if let Some(vwap_100) = book.vwap(100, Side::Buy) {
+        let best_ask = book.best_ask().unwrap() as f64;
+        let slippage_bps = ((vwap_100 - best_ask) / best_ask) * 10_000.0;
+
+        info!("   For 100 unit buy order:");
+        info!("   Best ask: {:.2}", best_ask);
+        info!("   Expected VWAP: {:.2}", vwap_100);
+        info!("   Expected slippage: {:.2} bps", slippage_bps);
+
+        if slippage_bps < 5.0 {
+            info!("   ✓ Low slippage - market order OK");
+        } else {
+            info!("   ⚠ High slippage - consider limit order");
+        }
+    }
+}

--- a/src/orderbook/tests/market_metrics.rs
+++ b/src/orderbook/tests/market_metrics.rs
@@ -1,0 +1,286 @@
+//! Tests for market metrics methods
+
+#[cfg(test)]
+mod tests {
+    use crate::OrderBook;
+    use pricelevel::{OrderId, Side, TimeInForce};
+
+    #[test]
+    fn test_spread_absolute() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Empty book
+        assert_eq!(book.spread_absolute(), None);
+
+        // Add bid and ask
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 105, 10, Side::Sell, TimeInForce::Gtc, None);
+
+        assert_eq!(book.spread_absolute(), Some(5));
+    }
+
+    #[test]
+    fn test_spread_bps() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Empty book
+        assert_eq!(book.spread_bps(None), None);
+
+        // Add orders at 10000 and 10010
+        let _ = book.add_limit_order(OrderId::new(), 10000, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(
+            OrderId::new(),
+            10010,
+            10,
+            Side::Sell,
+            TimeInForce::Gtc,
+            None,
+        );
+
+        // Spread = 10, mid = 10005, bps = (10/10005) * 10000 = ~9.995 bps
+        let spread_bps = book.spread_bps(None).unwrap();
+        assert!((spread_bps - 9.995).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_spread_bps_custom_multiplier() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add orders at 10000 and 10010
+        let _ = book.add_limit_order(OrderId::new(), 10000, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(
+            OrderId::new(),
+            10010,
+            10,
+            Side::Sell,
+            TimeInForce::Gtc,
+            None,
+        );
+
+        // Test with custom multiplier of 100 (for percentage)
+        // Spread = 10, mid = 10005, pct = (10/10005) * 100 = ~0.0999%
+        let spread_pct = book.spread_bps(Some(100.0)).unwrap();
+        assert!((spread_pct - 0.0999).abs() < 0.001);
+
+        // Test with default multiplier (10,000)
+        let spread_bps_default = book.spread_bps(None).unwrap();
+        let spread_bps_explicit = book.spread_bps(Some(10_000.0)).unwrap();
+        assert_eq!(spread_bps_default, spread_bps_explicit);
+    }
+
+    #[test]
+    fn test_vwap_buy_side() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add ask orders at different price levels
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 105, 15, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 110, 20, Side::Sell, TimeInForce::Gtc, None);
+
+        // VWAP for buying 10 units should be 100.0
+        let vwap = book.vwap(10, Side::Buy).unwrap();
+        assert_eq!(vwap, 100.0);
+
+        // VWAP for buying 20 units (10@100 + 10@105) = (1000 + 1050) / 20 = 102.5
+        let vwap = book.vwap(20, Side::Buy).unwrap();
+        assert_eq!(vwap, 102.5);
+
+        // VWAP for buying 25 units (10@100 + 15@105) = (1000 + 1575) / 25 = 103.0
+        let vwap = book.vwap(25, Side::Buy).unwrap();
+        assert_eq!(vwap, 103.0);
+
+        // Insufficient liquidity
+        assert_eq!(book.vwap(50, Side::Buy), None);
+    }
+
+    #[test]
+    fn test_vwap_sell_side() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add bid orders at different price levels
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 95, 15, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 90, 20, Side::Buy, TimeInForce::Gtc, None);
+
+        // VWAP for selling 10 units should be 100.0
+        let vwap = book.vwap(10, Side::Sell).unwrap();
+        assert_eq!(vwap, 100.0);
+
+        // VWAP for selling 20 units (10@100 + 10@95) = (1000 + 950) / 20 = 97.5
+        let vwap = book.vwap(20, Side::Sell).unwrap();
+        assert_eq!(vwap, 97.5);
+
+        // VWAP for selling 25 units (10@100 + 15@95) = (1000 + 1425) / 25 = 97.0
+        let vwap = book.vwap(25, Side::Sell).unwrap();
+        assert_eq!(vwap, 97.0);
+
+        // Insufficient liquidity
+        assert_eq!(book.vwap(50, Side::Sell), None);
+    }
+
+    #[test]
+    fn test_vwap_empty_book() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        assert_eq!(book.vwap(10, Side::Buy), None);
+        assert_eq!(book.vwap(10, Side::Sell), None);
+    }
+
+    #[test]
+    fn test_vwap_zero_quantity() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Sell, TimeInForce::Gtc, None);
+
+        assert_eq!(book.vwap(0, Side::Buy), None);
+    }
+
+    #[test]
+    fn test_micro_price() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Empty book
+        assert_eq!(book.micro_price(), None);
+
+        // Add orders with equal volumes
+        let _ = book.add_limit_order(OrderId::new(), 100, 50, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 105, 50, Side::Sell, TimeInForce::Gtc, None);
+
+        // With equal volumes, micro price equals mid price
+        // micro = (105 * 50 + 100 * 50) / 100 = 10250 / 100 = 102.5
+        let micro = book.micro_price().unwrap();
+        assert_eq!(micro, 102.5);
+
+        // Mid price should also be 102.5
+        let mid = book.mid_price().unwrap();
+        assert_eq!(mid, 102.5);
+    }
+
+    #[test]
+    fn test_micro_price_imbalanced() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add orders with imbalanced volumes (more bid volume)
+        let _ = book.add_limit_order(OrderId::new(), 100, 70, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 105, 30, Side::Sell, TimeInForce::Gtc, None);
+
+        // micro = (105 * 70 + 100 * 30) / 100 = (7350 + 3000) / 100 = 103.5
+        let micro = book.micro_price().unwrap();
+        assert_eq!(micro, 103.5);
+
+        // Mid price is 102.5, but micro price is higher due to more bid volume
+        let mid = book.mid_price().unwrap();
+        assert_eq!(mid, 102.5);
+        assert!(micro > mid);
+    }
+
+    #[test]
+    fn test_micro_price_zero_volumes() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // This scenario shouldn't happen in practice, but test for robustness
+        // If there are price levels but no volumes, micro_price should return None
+        // Since we can't create this state easily, we just test empty book
+        assert_eq!(book.micro_price(), None);
+    }
+
+    #[test]
+    fn test_order_book_imbalance_balanced() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add balanced orders
+        let _ = book.add_limit_order(OrderId::new(), 100, 50, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 105, 50, Side::Sell, TimeInForce::Gtc, None);
+
+        // Imbalance should be 0 for balanced book
+        let imbalance = book.order_book_imbalance(5);
+        assert_eq!(imbalance, 0.0);
+    }
+
+    #[test]
+    fn test_order_book_imbalance_buy_pressure() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // More bid volume (buy pressure)
+        let _ = book.add_limit_order(OrderId::new(), 100, 60, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 105, 40, Side::Sell, TimeInForce::Gtc, None);
+
+        // Imbalance = (60 - 40) / (60 + 40) = 20 / 100 = 0.2
+        let imbalance = book.order_book_imbalance(5);
+        assert_eq!(imbalance, 0.2);
+    }
+
+    #[test]
+    fn test_order_book_imbalance_sell_pressure() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // More ask volume (sell pressure)
+        let _ = book.add_limit_order(OrderId::new(), 100, 30, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 105, 70, Side::Sell, TimeInForce::Gtc, None);
+
+        // Imbalance = (30 - 70) / (30 + 70) = -40 / 100 = -0.4
+        let imbalance = book.order_book_imbalance(5);
+        assert_eq!(imbalance, -0.4);
+    }
+
+    #[test]
+    fn test_order_book_imbalance_multiple_levels() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add multiple levels
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 99, 20, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 98, 30, Side::Buy, TimeInForce::Gtc, None);
+
+        let _ = book.add_limit_order(OrderId::new(), 101, 15, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 102, 25, Side::Sell, TimeInForce::Gtc, None);
+
+        // Top 2 levels: bid=10+20=30, ask=15+25=40
+        // Imbalance = (30 - 40) / (30 + 40) = -10 / 70 = -0.142857...
+        let imbalance = book.order_book_imbalance(2);
+        assert!((imbalance - (-10.0 / 70.0)).abs() < 0.0001);
+
+        // Top 3 levels: bid=10+20+30=60, ask=15+25=40
+        // Imbalance = (60 - 40) / (60 + 40) = 20 / 100 = 0.2
+        let imbalance = book.order_book_imbalance(3);
+        assert_eq!(imbalance, 0.2);
+    }
+
+    #[test]
+    fn test_order_book_imbalance_empty_book() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        assert_eq!(book.order_book_imbalance(5), 0.0);
+    }
+
+    #[test]
+    fn test_order_book_imbalance_zero_levels() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let _ = book.add_limit_order(OrderId::new(), 100, 50, Side::Buy, TimeInForce::Gtc, None);
+
+        assert_eq!(book.order_book_imbalance(0), 0.0);
+    }
+
+    #[test]
+    fn test_all_metrics_together() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Setup a realistic order book
+        let _ = book.add_limit_order(OrderId::new(), 99, 20, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 100, 50, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 101, 30, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 102, 40, Side::Sell, TimeInForce::Gtc, None);
+
+        // Verify all metrics work together
+        assert_eq!(book.mid_price(), Some(100.5));
+        assert_eq!(book.spread_absolute(), Some(1));
+        assert!(book.spread_bps(None).is_some());
+        assert!(book.vwap(50, Side::Buy).is_some());
+        assert!(book.micro_price().is_some());
+
+        // Top 1 level: bid=50, ask=30, imbalance = (50-30)/(50+30) = 20/80 = 0.25
+        let imbalance = book.order_book_imbalance(1);
+        assert_eq!(imbalance, 0.25);
+    }
+}

--- a/src/orderbook/tests/mod.rs
+++ b/src/orderbook/tests/mod.rs
@@ -1,6 +1,7 @@
 mod book;
 mod depth_analysis;
 mod error;
+mod market_metrics;
 mod matching;
 mod modifications;
 mod operations;


### PR DESCRIPTION
…mentation, and examples

- Introduce default basis points multiplier for spread calculations.
- Implement `spread_absolute`, `spread_bps`, `vwap`, `micro_price`, and `order_book_imbalance` methods.
- Add extensive inline documentation on metrics with practical applications.
- Create `market_metrics.rs` example demonstrating trading signals, liquidity assessment, risk management, and spread evaluation.
- Add tests for all metrics in `market_metrics.rs` test module.
- Update `README.md` with new example and feature details.

#19 Add common market metrics (mid-price, VWAP, spread)