### PR TITLE
Add intelligent order placement utilities, tests, docs, and examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # OrderBook-rs Examples
 
-This directory contains **15 comprehensive examples** demonstrating various features and use cases of the OrderBook-rs library. Each example is designed to showcase specific functionality and best practices for different use cases from beginner tutorials to advanced performance testing.
+This directory contains **16 comprehensive examples** demonstrating various features and use cases of the OrderBook-rs library. Each example is designed to showcase specific functionality and best practices for different use cases from beginner tutorials to advanced performance testing.
 
 ## 📑 Quick Index
 
@@ -11,7 +11,8 @@ This directory contains **15 comprehensive examples** demonstrating various feat
 | `market_trades_demo` | Market order execution and trades | 🎓 Beginner |
 | `depth_analysis` | Market depth & liquidity analysis | 💡 Advanced |
 | `market_metrics` | Market metrics (VWAP, spread, imbalance) | 💡 Advanced |
-| `market_impact_simulation` | ⭐ **New!** Pre-trade impact & risk analysis | 💡 Advanced |
+| `market_impact_simulation` | Pre-trade impact & risk analysis | 💡 Advanced |
+| `intelligent_order_placement` | ⭐ **New!** Smart order placement for market makers | 💡 Advanced |
 | `trade_listener_demo` | Real-time trade notifications | 💡 Advanced |
 | `trade_listener_channels` | Multi-book trade routing | 💡 Advanced |
 | `orderbook_snapshot_restore` | State persistence & recovery | 💡 Advanced |
@@ -141,6 +142,50 @@ cargo run --bin market_impact_simulation
 - Liquidity analysis techniques
 - Pre-trade risk management workflows
 - Smart order sizing strategies
+
+---
+
+### 🎯 Intelligent Order Placement (`intelligent_order_placement.rs`)
+
+⭐ **New!** Smart order placement utilities for market makers and algorithmic traders.
+
+```bash
+cargo run --bin intelligent_order_placement
+```
+
+**Features demonstrated:**
+- `queue_ahead_at_price()` - Check order queue depth at specific price
+- `price_n_ticks_inside()` - Calculate price N ticks from best bid/ask
+- `price_for_queue_position()` - Find price for target queue position
+- `price_at_depth_adjusted()` - Optimal price for depth-based strategies
+
+**Key concepts:**
+- **Queue Position**: Understanding your place in the FIFO queue
+- **Tick-Based Pricing**: Strategic pricing relative to best prices
+- **Position Targeting**: Finding prices for specific competitive positions
+- **Depth-Based Strategy**: Optimizing placement based on cumulative depth
+
+**Use cases:**
+- **Market Making**: Optimize quote placement for execution probability
+- **Queue Optimization**: Maximize fills by targeting light queues
+- **Competitive Positioning**: Balance aggressiveness vs. execution cost
+- **Liquidity Provision**: Strategic placement at key depth levels
+- **Smart Routing**: Compare and select optimal price levels
+
+**Practical applications:**
+- Analyze queue depth at each price level
+- Calculate prices 1-3 ticks inside best bid/ask
+- Target specific queue positions (1st, 2nd, 3rd, etc.)
+- Find optimal prices based on target depth (e.g., just inside 100 units)
+- Implement adaptive market making strategies
+- Decision making: join heavy queue vs. place 1 tick inside
+
+**What you'll learn:**
+- How queue position affects execution probability
+- Strategic pricing for market makers
+- Trade-offs between price improvement and execution speed
+- Depth-based order placement strategies
+- Practical market making decision workflows
 
 ---
 
@@ -520,14 +565,15 @@ cargo run --bin prelude_demo
 ---
 
 ### 💡 For Advanced Features
