### PR TITLE
Add market impact analysis and simulation to OrderBook, including met…

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # OrderBook-rs Examples
 
-This directory contains **14 comprehensive examples** demonstrating various features and use cases of the OrderBook-rs library. Each example is designed to showcase specific functionality and best practices for different use cases from beginner tutorials to advanced performance testing.
+This directory contains **15 comprehensive examples** demonstrating various features and use cases of the OrderBook-rs library. Each example is designed to showcase specific functionality and best practices for different use cases from beginner tutorials to advanced performance testing.
 
 ## 📑 Quick Index
 
@@ -10,7 +10,8 @@ This directory contains **14 comprehensive examples** demonstrating various feat
 | `basic_orderbook` | Comprehensive OrderBook introduction | 🎓 Beginner |
 | `market_trades_demo` | Market order execution and trades | 🎓 Beginner |
 | `depth_analysis` | Market depth & liquidity analysis | 💡 Advanced |
-| `market_metrics` | ⭐ **New!** Market metrics (VWAP, spread, imbalance) | 💡 Advanced |
+| `market_metrics` | Market metrics (VWAP, spread, imbalance) | 💡 Advanced |
+| `market_impact_simulation` | ⭐ **New!** Pre-trade impact & risk analysis | 💡 Advanced |
 | `trade_listener_demo` | Real-time trade notifications | 💡 Advanced |
 | `trade_listener_channels` | Multi-book trade routing | 💡 Advanced |
 | `orderbook_snapshot_restore` | State persistence & recovery | 💡 Advanced |
@@ -95,6 +96,51 @@ cargo run --bin market_metrics
 - How to assess market liquidity
 - Execution cost estimation techniques
 - Building trading signals from order book data
+
+---
+
+### 🎯 Market Impact Simulation (`market_impact_simulation.rs`)
+
+⭐ **New!** Pre-trade analysis tool for understanding market impact before order execution.
+
+```bash
+cargo run --bin market_impact_simulation
+```
+
+**Features demonstrated:**
+- `market_impact()` - Comprehensive impact analysis before execution
+- `simulate_market_order()` - Step-by-step fill simulation
+- `liquidity_in_range()` - Price range liquidity analysis
+- Pre-trade risk assessment workflow
+
+**Key metrics provided:**
+- **Average Execution Price**: VWAP across all fills
+- **Slippage Analysis**: Absolute and basis points slippage
+- **Liquidity Depth**: Levels consumed and available quantity
+- **Fill Simulation**: Detailed breakdown of each fill
+- **Cost Estimation**: Total execution cost calculation
+
+**Use cases:**
+- **Risk Management**: Assess order impact before execution
+- **Smart Order Routing**: Compare liquidity across venues
+- **Execution Strategy**: Determine optimal order sizing
+- **Backtesting**: Realistic fill simulations for strategy testing
+- **Compliance**: Pre-trade risk checks and reporting
+
+**Practical applications:**
+- Analyze different order sizes (100, 250, 500, 1000 units)
+- Compare buy vs sell side liquidity
+- Simulate exact execution fills
+- Check liquidity in specific price ranges
+- Generate pre-trade risk classifications (LOW/MEDIUM/HIGH)
+- Recommend execution strategies (market order, split order, TWAP, etc.)
+
+**What you'll learn:**
+- How to assess market impact before trading
+- Understanding slippage and execution costs
+- Liquidity analysis techniques
+- Pre-trade risk management workflows
+- Smart order sizing strategies
 
 ---
 
@@ -474,13 +520,14 @@ cargo run --bin prelude_demo
 ---
 
 ### 💡 For Advanced Features
-1. **`market_metrics.rs`** - ⭐ **New!** Market metrics (VWAP, spread, imbalance)
-2. **`depth_analysis.rs`** - Market depth and liquidity analysis
-3. **`trade_listener_demo.rs`** - Real-time event notifications
-4. **`trade_listener_channels.rs`** - Multi-book trade routing
-5. **`orderbook_snapshot_restore.rs`** - State persistence and recovery
+1. **`market_impact_simulation.rs`** - ⭐ **New!** Pre-trade impact & risk analysis
+2. **`market_metrics.rs`** - Market metrics (VWAP, spread, imbalance)
+3. **`depth_analysis.rs`** - Market depth and liquidity analysis
+4. **`trade_listener_demo.rs`** - Real-time event notifications
+5. **`trade_listener_channels.rs`** - Multi-book trade routing
+6. **`orderbook_snapshot_restore.rs`** - State persistence and recovery
 
-**Use these to:** Build market-making bots, implement advanced trading strategies, manage multiple order books, generate trading signals.
+**Use these to:** Build market-making bots, implement advanced trading strategies, assess pre-trade risk, manage multiple order books, generate trading signals.
 
 ---
 
@@ -560,9 +607,10 @@ For detailed API documentation, see:
 2. Study `basic_orderbook` for comprehensive coverage
 3. Run `market_trades_demo` to see trades in action
 4. Learn `market_metrics` for trading signals and risk management
-5. Explore `depth_analysis` for advanced market making
-6. Try `multi_threaded_orderbook` to understand concurrency
-7. Dive into `orderbook_hft_simulation` for realistic scenarios
+5. Explore `market_impact_simulation` for pre-trade risk assessment
+6. Study `depth_analysis` for advanced market making
+7. Try `multi_threaded_orderbook` to understand concurrency
+8. Dive into `orderbook_hft_simulation` for realistic scenarios
 
 **Performance testing:**
 - Always use `--release` flag for accurate benchmarks

--- a/examples/src/bin/market_impact_simulation.rs
+++ b/examples/src/bin/market_impact_simulation.rs
@@ -1,0 +1,368 @@
+// examples/src/bin/market_impact_simulation.rs
+//
+// This example demonstrates market impact simulation and liquidity analysis.
+// These tools are essential for:
+// - Pre-trade analysis and risk management
+// - Smart order routing decisions
+// - Optimal order sizing
+// - Execution cost estimation
+//
+// Functions demonstrated:
+// - `market_impact()`: Analyze the impact of an order before execution
+// - `simulate_market_order()`: Step-by-step execution simulation
+// - `liquidity_in_range()`: Check available liquidity in price ranges
+//
+// Run this example with:
+//   cargo run --bin market_impact_simulation
+//   (from the examples directory)
+
+use orderbook_rs::OrderBook;
+use pricelevel::{OrderId, Side, TimeInForce, setup_logger};
+use tracing::info;
+
+fn main() {
+    // Set up logging
+    setup_logger();
+    info!("Market Impact Simulation Example");
+
+    // Create an order book with realistic market depth
+    let book = create_orderbook_with_depth("BTC/USD");
+
+    // Display current book state
+    display_orderbook_state(&book);
+
+    // Demonstrate market impact analysis
+    demo_market_impact_analysis(&book);
+
+    // Demonstrate order simulation
+    demo_order_simulation(&book);
+
+    // Demonstrate liquidity analysis
+    demo_liquidity_analysis(&book);
+
+    // Practical use case: Pre-trade risk assessment
+    demo_pretrade_risk_assessment(&book);
+}
+
+fn create_orderbook_with_depth(symbol: &str) -> OrderBook {
+    info!("\n=== Creating OrderBook with Market Depth ===");
+    info!("Symbol: {}", symbol);
+
+    let book = OrderBook::new(symbol);
+
+    // Add buy orders (bids) with decreasing liquidity
+    info!("\nAdding buy orders (bids):");
+    let bid_orders = vec![
+        (50000, 100), // Best bid
+        (49950, 150),
+        (49900, 200),
+        (49850, 250),
+        (49800, 300),
+        (49750, 350),
+    ];
+
+    for (price, quantity) in bid_orders {
+        let order_id = OrderId::new();
+        let _ = book.add_limit_order(order_id, price, quantity, Side::Buy, TimeInForce::Gtc, None);
+        info!("  Bid: {} @ {}", quantity, price);
+    }
+
+    // Add sell orders (asks) with decreasing liquidity
+    info!("\nAdding sell orders (asks):");
+    let ask_orders = vec![
+        (50100, 120), // Best ask
+        (50150, 180),
+        (50200, 220),
+        (50250, 280),
+        (50300, 320),
+        (50350, 380),
+    ];
+
+    for (price, quantity) in ask_orders {
+        let order_id = OrderId::new();
+        let _ = book.add_limit_order(
+            order_id,
+            price,
+            quantity,
+            Side::Sell,
+            TimeInForce::Gtc,
+            None,
+        );
+        info!("  Ask: {} @ {}", quantity, price);
+    }
+
+    book
+}
+
+fn display_orderbook_state(book: &OrderBook) {
+    info!("\n=== OrderBook State ===");
+
+    if let Some(best_bid) = book.best_bid() {
+        info!("Best Bid: {}", best_bid);
+    }
+
+    if let Some(best_ask) = book.best_ask() {
+        info!("Best Ask: {}", best_ask);
+    }
+
+    if let (Some(bid), Some(ask)) = (book.best_bid(), book.best_ask()) {
+        let spread = ask.saturating_sub(bid);
+        info!("Spread: {}", spread);
+    }
+}
+
+fn demo_market_impact_analysis(book: &OrderBook) {
+    info!("\n=== Market Impact Analysis ===");
+    info!("Analyzing the impact of different order sizes");
+
+    let order_sizes = vec![100, 250, 500, 1000];
+
+    // Analyze buy orders
+    info!("\nBuy orders (executing against asks):");
+    for size in &order_sizes {
+        let impact = book.market_impact(*size, Side::Buy);
+
+        info!("\n  Order size: {} units", size);
+        info!("    Average execution price: {:.2}", impact.avg_price);
+        info!("    Worst price: {}", impact.worst_price);
+        info!(
+            "    Slippage: {} ({:.2} bps)",
+            impact.slippage, impact.slippage_bps
+        );
+        info!("    Levels consumed: {}", impact.levels_consumed);
+        info!(
+            "    Available liquidity: {}",
+            impact.total_quantity_available
+        );
+
+        if impact.can_fill(*size) {
+            info!("    ✓ Order can be fully filled");
+        } else {
+            info!(
+                "    ✗ Insufficient liquidity (fill ratio: {:.2}%)",
+                impact.fill_ratio(*size) * 100.0
+            );
+        }
+    }
+
+    // Analyze sell orders
+    info!("\nSell orders (executing against bids):");
+    for size in &order_sizes {
+        let impact = book.market_impact(*size, Side::Sell);
+
+        info!("\n  Order size: {} units", size);
+        info!("    Average execution price: {:.2}", impact.avg_price);
+        info!("    Worst price: {}", impact.worst_price);
+        info!(
+            "    Slippage: {} ({:.2} bps)",
+            impact.slippage, impact.slippage_bps
+        );
+        info!("    Levels consumed: {}", impact.levels_consumed);
+
+        if impact.can_fill(*size) {
+            info!("    ✓ Order can be fully filled");
+        } else {
+            info!("    ✗ Insufficient liquidity");
+        }
+    }
+}
+
+fn demo_order_simulation(book: &OrderBook) {
+    info!("\n=== Order Execution Simulation ===");
+    info!("Step-by-step simulation of order execution");
+
+    // Simulate a buy order
+    let buy_quantity = 400;
+    info!("\nSimulating buy order of {} units:", buy_quantity);
+
+    let simulation = book.simulate_market_order(buy_quantity, Side::Buy);
+
+    info!("  Execution details:");
+    for (i, (price, qty)) in simulation.fills.iter().enumerate() {
+        info!(
+            "    Fill {}: {} units @ {} = {}",
+            i + 1,
+            qty,
+            price,
+            (*price as u128) * (*qty as u128)
+        );
+    }
+
+    info!("\n  Summary:");
+    info!("    Total filled: {} units", simulation.total_filled);
+    info!("    Average price: {:.2}", simulation.avg_price);
+    info!("    Remaining: {} units", simulation.remaining_quantity);
+    info!("    Total cost: {}", simulation.total_cost());
+    info!("    Levels used: {}", simulation.levels_count());
+
+    if simulation.is_fully_filled() {
+        info!("    ✓ Order fully filled");
+    } else {
+        info!("    ⚠ Partial fill only");
+    }
+
+    // Simulate a sell order
+    let sell_quantity = 400;
+    info!("\nSimulating sell order of {} units:", sell_quantity);
+
+    let simulation = book.simulate_market_order(sell_quantity, Side::Sell);
+
+    info!("  Execution details:");
+    for (i, (price, qty)) in simulation.fills.iter().enumerate() {
+        info!(
+            "    Fill {}: {} units @ {} = {}",
+            i + 1,
+            qty,
+            price,
+            (*price as u128) * (*qty as u128)
+        );
+    }
+
+    info!("\n  Summary:");
+    info!("    Total filled: {} units", simulation.total_filled);
+    info!("    Average price: {:.2}", simulation.avg_price);
+    info!("    Total revenue: {}", simulation.total_cost());
+}
+
+fn demo_liquidity_analysis(book: &OrderBook) {
+    info!("\n=== Liquidity Analysis ===");
+    info!("Analyzing liquidity distribution across price ranges");
+
+    // Analyze bid liquidity
+    info!("\nBid side liquidity:");
+    let bid_ranges = vec![
+        (49950, 50000, "Near touch"),
+        (49800, 50000, "Top 3 levels"),
+        (49000, 50000, "Wide range"),
+    ];
+
+    for (min_price, max_price, description) in bid_ranges {
+        let liquidity = book.liquidity_in_range(min_price, max_price, Side::Buy);
+        info!(
+            "  {} ({}-{}): {} units",
+            description, min_price, max_price, liquidity
+        );
+    }
+
+    // Analyze ask liquidity
+    info!("\nAsk side liquidity:");
+    let ask_ranges = vec![
+        (50100, 50150, "Near touch"),
+        (50100, 50300, "Top 3 levels"),
+        (50100, 51000, "Wide range"),
+    ];
+
+    for (min_price, max_price, description) in ask_ranges {
+        let liquidity = book.liquidity_in_range(min_price, max_price, Side::Sell);
+        info!(
+            "  {} ({}-{}): {} units",
+            description, min_price, max_price, liquidity
+        );
+    }
+
+    // Analyze specific price bands
+    info!("\nPrice band analysis:");
+    let bands = vec![
+        (50000, 50100, "Spread zone"),
+        (50100, 50200, "First 100 points above"),
+        (50200, 50300, "Next 100 points"),
+    ];
+
+    for (min_price, max_price, description) in bands {
+        let liquidity = book.liquidity_in_range(min_price, max_price, Side::Sell);
+        info!("  {}: {} units", description, liquidity);
+    }
+}
+
+fn demo_pretrade_risk_assessment(book: &OrderBook) {
+    info!("\n=== Pre-Trade Risk Assessment ===");
+    info!("Comprehensive analysis before order execution");
+
+    let order_size = 600;
+    let order_side = Side::Buy;
+
+    info!("\nProposed order:");
+    info!("  Size: {} units", order_size);
+    info!("  Side: {:?}", order_side);
+
+    // Step 1: Check market impact
+    let impact = book.market_impact(order_size, order_side);
+
+    info!("\n1. Market Impact Assessment:");
+    info!("   Average execution price: {:.2}", impact.avg_price);
+    info!("   Expected slippage: {:.2} bps", impact.slippage_bps);
+    info!("   Price levels to consume: {}", impact.levels_consumed);
+
+    // Step 2: Liquidity check
+    let can_fill = impact.can_fill(order_size);
+    let fill_ratio = impact.fill_ratio(order_size);
+
+    info!("\n2. Liquidity Check:");
+    if can_fill {
+        info!("   ✓ Sufficient liquidity available");
+        info!("   Can fill: 100%");
+    } else {
+        info!("   ⚠ Insufficient liquidity");
+        info!("   Can fill: {:.1}%", fill_ratio * 100.0);
+        info!(
+            "   Shortfall: {} units",
+            order_size - impact.total_quantity_available
+        );
+    }
+
+    // Step 3: Cost estimation
+    let simulation = book.simulate_market_order(order_size, order_side);
+    let total_cost = simulation.total_cost();
+
+    info!("\n3. Cost Estimation:");
+    info!("   Total cost: {} units", total_cost);
+    info!("   Average price: {:.2}", simulation.avg_price);
+
+    if let Some(best_ask) = book.best_ask() {
+        let best_cost = (best_ask as u128) * (order_size as u128);
+        let additional_cost = total_cost.saturating_sub(best_cost);
+        info!("   Cost at best price: {} units", best_cost);
+        info!("   Additional cost (slippage): {} units", additional_cost);
+    }
+
+    // Step 4: Risk classification
+    info!("\n4. Risk Classification:");
+    if impact.slippage_bps < 10.0 {
+        info!("   ✓ LOW RISK - Minimal slippage expected");
+        info!("   → Safe to execute as market order");
+    } else if impact.slippage_bps < 50.0 {
+        info!("   • MEDIUM RISK - Moderate slippage");
+        info!("   → Consider splitting order or using limit orders");
+    } else {
+        info!("   ✗ HIGH RISK - Significant slippage");
+        info!("   → Strongly recommend order splitting");
+        info!("   → Consider alternative execution strategies");
+    }
+
+    // Step 5: Execution recommendation
+    info!("\n5. Execution Recommendation:");
+
+    if !can_fill {
+        info!("   ⚠ Order cannot be fully filled");
+        info!(
+            "   → Reduce order size to {} units",
+            impact.total_quantity_available
+        );
+    } else if impact.slippage_bps > 50.0 {
+        info!(
+            "   → Split into smaller orders (suggested: {} units each)",
+            order_size / 3
+        );
+        info!("   → Use TWAP or VWAP algorithm");
+        info!("   → Time orders to minimize impact");
+    } else if impact.slippage_bps > 10.0 {
+        info!("   → Consider limit order at {:.2}", simulation.avg_price);
+        info!("   → Or split into 2-3 smaller orders");
+    } else {
+        info!("   ✓ Execute as single market order");
+        info!(
+            "   Expected execution: {:.2} @ {} units",
+            simulation.avg_price, simulation.total_filled
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,7 @@ pub mod prelude;
 mod utils;
 
 pub use orderbook::manager::{BookManager, BookManagerStd, BookManagerTokio};
+pub use orderbook::market_impact::{MarketImpact, OrderSimulation};
 pub use orderbook::trade::{TradeListener, TradeResult};
 pub use orderbook::{OrderBook, OrderBookError, OrderBookSnapshot};
 pub use utils::current_time_millis;

--- a/src/orderbook/market_impact.rs
+++ b/src/orderbook/market_impact.rs
@@ -1,0 +1,240 @@
+//! Market impact simulation and liquidity analysis
+//!
+//! This module provides tools for analyzing the impact of large orders
+//! before execution, helping traders understand:
+//! - Average execution price
+//! - Expected slippage
+//! - Number of price levels consumed
+//! - Available liquidity in price ranges
+
+use serde::{Deserialize, Serialize};
+
+/// Represents the market impact analysis of an order
+///
+/// Provides detailed metrics about how an order would affect the market,
+/// including price impact, slippage, and liquidity consumption.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MarketImpact {
+    /// Average execution price across all fills (in price units)
+    pub avg_price: f64,
+
+    /// Worst (furthest from best price) execution price (in price units)
+    pub worst_price: u64,
+
+    /// Absolute slippage from best price (in price units)
+    pub slippage: u64,
+
+    /// Slippage in basis points
+    pub slippage_bps: f64,
+
+    /// Number of price levels that would be consumed
+    pub levels_consumed: usize,
+
+    /// Total quantity available to fill the order (in units)
+    pub total_quantity_available: u64,
+}
+
+/// Represents a simulated order execution
+///
+/// Provides step-by-step details of how an order would be filled,
+/// including all individual fills at different price levels.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OrderSimulation {
+    /// Vector of fills as (price, quantity) pairs
+    pub fills: Vec<(u64, u64)>,
+
+    /// Average execution price across all fills (in price units)
+    pub avg_price: f64,
+
+    /// Total quantity that would be filled (in units)
+    pub total_filled: u64,
+
+    /// Quantity that could not be filled due to insufficient liquidity (in units)
+    pub remaining_quantity: u64,
+}
+
+impl MarketImpact {
+    /// Creates a new MarketImpact with all fields set to zero/empty
+    ///
+    /// # Returns
+    /// A MarketImpact instance with default values indicating no impact
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            avg_price: 0.0,
+            worst_price: 0,
+            slippage: 0,
+            slippage_bps: 0.0,
+            levels_consumed: 0,
+            total_quantity_available: 0,
+        }
+    }
+
+    /// Checks if the order can be fully filled
+    ///
+    /// # Arguments
+    /// - `requested_quantity`: The quantity originally requested (in units)
+    ///
+    /// # Returns
+    /// `true` if sufficient liquidity exists to fill the entire order
+    #[must_use]
+    pub fn can_fill(&self, requested_quantity: u64) -> bool {
+        self.total_quantity_available >= requested_quantity
+    }
+
+    /// Returns the fill ratio (0.0 to 1.0)
+    ///
+    /// # Arguments
+    /// - `requested_quantity`: The quantity originally requested (in units)
+    ///
+    /// # Returns
+    /// The ratio of available quantity to requested quantity
+    #[must_use]
+    pub fn fill_ratio(&self, requested_quantity: u64) -> f64 {
+        if requested_quantity == 0 {
+            return 0.0;
+        }
+        (self.total_quantity_available as f64) / (requested_quantity as f64)
+    }
+}
+
+impl OrderSimulation {
+    /// Creates a new OrderSimulation with empty fills
+    ///
+    /// # Returns
+    /// An OrderSimulation instance with no fills
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            fills: Vec::new(),
+            avg_price: 0.0,
+            total_filled: 0,
+            remaining_quantity: 0,
+        }
+    }
+
+    /// Checks if the order was fully filled
+    ///
+    /// # Returns
+    /// `true` if no quantity remains unfilled
+    #[must_use]
+    pub fn is_fully_filled(&self) -> bool {
+        self.remaining_quantity == 0
+    }
+
+    /// Returns the number of price levels used in the simulation
+    ///
+    /// # Returns
+    /// The count of distinct price levels in the fills
+    #[must_use]
+    pub fn levels_count(&self) -> usize {
+        self.fills.len()
+    }
+
+    /// Calculates the total cost of the simulated order
+    ///
+    /// # Returns
+    /// The total cost (price × quantity summed across all fills)
+    #[must_use]
+    pub fn total_cost(&self) -> u128 {
+        self.fills
+            .iter()
+            .map(|(price, qty)| (*price as u128) * (*qty as u128))
+            .sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_market_impact_empty() {
+        let impact = MarketImpact::empty();
+        assert_eq!(impact.avg_price, 0.0);
+        assert_eq!(impact.worst_price, 0);
+        assert_eq!(impact.levels_consumed, 0);
+    }
+
+    #[test]
+    fn test_market_impact_can_fill() {
+        let impact = MarketImpact {
+            avg_price: 100.0,
+            worst_price: 105,
+            slippage: 5,
+            slippage_bps: 50.0,
+            levels_consumed: 3,
+            total_quantity_available: 100,
+        };
+
+        assert!(impact.can_fill(100));
+        assert!(impact.can_fill(50));
+        assert!(!impact.can_fill(101));
+    }
+
+    #[test]
+    fn test_market_impact_fill_ratio() {
+        let impact = MarketImpact {
+            avg_price: 100.0,
+            worst_price: 105,
+            slippage: 5,
+            slippage_bps: 50.0,
+            levels_consumed: 3,
+            total_quantity_available: 75,
+        };
+
+        assert_eq!(impact.fill_ratio(100), 0.75);
+        assert_eq!(impact.fill_ratio(75), 1.0);
+        assert_eq!(impact.fill_ratio(0), 0.0);
+    }
+
+    #[test]
+    fn test_order_simulation_empty() {
+        let sim = OrderSimulation::empty();
+        assert!(sim.fills.is_empty());
+        assert_eq!(sim.total_filled, 0);
+        assert!(sim.is_fully_filled());
+    }
+
+    #[test]
+    fn test_order_simulation_is_fully_filled() {
+        let sim = OrderSimulation {
+            fills: vec![(100, 50), (105, 50)],
+            avg_price: 102.5,
+            total_filled: 100,
+            remaining_quantity: 0,
+        };
+        assert!(sim.is_fully_filled());
+
+        let sim_partial = OrderSimulation {
+            fills: vec![(100, 50)],
+            avg_price: 100.0,
+            total_filled: 50,
+            remaining_quantity: 50,
+        };
+        assert!(!sim_partial.is_fully_filled());
+    }
+
+    #[test]
+    fn test_order_simulation_levels_count() {
+        let sim = OrderSimulation {
+            fills: vec![(100, 30), (105, 40), (110, 30)],
+            avg_price: 105.0,
+            total_filled: 100,
+            remaining_quantity: 0,
+        };
+        assert_eq!(sim.levels_count(), 3);
+    }
+
+    #[test]
+    fn test_order_simulation_total_cost() {
+        let sim = OrderSimulation {
+            fills: vec![(100, 10), (105, 10)],
+            avg_price: 102.5,
+            total_filled: 20,
+            remaining_quantity: 0,
+        };
+        // (100 * 10) + (105 * 10) = 1000 + 1050 = 2050
+        assert_eq!(sim.total_cost(), 2050);
+    }
+}

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -4,6 +4,8 @@ pub mod book;
 pub mod error;
 /// Multi-book management with centralized trade event routing.
 pub mod manager;