-1. **`market_impact_simulation.rs`** - ⭐ **New!** Pre-trade impact & risk analysis
-2. **`market_metrics.rs`** - Market metrics (VWAP, spread, imbalance)
-3. **`depth_analysis.rs`** - Market depth and liquidity analysis
-4. **`trade_listener_demo.rs`** - Real-time event notifications
-5. **`trade_listener_channels.rs`** - Multi-book trade routing
-6. **`orderbook_snapshot_restore.rs`** - State persistence and recovery
+1. **`intelligent_order_placement.rs`** - ⭐ **New!** Smart order placement for market makers
+2. **`market_impact_simulation.rs`** - Pre-trade impact & risk analysis
+3. **`market_metrics.rs`** - Market metrics (VWAP, spread, imbalance)
+4. **`depth_analysis.rs`** - Market depth and liquidity analysis
+5. **`trade_listener_demo.rs`** - Real-time event notifications
+6. **`trade_listener_channels.rs`** - Multi-book trade routing
+7. **`orderbook_snapshot_restore.rs`** - State persistence and recovery
 
-**Use these to:** Build market-making bots, implement advanced trading strategies, assess pre-trade risk, manage multiple order books, generate trading signals.
+**Use these to:** Build market-making bots, optimize order placement, implement advanced trading strategies, assess pre-trade risk, manage multiple order books, generate trading signals.
 
 ---
 
@@ -608,9 +654,10 @@ For detailed API documentation, see:
 3. Run `market_trades_demo` to see trades in action
 4. Learn `market_metrics` for trading signals and risk management
 5. Explore `market_impact_simulation` for pre-trade risk assessment
-6. Study `depth_analysis` for advanced market making
-7. Try `multi_threaded_orderbook` to understand concurrency
-8. Dive into `orderbook_hft_simulation` for realistic scenarios
+6. Study `intelligent_order_placement` for market making strategies
+7. Review `depth_analysis` for advanced liquidity analysis
+8. Try `multi_threaded_orderbook` to understand concurrency
+9. Dive into `orderbook_hft_simulation` for realistic scenarios
 
 **Performance testing:**
 - Always use `--release` flag for accurate benchmarks