+/// Market impact simulation and liquidity analysis.
+pub mod market_impact;
 pub mod matching;
 
 mod cache;
@@ -19,6 +21,7 @@ pub mod trade;
 
 pub use book::OrderBook;
 pub use error::OrderBookError;
+pub use market_impact::{MarketImpact, OrderSimulation};
 pub use snapshot::{
     ORDERBOOK_SNAPSHOT_FORMAT_VERSION, OrderBookSnapshot, OrderBookSnapshotPackage,
 };

--- a/src/orderbook/tests/market_impact_tests.rs
+++ b/src/orderbook/tests/market_impact_tests.rs
@@ -1,0 +1,282 @@
+//! Tests for market impact simulation and liquidity analysis
+
+#[cfg(test)]
+mod tests {
+    use crate::OrderBook;
+    use pricelevel::{OrderId, Side, TimeInForce};
+
+    #[test]
+    fn test_market_impact_basic() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add ask orders
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 105, 15, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 110, 20, Side::Sell, TimeInForce::Gtc, None);
+
+        // Buy 20 units (will consume 2 levels)
+        let impact = book.market_impact(20, Side::Buy);
+
+        assert_eq!(impact.total_quantity_available, 20);
+        assert_eq!(impact.levels_consumed, 2);
+        assert_eq!(impact.worst_price, 105);
+        assert_eq!(impact.slippage, 5);
+        // avg_price = (100*10 + 105*10) / 20 = 102.5
+        assert_eq!(impact.avg_price, 102.5);
+    }
+
+    #[test]
+    fn test_market_impact_insufficient_liquidity() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add limited ask orders
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Sell, TimeInForce::Gtc, None);
+
+        // Request more than available
+        let impact = book.market_impact(50, Side::Buy);
+
+        assert_eq!(impact.total_quantity_available, 10);
+        assert_eq!(impact.levels_consumed, 1);
+        assert!(!impact.can_fill(50));
+        assert_eq!(impact.fill_ratio(50), 0.2);
+    }
+
+    #[test]
+    fn test_market_impact_empty_book() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let impact = book.market_impact(100, Side::Buy);
+
+        assert_eq!(impact.avg_price, 0.0);
+        assert_eq!(impact.worst_price, 0);
+        assert_eq!(impact.levels_consumed, 0);
+        assert_eq!(impact.total_quantity_available, 0);
+    }
+
+    #[test]
+    fn test_market_impact_zero_quantity() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Sell, TimeInForce::Gtc, None);
+
+        let impact = book.market_impact(0, Side::Buy);
+
+        assert_eq!(impact.total_quantity_available, 0);
+        assert_eq!(impact.levels_consumed, 0);
+    }
+
+    #[test]
+    fn test_market_impact_sell_side() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add bid orders
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 95, 15, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 90, 20, Side::Buy, TimeInForce::Gtc, None);
+
+        // Sell 20 units (will consume 2 levels)
+        let impact = book.market_impact(20, Side::Sell);
+
+        assert_eq!(impact.total_quantity_available, 20);
+        assert_eq!(impact.levels_consumed, 2);
+        assert_eq!(impact.worst_price, 95);
+        assert_eq!(impact.slippage, 5); // 100 - 95
+        // avg_price = (100*10 + 95*10) / 20 = 97.5
+        assert_eq!(impact.avg_price, 97.5);
+    }
+
+    #[test]
+    fn test_market_impact_slippage_bps() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add ask orders at 10000 and 10100
+        let _ = book.add_limit_order(
+            OrderId::new(),
+            10000,
+            10,
+            Side::Sell,
+            TimeInForce::Gtc,
+            None,
+        );
+        let _ = book.add_limit_order(
+            OrderId::new(),
+            10100,
+            10,
+            Side::Sell,
+            TimeInForce::Gtc,
+            None,
+        );
+
+        // Buy 15 units (will go into second level)
+        let impact = book.market_impact(15, Side::Buy);
+
+        // Slippage = 100, best_price = 10000, bps = (100/10000) * 10000 = 100 bps
+        assert_eq!(impact.slippage, 100);
+        assert_eq!(impact.slippage_bps, 100.0);
+    }
+
+    #[test]
+    fn test_simulate_market_order_basic() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add ask orders
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 105, 15, Side::Sell, TimeInForce::Gtc, None);
+
+        // Buy 20 units
+        let simulation = book.simulate_market_order(20, Side::Buy);
+
+        assert_eq!(simulation.fills.len(), 2);
+        assert_eq!(simulation.fills[0], (100, 10));
+        assert_eq!(simulation.fills[1], (105, 10));
+        assert_eq!(simulation.total_filled, 20);
+        assert_eq!(simulation.remaining_quantity, 0);
+        assert!(simulation.is_fully_filled());
+        // avg_price = (100*10 + 105*10) / 20 = 102.5
+        assert_eq!(simulation.avg_price, 102.5);
+    }
+
+    #[test]
+    fn test_simulate_market_order_partial_fill() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add limited ask orders
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 105, 15, Side::Sell, TimeInForce::Gtc, None);
+
+        // Request more than available
+        let simulation = book.simulate_market_order(50, Side::Buy);
+
+        assert_eq!(simulation.total_filled, 25);
+        assert_eq!(simulation.remaining_quantity, 25);
+        assert!(!simulation.is_fully_filled());
+        assert_eq!(simulation.levels_count(), 2);
+    }
+
+    #[test]
+    fn test_simulate_market_order_empty_book() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let simulation = book.simulate_market_order(100, Side::Buy);
+
+        assert_eq!(simulation.fills.len(), 0);
+        assert_eq!(simulation.total_filled, 0);
+        assert_eq!(simulation.remaining_quantity, 100);
+    }
+
+    #[test]
+    fn test_simulate_market_order_total_cost() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 105, 10, Side::Sell, TimeInForce::Gtc, None);
+
+        let simulation = book.simulate_market_order(20, Side::Buy);
+
+        // Total cost = (100*10) + (105*10) = 2050
+        assert_eq!(simulation.total_cost(), 2050);
+    }
+
+    #[test]
+    fn test_liquidity_in_range_basic() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add buy orders at different prices
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 105, 15, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 110, 20, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 115, 25, Side::Buy, TimeInForce::Gtc, None);
+
+        // Get liquidity between 105 and 110 (inclusive)
+        let liquidity = book.liquidity_in_range(105, 110, Side::Buy);
+
+        assert_eq!(liquidity, 35); // 15 + 20
+    }
+
+    #[test]
+    fn test_liquidity_in_range_full_range() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 105, 15, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 110, 20, Side::Buy, TimeInForce::Gtc, None);
+
+        // Get all liquidity
+        let liquidity = book.liquidity_in_range(0, u64::MAX, Side::Buy);
+
+        assert_eq!(liquidity, 45); // 10 + 15 + 20
+    }
+
+    #[test]
+    fn test_liquidity_in_range_no_overlap() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 105, 15, Side::Buy, TimeInForce::Gtc, None);
+
+        // Range outside of available prices
+        let liquidity = book.liquidity_in_range(200, 300, Side::Buy);
+
+        assert_eq!(liquidity, 0);
+    }
+
+    #[test]
+    fn test_liquidity_in_range_invalid_range() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+
+        // min_price > max_price
+        let liquidity = book.liquidity_in_range(200, 100, Side::Buy);
+
+        assert_eq!(liquidity, 0);
+    }
+
+    #[test]
+    fn test_liquidity_in_range_empty_book() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let liquidity = book.liquidity_in_range(100, 200, Side::Buy);
+
+        assert_eq!(liquidity, 0);
+    }
+
+    #[test]
+    fn test_liquidity_in_range_asks() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add sell orders
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 105, 15, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 110, 20, Side::Sell, TimeInForce::Gtc, None);
+
+        let liquidity = book.liquidity_in_range(100, 105, Side::Sell);
+
+        assert_eq!(liquidity, 25); // 10 + 15
+    }
+
+    #[test]
+    fn test_all_functions_together() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Setup order book
+        let _ = book.add_limit_order(OrderId::new(), 99, 20, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 100, 30, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 101, 25, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 102, 35, Side::Sell, TimeInForce::Gtc, None);
+
+        // Test market impact
+        let impact = book.market_impact(50, Side::Buy);
+        assert_eq!(impact.total_quantity_available, 50);
+        assert!(impact.can_fill(50));
+
+        // Test simulation
+        let simulation = book.simulate_market_order(50, Side::Buy);
+        assert!(simulation.is_fully_filled());
+        assert_eq!(simulation.levels_count(), 2);
+
+        // Test liquidity
+        let liquidity = book.liquidity_in_range(101, 102, Side::Sell);
+        assert_eq!(liquidity, 60); // 25 + 35
+    }
+}

--- a/src/orderbook/tests/mod.rs
+++ b/src/orderbook/tests/mod.rs
@@ -1,6 +1,7 @@
 mod book;
 mod depth_analysis;
 mod error;
+mod market_impact_tests;
 mod market_metrics;
 mod matching;
 mod modifications;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -21,6 +21,9 @@ pub use crate::orderbook::OrderBook;
 pub use crate::orderbook::OrderBookError;
 pub use crate::orderbook::manager::{BookManager, BookManagerStd, BookManagerTokio};
 
+// Market impact and simulation types
+pub use crate::orderbook::market_impact::{MarketImpact, OrderSimulation};
+
 // Trade-related types
 pub use crate::orderbook::trade::{
     TradeEvent, TradeInfo, TradeListener, TradeResult, TransactionInfo,


### PR DESCRIPTION
…hods, tests, documentation, and examples

- Introduce `market_impact`, `simulate_market_order`, and `liquidity_in_range` methods for pre-trade analysis, execution simulation, and liquidity assessment.
- Add `MarketImpact` and `OrderSimulation` structs for detailed impact and simulation metrics.
- Create `market_impact_simulation.rs` example demonstrating pre-trade risk analysis, order execution simulation, and liquidity evaluation.
- Add extensive inline documentation and tests for new functionality.
- Update `README.md` with new example and feature details.

#20 Add market impact simulation and liquidity analysis methods

#20 Add market impact simulation and liquidity analysis