--- a/examples/src/bin/intelligent_order_placement.rs
+++ b/examples/src/bin/intelligent_order_placement.rs
@@ -1,0 +1,452 @@
+// examples/src/bin/intelligent_order_placement.rs
+//
+// This example demonstrates intelligent order placement utilities for market makers.
+// These tools help traders:
+// - Optimize queue position for maximum execution probability
+// - Place orders at strategic price levels
+// - Implement depth-based trading strategies
+// - Understand competitive positioning in the order book
+//
+// Functions demonstrated:
+// - `queue_ahead_at_price()`: Check queue position at a price level
+// - `price_n_ticks_inside()`: Calculate price N ticks from best
+// - `price_for_queue_position()`: Find price for target queue position
+// - `price_at_depth_adjusted()`: Optimal price for depth-based strategies
+//
+// Run this example with:
+//   cargo run --bin intelligent_order_placement
+//   (from the examples directory)
+
+use orderbook_rs::OrderBook;
+use pricelevel::{OrderId, Side, TimeInForce, setup_logger};
+use tracing::info;
+
+fn main() {
+    // Set up logging
+    setup_logger();
+    info!("Intelligent Order Placement Example");
+
+    // Create an order book with realistic depth
+    let book = create_orderbook_with_depth("BTC/USD");
+
+    // Display current book state
+    display_orderbook_state(&book);
+
+    // Demonstrate queue position analysis
+    demo_queue_position_analysis(&book);
+
+    // Demonstrate tick-based pricing
+    demo_tick_based_pricing(&book);
+
+    // Demonstrate queue position targeting
+    demo_queue_position_targeting(&book);
+
+    // Demonstrate depth-based strategies
+    demo_depth_based_strategies(&book);
+
+    // Practical use case: Market making strategy
+    demo_market_making_strategy(&book);
+}
+
+fn create_orderbook_with_depth(symbol: &str) -> OrderBook {
+    info!("\n=== Creating OrderBook with Market Depth ===");
+    info!("Symbol: {}", symbol);
+
+    let book = OrderBook::new(symbol);
+
+    // Add buy orders (bids) - multiple orders at same price to show queue
+    info!("\nAdding buy orders (bids):");
+
+    // Best bid level with 3 orders
+    let _ = book.add_limit_order(OrderId::new(), 50000, 10, Side::Buy, TimeInForce::Gtc, None);
+    let _ = book.add_limit_order(OrderId::new(), 50000, 15, Side::Buy, TimeInForce::Gtc, None);
+    let _ = book.add_limit_order(OrderId::new(), 50000, 20, Side::Buy, TimeInForce::Gtc, None);
+    info!("  @ 50000: 3 orders (10 + 15 + 20 = 45 total)");
+
+    // Second level
+    let _ = book.add_limit_order(OrderId::new(), 49950, 25, Side::Buy, TimeInForce::Gtc, None);
+    let _ = book.add_limit_order(OrderId::new(), 49950, 30, Side::Buy, TimeInForce::Gtc, None);
+    info!("  @ 49950: 2 orders (25 + 30 = 55 total)");
+
+    // Deeper levels
+    let _ = book.add_limit_order(OrderId::new(), 49900, 35, Side::Buy, TimeInForce::Gtc, None);
+    let _ = book.add_limit_order(OrderId::new(), 49850, 40, Side::Buy, TimeInForce::Gtc, None);
+    let _ = book.add_limit_order(OrderId::new(), 49800, 45, Side::Buy, TimeInForce::Gtc, None);
+
+    // Add sell orders (asks)
+    info!("\nAdding sell orders (asks):");
+
+    // Best ask level with 2 orders
+    let _ = book.add_limit_order(
+        OrderId::new(),
+        50100,
+        12,
+        Side::Sell,
+        TimeInForce::Gtc,
+        None,
+    );
+    let _ = book.add_limit_order(
+        OrderId::new(),
+        50100,
+        18,
+        Side::Sell,
+        TimeInForce::Gtc,
+        None,
+    );
+    info!("  @ 50100: 2 orders (12 + 18 = 30 total)");
+
+    // Second level
+    let _ = book.add_limit_order(
+        OrderId::new(),
+        50150,
+        22,
+        Side::Sell,
+        TimeInForce::Gtc,
+        None,
+    );
+    let _ = book.add_limit_order(
+        OrderId::new(),
+        50150,
+        28,
+        Side::Sell,
+        TimeInForce::Gtc,
+        None,
+    );
+    let _ = book.add_limit_order(
+        OrderId::new(),
+        50150,
+        33,
+        Side::Sell,
+        TimeInForce::Gtc,
+        None,
+    );
+    info!("  @ 50150: 3 orders (22 + 28 + 33 = 83 total)");
+
+    // Deeper levels
+    let _ = book.add_limit_order(
+        OrderId::new(),
+        50200,
+        38,
+        Side::Sell,
+        TimeInForce::Gtc,
+        None,
+    );
+    let _ = book.add_limit_order(
+        OrderId::new(),
+        50250,
+        43,
+        Side::Sell,
+        TimeInForce::Gtc,
+        None,
+    );
+    let _ = book.add_limit_order(
+        OrderId::new(),
+        50300,
+        48,
+        Side::Sell,
+        TimeInForce::Gtc,
+        None,
+    );
+
+    book
+}
+
+fn display_orderbook_state(book: &OrderBook) {
+    info!("\n=== OrderBook State ===");
+
+    if let Some(best_bid) = book.best_bid() {
+        info!("Best Bid: {}", best_bid);
+    }
+
+    if let Some(best_ask) = book.best_ask() {
+        info!("Best Ask: {}", best_ask);
+    }
+
+    if let (Some(bid), Some(ask)) = (book.best_bid(), book.best_ask()) {
+        let spread = ask.saturating_sub(bid);
+        info!("Spread: {}", spread);
+    }
+}
+
+fn demo_queue_position_analysis(book: &OrderBook) {
+    info!("\n=== Queue Position Analysis ===");
+    info!("Understanding your position in the order queue");
+
+    // Analyze buy side
+    info!("\nBuy side (bids):");
+    let bid_prices = vec![50000, 49950, 49900];
+
+    for price in bid_prices {
+        let queue_depth = book.queue_ahead_at_price(price, Side::Buy);
+        if queue_depth > 0 {
+            info!("  @ {}: {} orders in queue", price, queue_depth);
+            info!(
+                "    → If you place an order here, you'll be {}th in line",
+                queue_depth + 1
+            );
+        }
+    }
+
+    // Analyze sell side
+    info!("\nSell side (asks):");
+    let ask_prices = vec![50100, 50150, 50200];
+
+    for price in ask_prices {
+        let queue_depth = book.queue_ahead_at_price(price, Side::Sell);
+        if queue_depth > 0 {
+            info!("  @ {}: {} orders in queue", price, queue_depth);
+
+            if queue_depth == 1 {
+                info!("    → Light queue - good execution probability");
+            } else if queue_depth <= 3 {
+                info!("    → Moderate queue - decent execution chance");
+            } else {
+                info!("    → Heavy queue - consider alternative price");
+            }
+        }
+    }
+}
+
+fn demo_tick_based_pricing(book: &OrderBook) {
+    info!("\n=== Tick-Based Pricing ===");
+    info!("Calculate prices relative to best bid/ask");
+
+    let tick_size = 50; // $50 per tick
+
+    // Buy side examples
+    info!("\nBuy side (bids):");
+    for n_ticks in 1..=3 {
+        if let Some(price) = book.price_n_ticks_inside(n_ticks, tick_size, Side::Buy) {
+            let best_bid = book.best_bid().unwrap();
+            let distance = best_bid - price;
+            info!(
+                "  {} tick(s) inside: {} (${} below best bid)",
+                n_ticks, price, distance
+            );
+
+            if n_ticks == 1 {
+                info!("    → Competitive but not best - good for passive fills");
+            } else if n_ticks == 2 {
+                info!("    → More passive - lower execution probability");
+            }
+        }
+    }
+
+    // Sell side examples
+    info!("\nSell side (asks):");
+    for n_ticks in 1..=3 {
+        if let Some(price) = book.price_n_ticks_inside(n_ticks, tick_size, Side::Sell) {
+            let best_ask = book.best_ask().unwrap();
+            let distance = price - best_ask;
+            info!(
+                "  {} tick(s) inside: {} (${} above best ask)",
+                n_ticks, price, distance
+            );
+        }
+    }
+
+    // Practical application
+    info!("\n💡 Practical Application:");
+    if let Some(bid_price) = book.price_n_ticks_inside(1, tick_size, Side::Buy) {
+        info!("  To be competitive without being at the touch:");
+        info!("  → Place buy order at: {}", bid_price);
+        info!("  → This gives you priority over deeper orders");
+        info!("  → But saves you {} per unit vs best bid", tick_size);
+    }
+}
+
+fn demo_queue_position_targeting(book: &OrderBook) {
+    info!("\n=== Queue Position Targeting ===");
+    info!("Find prices for specific queue positions");
+
+    // Buy side
+    info!("\nBuy side - finding prices for positions:");
+    for position in 1..=5 {
+        if let Some(price) = book.price_for_queue_position(position, Side::Buy) {
+            let queue_depth = book.queue_ahead_at_price(price, Side::Buy);
+            info!(
+                "  Position {}: price = {} ({} orders at this level)",
+                position, price, queue_depth
+            );
+
+            if position == 1 {
+                info!("    ✓ Best bid - maximum execution probability");
+            } else if position == 2 {
+                info!("    • Second best - still competitive");
+            }
+        } else {
+            info!("  Position {}: No price level exists", position);
+            break;
+        }
+    }
+
+    // Sell side
+    info!("\nSell side - finding prices for positions:");
+    for position in 1..=5 {
+        if let Some(price) = book.price_for_queue_position(position, Side::Sell) {
+            let queue_depth = book.queue_ahead_at_price(price, Side::Sell);
+            info!(
+                "  Position {}: price = {} ({} orders at this level)",
+                position, price, queue_depth
+            );
+        } else {
+            break;
+        }
+    }
+}
+
+fn demo_depth_based_strategies(book: &OrderBook) {
+    info!("\n=== Depth-Based Strategies ===");
+    info!("Optimize order placement based on cumulative depth");
+
+    let tick_size = 50;
+
+    // Buy side depth targets
+    info!("\nBuy side depth-based pricing:");
+    let buy_targets = vec![50, 100, 150];
+
+    for target_depth in buy_targets {
+        if let Some(price) = book.price_at_depth_adjusted(target_depth, tick_size, Side::Buy) {
+            info!("\n  Target: {} units of depth", target_depth);
+            info!("  Suggested price: {}", price);
+
+            // Calculate actual depth at this price
+            let actual_depth = calculate_depth_at_price(book, price, Side::Buy);
+            info!("  Actual depth at price: {} units", actual_depth);
+
+            if actual_depth >= target_depth {
+                info!("  ✓ Your order will be just inside target depth");
+            } else {
+                info!("  ⚠ Insufficient depth - this is the deepest available");
+            }
+        }
+    }
+
+    // Sell side depth targets
+    info!("\nSell side depth-based pricing:");
+    let sell_targets = vec![30, 80, 120];
+
+    for target_depth in sell_targets {
+        if let Some(price) = book.price_at_depth_adjusted(target_depth, tick_size, Side::Sell) {
+            info!("\n  Target: {} units of depth", target_depth);
+            info!("  Suggested price: {}", price);
+
+            let actual_depth = calculate_depth_at_price(book, price, Side::Sell);
+            info!("  Actual depth at price: {} units", actual_depth);
+        }
+    }
+}
+
+fn demo_market_making_strategy(book: &OrderBook) {
+    info!("\n=== Market Making Strategy Example ===");
+    info!("Practical application of intelligent order placement");
+
+    let tick_size = 50;
+
+    info!("\nStrategy: Provide liquidity with optimized queue position");
+    info!("Goal: Be competitive but not necessarily at touch");
+
+    // Analyze current market
+    let best_bid = book.best_bid().unwrap();
+    let best_ask = book.best_ask().unwrap();
+    let spread = best_ask - best_bid;
+
+    info!("\nMarket Analysis:");
+    info!("  Best Bid: {}", best_bid);
+    info!("  Best Ask: {}", best_ask);
+    info!(
+        "  Spread: {} ({}%)",
+        spread,
+        (spread as f64 / best_bid as f64) * 100.0
+    );
+
+    // Check queue at best prices
+    let bid_queue = book.queue_ahead_at_price(best_bid, Side::Buy);
+    let ask_queue = book.queue_ahead_at_price(best_ask, Side::Sell);
+
+    info!("\nQueue Analysis:");
+    info!("  Orders at best bid: {}", bid_queue);
+    info!("  Orders at best ask: {}", ask_queue);
+
+    // Decision making
+    info!("\n📊 Strategy Decision:");
+
+    // Buy side decision
+    if bid_queue > 3 {
+        info!("\n  Buy side:");
+        info!("  ✗ Best bid has heavy queue ({} orders)", bid_queue);
+
+        if let Some(alt_price) = book.price_n_ticks_inside(1, tick_size, Side::Buy) {
+            let alt_queue = book.queue_ahead_at_price(alt_price, Side::Buy);
+            info!("  → Consider 1 tick inside at {}", alt_price);
+            info!("  → Queue there: {} orders", alt_queue);
+            info!("  → Cost: ${} per unit less competitive", tick_size);
+            info!(
+                "  ✓ RECOMMENDATION: Place at {} for better execution probability",
+                alt_price
+            );
+        }
+    } else {
+        info!("\n  Buy side:");
+        info!("  ✓ Light queue at best bid ({} orders)", bid_queue);
+        info!("  ✓ RECOMMENDATION: Place at best bid {}", best_bid);
+    }
+
+    // Sell side decision
+    if ask_queue > 3 {
+        info!("\n  Sell side:");
+        info!("  ✗ Best ask has heavy queue ({} orders)", ask_queue);
+
+        if let Some(alt_price) = book.price_n_ticks_inside(1, tick_size, Side::Sell) {
+            let alt_queue = book.queue_ahead_at_price(alt_price, Side::Sell);
+            info!("  → Consider 1 tick inside at {}", alt_price);
+            info!("  → Queue there: {} orders", alt_queue);
+            info!("  ✓ RECOMMENDATION: Place at {}", alt_price);
+        }
+    } else {
+        info!("\n  Sell side:");
+        info!("  ✓ Light queue at best ask ({} orders)", ask_queue);
+        info!("  ✓ RECOMMENDATION: Place at best ask {}", best_ask);
+    }
+
+    // Alternative: Depth-based strategy
+    info!("\n💡 Alternative: Depth-Based Approach");
+    let target_depth = 100;
+
+    if let Some(bid_price) = book.price_at_depth_adjusted(target_depth, tick_size, Side::Buy) {
+        info!(
+            "  Buy: Place at {} to be just inside {} units depth",
+            bid_price, target_depth
+        );
+    }
+
+    if let Some(ask_price) = book.price_at_depth_adjusted(target_depth, tick_size, Side::Sell) {
+        info!(
+            "  Sell: Place at {} to be just inside {} units depth",
+            ask_price, target_depth
+        );
+    }
+
+    info!("\n✨ Key Takeaways:");
+    info!("  1. Queue position matters - heavy queues = lower execution probability");
+    info!("  2. Sometimes 1 tick worse price = much better execution");
+    info!("  3. Depth-based strategies can optimize risk/reward");
+    info!("  4. Monitor and adjust based on market dynamics");
+}
+
+// Helper function to calculate depth at a specific price
+fn calculate_depth_at_price(book: &OrderBook, target_price: u64, side: Side) -> u64 {
+    let best_price = match side {
+        Side::Buy => book.best_bid(),
+        Side::Sell => book.best_ask(),
+    };
+
+    if let Some(best) = best_price {
+        match side {
+            Side::Buy => book.liquidity_in_range(target_price, best, side),
+            Side::Sell => book.liquidity_in_range(best, target_price, side),
+        }
+    } else {
+        0
+    }
+}

--- a/src/orderbook/tests/mod.rs
+++ b/src/orderbook/tests/mod.rs
@@ -7,6 +7,7 @@ mod matching;
 mod modifications;
 mod operations;
 mod order;
+mod order_placement_tests;
 mod serialize_tests;
 mod snapshot;
 mod time_in_force;

--- a/src/orderbook/tests/order_placement_tests.rs
+++ b/src/orderbook/tests/order_placement_tests.rs
@@ -1,0 +1,295 @@
+//! Tests for intelligent order placement utilities
+
+#[cfg(test)]
+mod tests {
+    use crate::OrderBook;
+    use pricelevel::{OrderId, Side, TimeInForce};
+
+    #[test]
+    fn test_queue_ahead_at_price_basic() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add multiple orders at same price
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 100, 20, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 100, 30, Side::Buy, TimeInForce::Gtc, None);
+
+        assert_eq!(book.queue_ahead_at_price(100, Side::Buy), 3);
+    }
+
+    #[test]
+    fn test_queue_ahead_at_price_no_orders() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        assert_eq!(book.queue_ahead_at_price(100, Side::Buy), 0);
+    }
+
+    #[test]
+    fn test_queue_ahead_at_price_different_levels() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 99, 20, Side::Buy, TimeInForce::Gtc, None);
+
+        assert_eq!(book.queue_ahead_at_price(100, Side::Buy), 1);
+        assert_eq!(book.queue_ahead_at_price(99, Side::Buy), 1);
+        assert_eq!(book.queue_ahead_at_price(98, Side::Buy), 0);
+    }
+
+    #[test]
+    fn test_price_n_ticks_inside_buy() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+
+        // 1 tick inside with tick_size = 1 means 100 - 1 = 99
+        assert_eq!(book.price_n_ticks_inside(1, 1, Side::Buy), Some(99));
+
+        // 5 ticks inside = 100 - 5 = 95
+        assert_eq!(book.price_n_ticks_inside(5, 1, Side::Buy), Some(95));
+
+        // With tick_size = 10
+        assert_eq!(book.price_n_ticks_inside(2, 10, Side::Buy), Some(80));
+    }
+
+    #[test]
+    fn test_price_n_ticks_inside_sell() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Sell, TimeInForce::Gtc, None);
+
+        // 1 tick inside with tick_size = 1 means 100 + 1 = 101
+        assert_eq!(book.price_n_ticks_inside(1, 1, Side::Sell), Some(101));
+
+        // 5 ticks inside = 100 + 5 = 105
+        assert_eq!(book.price_n_ticks_inside(5, 1, Side::Sell), Some(105));
+
+        // With tick_size = 10
+        assert_eq!(book.price_n_ticks_inside(2, 10, Side::Sell), Some(120));
+    }
+
+    #[test]
+    fn test_price_n_ticks_inside_zero_values() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+
+        // Zero ticks should return None
+        assert_eq!(book.price_n_ticks_inside(0, 1, Side::Buy), None);
+
+        // Zero tick_size should return None
+        assert_eq!(book.price_n_ticks_inside(1, 0, Side::Buy), None);
+    }
+
+    #[test]
+    fn test_price_n_ticks_inside_empty_book() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        assert_eq!(book.price_n_ticks_inside(1, 1, Side::Buy), None);
+        assert_eq!(book.price_n_ticks_inside(1, 1, Side::Sell), None);
+    }
+
+    #[test]
+    fn test_price_n_ticks_inside_underflow() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let _ = book.add_limit_order(OrderId::new(), 5, 10, Side::Buy, TimeInForce::Gtc, None);
+
+        // Trying to go 10 ticks inside would underflow (5 - 10 < 0)
+        assert_eq!(book.price_n_ticks_inside(10, 1, Side::Buy), None);
+    }
+
+    #[test]
+    fn test_price_for_queue_position_basic() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 99, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 98, 10, Side::Buy, TimeInForce::Gtc, None);
+
+        // Position 1 should be best bid (100)
+        assert_eq!(book.price_for_queue_position(1, Side::Buy), Some(100));
+
+        // Position 2 should be second best (99)
+        assert_eq!(book.price_for_queue_position(2, Side::Buy), Some(99));
+
+        // Position 3 should be third best (98)
+        assert_eq!(book.price_for_queue_position(3, Side::Buy), Some(98));
+
+        // Position 4 doesn't exist
+        assert_eq!(book.price_for_queue_position(4, Side::Buy), None);
+    }
+
+    #[test]
+    fn test_price_for_queue_position_sell_side() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 101, 10, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 102, 10, Side::Sell, TimeInForce::Gtc, None);
+
+        // Position 1 should be best ask (100)
+        assert_eq!(book.price_for_queue_position(1, Side::Sell), Some(100));
+
+        // Position 2 should be second best (101)
+        assert_eq!(book.price_for_queue_position(2, Side::Sell), Some(101));
+    }
+
+    #[test]
+    fn test_price_for_queue_position_zero() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+
+        // Position 0 is invalid
+        assert_eq!(book.price_for_queue_position(0, Side::Buy), None);
+    }
+
+    #[test]
+    fn test_price_for_queue_position_empty_book() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        assert_eq!(book.price_for_queue_position(1, Side::Buy), None);
+    }
+
+    #[test]
+    fn test_price_at_depth_adjusted_basic() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Add orders with cumulative depth
+        let _ = book.add_limit_order(OrderId::new(), 100, 50, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 99, 60, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 98, 70, Side::Buy, TimeInForce::Gtc, None);
+
+        // Want to be just inside 100 units of depth
+        // Depth at 100: 50, at 99: 110 (50+60), so we reach target at 99
+        // One tick better than 99 is 100
+        if let Some(price) = book.price_at_depth_adjusted(100, 1, Side::Buy) {
+            assert_eq!(price, 100);
+        }
+
+        // Target depth 50 or less should return 101 (one tick better than 100)
+        if let Some(price) = book.price_at_depth_adjusted(50, 1, Side::Buy) {
+            assert_eq!(price, 101);
+        }
+    }
+
+    #[test]
+    fn test_price_at_depth_adjusted_insufficient_depth() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let _ = book.add_limit_order(OrderId::new(), 100, 50, Side::Buy, TimeInForce::Gtc, None);
+
+        // Target depth exceeds available, should return deepest price
+        if let Some(price) = book.price_at_depth_adjusted(100, 1, Side::Buy) {
+            assert_eq!(price, 100);
+        }
+    }
+
+    #[test]
+    fn test_price_at_depth_adjusted_sell_side() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let _ = book.add_limit_order(OrderId::new(), 100, 50, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 101, 60, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 102, 70, Side::Sell, TimeInForce::Gtc, None);
+
+        // Want to be just inside 100 units of depth
+        // Depth at 100: 50, at 101: 110, so we reach target at 101
+        // One tick better than 101 is 100 (for sell, better = lower)
+        if let Some(price) = book.price_at_depth_adjusted(100, 1, Side::Sell) {
+            assert_eq!(price, 100);
+        }
+    }
+
+    #[test]
+    fn test_price_at_depth_adjusted_zero_values() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let _ = book.add_limit_order(OrderId::new(), 100, 50, Side::Buy, TimeInForce::Gtc, None);
+
+        // Zero target_depth should return None
+        assert_eq!(book.price_at_depth_adjusted(0, 1, Side::Buy), None);
+
+        // Zero tick_size should return None
+        assert_eq!(book.price_at_depth_adjusted(100, 0, Side::Buy), None);
+    }
+
+    #[test]
+    fn test_price_at_depth_adjusted_empty_book() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        assert_eq!(book.price_at_depth_adjusted(100, 1, Side::Buy), None);
+    }
+
+    #[test]
+    fn test_all_placement_functions_together() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Setup realistic order book
+        let _ = book.add_limit_order(OrderId::new(), 100, 30, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 100, 20, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 99, 40, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 98, 50, Side::Buy, TimeInForce::Gtc, None);
+
+        let _ = book.add_limit_order(OrderId::new(), 105, 25, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 106, 35, Side::Sell, TimeInForce::Gtc, None);
+
+        // Test queue_ahead_at_price
+        assert_eq!(book.queue_ahead_at_price(100, Side::Buy), 2);
+        assert_eq!(book.queue_ahead_at_price(99, Side::Buy), 1);
+
+        // Test price_n_ticks_inside
+        assert_eq!(book.price_n_ticks_inside(1, 1, Side::Buy), Some(99));
+        assert_eq!(book.price_n_ticks_inside(1, 1, Side::Sell), Some(106));
+
+        // Test price_for_queue_position
+        assert_eq!(book.price_for_queue_position(1, Side::Buy), Some(100));
+        assert_eq!(book.price_for_queue_position(2, Side::Buy), Some(99));
+        assert_eq!(book.price_for_queue_position(1, Side::Sell), Some(105));
+
+        // Test price_at_depth_adjusted
+        // Buy side depth: 100=50, 99=90, 98=140
+        if let Some(price) = book.price_at_depth_adjusted(70, 1, Side::Buy) {
+            assert_eq!(price, 100); // Just inside level that reaches 90
+        }
+    }
+
+    #[test]
+    fn test_queue_position_with_multiple_levels() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        // Create a deep book
+        for i in 0..10 {
+            let price = 100 - i;
+            let _ =
+                book.add_limit_order(OrderId::new(), price, 10, Side::Buy, TimeInForce::Gtc, None);
+        }
+
+        // Test various positions
+        assert_eq!(book.price_for_queue_position(1, Side::Buy), Some(100));
+        assert_eq!(book.price_for_queue_position(5, Side::Buy), Some(96));
+        assert_eq!(book.price_for_queue_position(10, Side::Buy), Some(91));
+        assert_eq!(book.price_for_queue_position(11, Side::Buy), None);
+    }
+
+    #[test]
+    fn test_tick_calculations_with_large_values() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let _ = book.add_limit_order(
+            OrderId::new(),
+            100000,
+            10,
+            Side::Buy,
+            TimeInForce::Gtc,
+            None,
+        );
+
+        // Test with large tick size
+        assert_eq!(book.price_n_ticks_inside(10, 100, Side::Buy), Some(99000));
+
+        // Test with large number of ticks
+        assert_eq!(book.price_n_ticks_inside(1000, 1, Side::Buy), Some(99000));
+    }
+}


### PR DESCRIPTION
- Introduce `queue_ahead_at_price`, `price_n_ticks_inside`, `price_for_queue_position`, and `price_at_depth_adjusted` methods for strategic and depth-based order placement.
- Create comprehensive example in `intelligent_order_placement.rs` demonstrating market making strategies.
- Add `order_placement_tests.rs` for extensive coverage of new methods.
- Update `README.md` with new example and feature details.

#21 Add utilities for intelligent order placement