### PR TITLE
Add functional-style iterators for order book analysis, tests, docs, …

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,51 @@ This version introduces significant performance optimizations and architectural 
 ### Status
 This project is currently in active development and is not yet suitable for production use.
 
+### Advanced Features
+
+#### Market Metrics & Analysis
+
+The order book provides comprehensive market analysis capabilities:
+
+- **VWAP Calculation**: Volume-Weighted Average Price for analyzing true market price
+- **Spread Analysis**: Absolute and basis point spread calculations
+- **Micro Price**: Fair price estimation incorporating depth
+- **Order Book Imbalance**: Buy/sell pressure indicators
+- **Market Impact Simulation**: Pre-trade analysis for estimating slippage and execution costs
+- **Depth Analysis**: Cumulative depth and liquidity distribution
+
+#### Intelligent Order Placement
+
+Advanced utilities for market makers and algorithmic traders:
+
+- **Queue Analysis**: `queue_ahead_at_price()` - Check depth at specific price levels
+- **Tick-Based Pricing**: `price_n_ticks_inside()` - Calculate prices N ticks from best bid/ask
+- **Position Targeting**: `price_for_queue_position()` - Find prices for target queue positions
+- **Depth-Based Strategy**: `price_at_depth_adjusted()` - Optimal prices based on cumulative depth
+
+#### Functional Iterators
+
+Memory-efficient, composable iterators for order book analysis:
+
+- **Cumulative Depth Iteration**: `levels_with_cumulative_depth()` - Lazy iteration with running depth totals
+- **Depth-Limited Iteration**: `levels_until_depth()` - Auto-stop when target depth is reached
+- **Range-Based Iteration**: `levels_in_range()` - Filter levels by price range
+- **Predicate Search**: `find_level()` - Find first level matching custom conditions
+
+**Benefits:**
+- Zero allocation - O(1) memory vs O(N) for vectors
+- Lazy evaluation - compute only what's needed
+- Composable - works with standard iterator combinators (`.map()`, `.filter()`, `.take()`)
+- Short-circuit - stops early when conditions are met
+
+#### Multi-Book Management
+
+Centralized trade event routing and multi-book orchestration:
+
+- **BookManager**: Manage multiple order books with unified trade listener
+- **Standard & Tokio Support**: Synchronous and async variants
+- **Event Routing**: Centralized trade notifications across all books
+
 ## Performance Analysis of the OrderBook System
 
 This analyzes the performance of the OrderBook system based on tests conducted on an Apple M4 Max processor. The data comes from a High-Frequency Trading (HFT) simulation and price level distribution performance tests.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # OrderBook-rs Examples
 
-This directory contains **16 comprehensive examples** demonstrating various features and use cases of the OrderBook-rs library. Each example is designed to showcase specific functionality and best practices for different use cases from beginner tutorials to advanced performance testing.
+This directory contains **17 comprehensive examples** demonstrating various features and use cases of the OrderBook-rs library. Each example is designed to showcase specific functionality and best practices for different use cases from beginner tutorials to advanced performance testing.
 
 ## 📑 Quick Index
 
@@ -12,7 +12,8 @@ This directory contains **16 comprehensive examples** demonstrating various feat
 | `depth_analysis` | Market depth & liquidity analysis | 💡 Advanced |
 | `market_metrics` | Market metrics (VWAP, spread, imbalance) | 💡 Advanced |
 | `market_impact_simulation` | Pre-trade impact & risk analysis | 💡 Advanced |
-| `intelligent_order_placement` | ⭐ **New!** Smart order placement for market makers | 💡 Advanced |
+| `intelligent_order_placement` | Smart order placement for market makers | 💡 Advanced |
+| `functional_iterators` | ⭐ **New!** Functional-style depth analysis with iterators | 💡 Advanced |
 | `trade_listener_demo` | Real-time trade notifications | 💡 Advanced |
 | `trade_listener_channels` | Multi-book trade routing | 💡 Advanced |
 | `orderbook_snapshot_restore` | State persistence & recovery | 💡 Advanced |
@@ -186,6 +187,59 @@ cargo run --bin intelligent_order_placement
 - Trade-offs between price improvement and execution speed
 - Depth-based order placement strategies
 - Practical market making decision workflows
+
+---
+
+### 🔄 Functional Iterators (`functional_iterators.rs`)
+
+⭐ **New!** Modern functional-style iterators for memory-efficient order book analysis.
+
+```bash
+cargo run --bin functional_iterators
+```
+
+**Features demonstrated:**
+- `levels_with_cumulative_depth()` - Iterate with running depth totals
+- `levels_until_depth()` - Auto-stop at target depth
+- `levels_in_range()` - Filter by price range
+- `find_level()` - Find first matching level with predicates
+
+**Key concepts:**
+- **Lazy Evaluation**: No upfront memory allocation
+- **Composability**: Chain operations with standard iterator combinators
+- **Short-circuiting**: Stop early when condition is met
+- **Zero-copy**: Efficient traversal without intermediate collections
+- **Functional Style**: Expressive, readable code
+
+**Use cases:**
+- **Execution Planning**: Determine levels needed for target quantity
+- **Liquidity Analysis**: Analyze depth distribution without allocations
+- **Risk Assessment**: Calculate slippage efficiently
+- **Market Quality Metrics**: Compute depth statistics on-the-fly
+- **Smart Routing**: Compare venues without materializing full depth
+
+**Practical applications:**
+- Iterate through levels with cumulative depth tracking
+- Find first level exceeding quantity threshold
+- Calculate total liquidity in price range
+- Analyze depth distribution by bands
+- Build complex analysis pipelines with `.map()`, `.filter()`, `.take()`
+- Early termination for performance optimization
+
+**Benefits over traditional approaches:**
+- **Memory efficient**: O(1) memory vs O(N) for vectors
+- **Performance**: Can short-circuit, avoiding unnecessary work
+- **Composable**: Works seamlessly with Rust iterator ecosystem
+- **Expressive**: Functional style is more readable than imperative loops
+- **Flexible**: Easy to combine with other iterator operations
+
+**What you'll learn:**
+- Modern functional programming patterns in Rust
+- Lazy evaluation and its benefits
+- Iterator composition techniques
+- Zero-allocation data processing
+- Building efficient analysis pipelines
+- Short-circuit optimization strategies
 
 ---
 
@@ -565,15 +619,16 @@ cargo run --bin prelude_demo
 ---
 
 ### 💡 For Advanced Features
-1. **`intelligent_order_placement.rs`** - ⭐ **New!** Smart order placement for market makers
-2. **`market_impact_simulation.rs`** - Pre-trade impact & risk analysis
-3. **`market_metrics.rs`** - Market metrics (VWAP, spread, imbalance)
-4. **`depth_analysis.rs`** - Market depth and liquidity analysis
-5. **`trade_listener_demo.rs`** - Real-time event notifications
-6. **`trade_listener_channels.rs`** - Multi-book trade routing
-7. **`orderbook_snapshot_restore.rs`** - State persistence and recovery
+1. **`functional_iterators.rs`** - ⭐ **New!** Functional-style depth analysis with iterators
+2. **`intelligent_order_placement.rs`** - Smart order placement for market makers
+3. **`market_impact_simulation.rs`** - Pre-trade impact & risk analysis
+4. **`market_metrics.rs`** - Market metrics (VWAP, spread, imbalance)
+5. **`depth_analysis.rs`** - Market depth and liquidity analysis
+6. **`trade_listener_demo.rs`** - Real-time event notifications
+7. **`trade_listener_channels.rs`** - Multi-book trade routing
+8. **`orderbook_snapshot_restore.rs`** - State persistence and recovery
 
-**Use these to:** Build market-making bots, optimize order placement, implement advanced trading strategies, assess pre-trade risk, manage multiple order books, generate trading signals.
+**Use these to:** Build market-making bots, optimize order placement, implement advanced trading strategies, assess pre-trade risk, manage multiple order books, generate trading signals, perform efficient depth analysis.
 
 ---
 
@@ -653,11 +708,12 @@ For detailed API documentation, see:
 2. Study `basic_orderbook` for comprehensive coverage
 3. Run `market_trades_demo` to see trades in action
 4. Learn `market_metrics` for trading signals and risk management
-5. Explore `market_impact_simulation` for pre-trade risk assessment
-6. Study `intelligent_order_placement` for market making strategies
-7. Review `depth_analysis` for advanced liquidity analysis
-8. Try `multi_threaded_orderbook` to understand concurrency
-9. Dive into `orderbook_hft_simulation` for realistic scenarios
+5. Explore `functional_iterators` for efficient depth analysis
+6. Study `market_impact_simulation` for pre-trade risk assessment
+7. Review `intelligent_order_placement` for market making strategies
+8. Analyze `depth_analysis` for advanced liquidity analysis
+9. Try `multi_threaded_orderbook` to understand concurrency
+10. Dive into `orderbook_hft_simulation` for realistic scenarios
 
 **Performance testing:**
 - Always use `--release` flag for accurate benchmarks

--- a/examples/src/bin/functional_iterators.rs
+++ b/examples/src/bin/functional_iterators.rs
@@ -1,0 +1,434 @@
+// examples/src/bin/functional_iterators.rs
+//
+// This example demonstrates functional-style iterators for order book analysis.
+// These iterators provide memory-efficient, composable ways to analyze market depth
+// without unnecessary allocations, supporting lazy evaluation and early short-circuiting.
+//
+// Functions demonstrated:
+// - `levels_with_cumulative_depth()`: Iterate with running depth totals
+// - `levels_until_depth()`: Stop automatically at target depth
+// - `levels_in_range()`: Filter by price range
+// - `find_level()`: Find first matching level
+//
+// Run this example with:
+//   cargo run --bin functional_iterators
+//   (from the examples directory)
+
+use orderbook_rs::OrderBook;
+use pricelevel::{OrderId, Side, TimeInForce, setup_logger};
+use tracing::info;
+
+fn main() {
+    // Set up logging
+    setup_logger();
+    info!("Functional Iterators Example");
+
+    // Create an order book with realistic depth
+    let book = create_orderbook_with_depth("BTC/USD");
+
+    // Display current book state
+    display_orderbook_state(&book);
+
+    // Demonstrate basic iteration
+    demo_basic_iteration(&book);
+
+    // Demonstrate lazy evaluation benefits
+    demo_lazy_evaluation(&book);
+
+    // Demonstrate iterator composition
+    demo_iterator_composition(&book);
+
+    // Demonstrate range-based analysis
+    demo_range_analysis(&book);
+
+    // Demonstrate find operations
+    demo_find_operations(&book);
+
+    // Practical use cases
+    demo_practical_use_cases(&book);
+}
+
+fn create_orderbook_with_depth(symbol: &str) -> OrderBook {
+    info!("\n=== Creating OrderBook with Depth ===");
+    info!("Symbol: {}", symbol);
+
+    let book = OrderBook::new(symbol);
+
+    // Add buy orders (bids) with varying sizes
+    info!("\nAdding buy orders (bids):");
+    let bid_orders = vec![
+        (50000, 5),
+        (49950, 10),
+        (49900, 15),
+        (49850, 20),
+        (49800, 25),
+        (49750, 30),
+        (49700, 35),
+        (49650, 40),
+        (49600, 45),
+        (49550, 50),
+    ];
+
+    for (price, quantity) in bid_orders {
+        let _ = book.add_limit_order(
+            OrderId::new(),
+            price,
+            quantity,
+            Side::Buy,
+            TimeInForce::Gtc,
+            None,
+        );
+        info!("  Bid: {} @ {}", quantity, price);
+    }
+
+    // Add sell orders (asks) with varying sizes
+    info!("\nAdding sell orders (asks):");
+    let ask_orders = vec![
+        (50100, 8),
+        (50150, 12),
+        (50200, 16),
+        (50250, 20),
+        (50300, 24),
+        (50350, 28),
+        (50400, 32),
+        (50450, 36),
+        (50500, 40),
+        (50550, 44),
+    ];
+
+    for (price, quantity) in ask_orders {
+        let _ = book.add_limit_order(
+            OrderId::new(),
+            price,
+            quantity,
+            Side::Sell,
+            TimeInForce::Gtc,
+            None,
+        );
+        info!("  Ask: {} @ {}", quantity, price);
+    }
+
+    book
+}
+
+fn display_orderbook_state(book: &OrderBook) {
+    info!("\n=== OrderBook State ===");
+
+    if let Some(best_bid) = book.best_bid() {
+        info!("Best Bid: {}", best_bid);
+    }
+
+    if let Some(best_ask) = book.best_ask() {
+        info!("Best Ask: {}", best_ask);
+    }
+
+    if let (Some(bid), Some(ask)) = (book.best_bid(), book.best_ask()) {
+        let spread = ask.saturating_sub(bid);
+        info!("Spread: {}", spread);
+    }
+}
+
+fn demo_basic_iteration(book: &OrderBook) {
+    info!("\n=== Basic Iteration ===");
+    info!("Iterate through levels with cumulative depth tracking");
+
+    info!("\nBuy side (first 5 levels):");
+    for (i, level) in book
+        .levels_with_cumulative_depth(Side::Buy)
+        .take(5)
+        .enumerate()
+    {
+        info!(
+            "  Level {}: Price={}, Qty={}, Cumulative={}",
+            i + 1,
+            level.price,
+            level.quantity,
+            level.cumulative_depth
+        );
+    }
+
+    info!("\nSell side (first 5 levels):");
+    for (i, level) in book
+        .levels_with_cumulative_depth(Side::Sell)
+        .take(5)
+        .enumerate()
+    {
+        info!(
+            "  Level {}: Price={}, Qty={}, Cumulative={}",
+            i + 1,
+            level.price,
+            level.quantity,
+            level.cumulative_depth
+        );
+    }
+}
+
+fn demo_lazy_evaluation(book: &OrderBook) {
+    info!("\n=== Lazy Evaluation Benefits ===");
+    info!("Iterators don't allocate memory upfront");
+
+    // Example 1: Early termination
+    info!("\n1. Find first level with >20 units (short-circuits early):");
+    for level in book.levels_with_cumulative_depth(Side::Buy) {
+        if level.quantity > 20 {
+            info!("  Found: {} units @ {}", level.quantity, level.price);
+            info!("  Stopped early without processing remaining levels");
+            break;
+        }
+    }
+
+    // Example 2: Automatic depth limit
+    info!("\n2. Process only until 100 units accumulated:");
+    let count = book.levels_until_depth(100, Side::Buy).count();
+    info!("  Processed {} levels to reach 100 units", count);
+    info!("  Remaining levels were never touched (efficient!)");
+
+    // Example 3: No vector allocation
+    info!("\n3. Calculate total without allocating vectors:");
+    let total: u64 = book
+        .levels_with_cumulative_depth(Side::Buy)
+        .take(5)
+        .map(|level| level.quantity)
+        .sum();
+    info!(
+        "  Total quantity in top 5 levels: {} (no intermediate allocations)",
+        total
+    );
+}
+
+fn demo_iterator_composition(book: &OrderBook) {
+    info!("\n=== Iterator Composition ===");
+    info!("Chain multiple operations elegantly");
+
+    // Example 1: Filter and map
+    info!("\n1. Filter levels with >15 units, sum their quantities:");
+    let total: u64 = book
+        .levels_with_cumulative_depth(Side::Buy)
+        .filter(|level| level.quantity > 15)
+        .map(|level| level.quantity)
+        .sum();
+    info!("  Total of large orders: {}", total);
+
+    // Example 2: Take while condition
+    info!("\n2. Take levels while cumulative depth < 50:");
+    let levels: Vec<_> = book
+        .levels_with_cumulative_depth(Side::Buy)
+        .take_while(|level| level.cumulative_depth < 50)
+        .collect();
+    info!(
+        "  Collected {} levels before reaching 50 units",
+        levels.len()
+    );
+
+    // Example 3: Complex pipeline
+    info!("\n3. Complex analysis pipeline:");
+    let avg = book
+        .levels_with_cumulative_depth(Side::Buy)
+        .take(5)
+        .filter(|level| level.quantity >= 10)
+        .map(|level| level.quantity as f64)
+        .sum::<f64>()
+        / 5.0;
+    info!("  Average size of top 5 levels (>=10 units): {:.2}", avg);
+
+    // Example 4: Find and enumerate
+    info!("\n4. Enumerate and find specific condition:");
+    if let Some((idx, level)) = book
+        .levels_with_cumulative_depth(Side::Sell)
+        .enumerate()
+        .find(|(_, level)| level.cumulative_depth > 30)
+    {
+        info!(
+            "  First level with cumulative >30: index={}, price={}",
+            idx, level.price
+        );
+    }
+}
+
+fn demo_range_analysis(book: &OrderBook) {
+    info!("\n=== Range-Based Analysis ===");
+    info!("Analyze specific price bands efficiently");
+
+    // Example 1: Total liquidity in range
+    info!("\n1. Total liquidity in price range:");
+    let ranges = vec![
+        (49800, 50000, "Near touch"),
+        (49500, 49800, "Mid depth"),
+        (49000, 49500, "Deep book"),
+    ];
+
+    for (min, max, desc) in ranges {
+        let total: u64 = book
+            .levels_in_range(min, max, Side::Buy)
+            .map(|level| level.quantity)
+            .sum();
+        info!("  {}: {} units ({}-{})", desc, total, min, max);
+    }
+
+    // Example 2: Level count in range
+    info!("\n2. Count levels in ranges:");
+    let count_near = book.levels_in_range(49900, 50000, Side::Buy).count();
+    let count_mid = book.levels_in_range(49700, 49900, Side::Buy).count();
+    info!("  Near touch (49900-50000): {} levels", count_near);
+    info!("  Mid depth (49700-49900): {} levels", count_mid);
+
+    // Example 3: Average size in range
+    info!("\n3. Average order size in range:");
+    let levels: Vec<_> = book.levels_in_range(49700, 50000, Side::Buy).collect();
+    if !levels.is_empty() {
+        let total: u64 = levels.iter().map(|l| l.quantity).sum();
+        let avg = total as f64 / levels.len() as f64;
+        info!("  Range 49700-50000: {:.2} units avg", avg);
+    }
+}
+
+fn demo_find_operations(book: &OrderBook) {
+    info!("\n=== Find Operations ===");
+    info!("Search with custom predicates");
+
+    // Example 1: Find by quantity threshold
+    info!("\n1. Find first level with quantity > 25:");
+    if let Some(level) = book.find_level(Side::Buy, |info| info.quantity > 25) {
+        info!("  Found: {} units @ {}", level.quantity, level.price);
+    }
+
+    // Example 2: Find by cumulative depth
+    info!("\n2. Find where cumulative depth reaches 100:");
+    if let Some(level) = book.find_level(Side::Buy, |info| info.cumulative_depth >= 100) {
+        info!(
+            "  Reached @ price={}, cumulative={}",
+            level.price, level.cumulative_depth
+        );
+    }
+
+    // Example 3: Find by price condition
+    info!("\n3. Find first level below 49800:");
+    if let Some(level) = book.find_level(Side::Buy, |info| info.price < 49800) {
+        info!(
+            "  Found: price={}, quantity={}",
+            level.price, level.quantity
+        );
+    }
+
+    // Example 4: Complex predicate
+    info!("\n4. Find level with quantity >20 AND cumulative >50:");
+    if let Some(level) = book.find_level(Side::Buy, |info| {
+        info.quantity > 20 && info.cumulative_depth > 50
+    }) {
+        info!(
+            "  Found: qty={}, cumulative={}, @ {}",
+            level.quantity, level.cumulative_depth, level.price
+        );
+    }
+}
+
+fn demo_practical_use_cases(book: &OrderBook) {
+    info!("\n=== Practical Use Cases ===");
+
+    // Use case 1: Execution planning
+    info!("\n1. Execution Planning:");
+    info!("   How many levels needed to fill 150 units?");
+    let levels: Vec<_> = book.levels_until_depth(150, Side::Buy).collect();
+    info!("   → Need to consume {} price levels", levels.len());
+    if let Some(last) = levels.last() {
+        info!("   → Worst execution price: {}", last.price);
+        info!("   → Total available: {} units", last.cumulative_depth);
+    }
+
+    // Use case 2: Liquidity analysis
+    info!("\n2. Liquidity Distribution:");
+    let ranges = vec![
+        (0, 25, "Top 25 units"),
+        (25, 50, "Next 25 units"),
+        (50, 100, "Next 50 units"),
+    ];
+
+    for (start, end, desc) in ranges {
+        let levels: Vec<_> = book
+            .levels_with_cumulative_depth(Side::Buy)
+            .skip_while(|l| l.cumulative_depth <= start)
+            .take_while(|l| l.cumulative_depth <= end)
+            .collect();
+
+        if !levels.is_empty() {
+            let avg_price =
+                levels.iter().map(|l| l.price).sum::<u64>() as f64 / levels.len() as f64;
+            info!(
+                "   {}: avg price {:.0}, {} levels",
+                desc,
+                avg_price,
+                levels.len()
+            );
+        }
+    }
+
+    // Use case 3: Risk assessment
+    info!("\n3. Risk Assessment:");
+    info!("   Analyze slippage for different order sizes:");
+    let sizes = vec![25, 50, 100, 200];
+
+    for size in sizes {
+        if let Some(last_level) = book.levels_until_depth(size, Side::Buy).last() {
+            let best_bid = book.best_bid().unwrap();
+            let slippage = best_bid - last_level.price;
+            let slippage_pct = (slippage as f64 / best_bid as f64) * 100.0;
+
+            info!(
+                "   Order size {}: worst price={}, slippage={:.3}%",
+                size, last_level.price, slippage_pct
+            );
+        }
+    }
+
+    // Use case 4: Market quality metrics
+    info!("\n4. Market Quality Metrics:");
+
+    // Depth at different levels
+    let depth_at_5 = book
+        .levels_with_cumulative_depth(Side::Buy)
+        .nth(4)
+        .map(|l| l.cumulative_depth)
+        .unwrap_or(0);
+
+    info!("   Depth at 5th level: {} units", depth_at_5);
+
+    // Average spread between levels
+    let levels: Vec<_> = book
+        .levels_with_cumulative_depth(Side::Buy)
+        .take(5)
+        .collect();
+
+    if levels.len() >= 2 {
+        let spreads: Vec<u64> = levels.windows(2).map(|w| w[0].price - w[1].price).collect();
+        let avg_spread = spreads.iter().sum::<u64>() as f64 / spreads.len() as f64;
+        info!("   Average spread between top 5 levels: {:.0}", avg_spread);
+    }
+
+    // Use case 5: Smart order routing
+    info!("\n5. Smart Order Routing Decision:");
+    let target_size = 75;
+
+    // Check if we can fill without excessive slippage
+    if let Some(last_level) = book.levels_until_depth(target_size, Side::Buy).last() {
+        let best = book.best_bid().unwrap();
+        let slippage_bps = ((best - last_level.price) as f64 / best as f64) * 10000.0;
+
+        info!("   Target order: {} units", target_size);
+        info!("   Expected slippage: {:.2} bps", slippage_bps);
+
+        if slippage_bps < 10.0 {
+            info!("   ✓ RECOMMENDATION: Execute on this venue (low slippage)");
+        } else if slippage_bps < 50.0 {
+            info!("   • RECOMMENDATION: Acceptable, but compare other venues");
+        } else {
+            info!("   ✗ RECOMMENDATION: Split order or use different venue");
+        }
+    }
+
+    info!("\n✨ Key Benefits of Functional Iterators:");
+    info!("  • Zero allocation - no intermediate vectors");
+    info!("  • Lazy evaluation - compute only what's needed");
+    info!("  • Composable - chain operations elegantly");
+    info!("  • Short-circuit - stop early when condition met");
+    info!("  • Expressive - readable functional style");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,51 @@
 //! ## Status
 //! This project is currently in active development and is not yet suitable for production use.
 //!
+//! ## Advanced Features
+//!
+//! ### Market Metrics & Analysis
+//!
+//! The order book provides comprehensive market analysis capabilities:
+//!
+//! - **VWAP Calculation**: Volume-Weighted Average Price for analyzing true market price
+//! - **Spread Analysis**: Absolute and basis point spread calculations
+//! - **Micro Price**: Fair price estimation incorporating depth
+//! - **Order Book Imbalance**: Buy/sell pressure indicators
+//! - **Market Impact Simulation**: Pre-trade analysis for estimating slippage and execution costs
+//! - **Depth Analysis**: Cumulative depth and liquidity distribution
+//!
+//! ### Intelligent Order Placement
+//!
+//! Advanced utilities for market makers and algorithmic traders:
+//!
+//! - **Queue Analysis**: `queue_ahead_at_price()` - Check depth at specific price levels
+//! - **Tick-Based Pricing**: `price_n_ticks_inside()` - Calculate prices N ticks from best bid/ask
+//! - **Position Targeting**: `price_for_queue_position()` - Find prices for target queue positions
+//! - **Depth-Based Strategy**: `price_at_depth_adjusted()` - Optimal prices based on cumulative depth
+//!
+//! ### Functional Iterators
+//!
+//! Memory-efficient, composable iterators for order book analysis:
+//!
+//! - **Cumulative Depth Iteration**: `levels_with_cumulative_depth()` - Lazy iteration with running depth totals
+//! - **Depth-Limited Iteration**: `levels_until_depth()` - Auto-stop when target depth is reached
+//! - **Range-Based Iteration**: `levels_in_range()` - Filter levels by price range
+//! - **Predicate Search**: `find_level()` - Find first level matching custom conditions
+//!
+//! **Benefits:**
+//! - Zero allocation - O(1) memory vs O(N) for vectors
+//! - Lazy evaluation - compute only what's needed
+//! - Composable - works with standard iterator combinators (`.map()`, `.filter()`, `.take()`)
+//! - Short-circuit - stops early when conditions are met
+//!
+//! ### Multi-Book Management
+//!
+//! Centralized trade event routing and multi-book orchestration:
+//!
+//! - **BookManager**: Manage multiple order books with unified trade listener
+//! - **Standard & Tokio Support**: Synchronous and async variants
+//! - **Event Routing**: Centralized trade notifications across all books
+//!
 //! # Performance Analysis of the OrderBook System
 //!
 //! This analyzes the performance of the OrderBook system based on tests conducted on an Apple M4 Max processor. The data comes from a High-Frequency Trading (HFT) simulation and price level distribution performance tests.
@@ -156,6 +201,7 @@ pub mod orderbook;
 pub mod prelude;
 mod utils;
 
+pub use orderbook::iterators::LevelInfo;
 pub use orderbook::manager::{BookManager, BookManagerStd, BookManagerTokio};
 pub use orderbook::market_impact::{MarketImpact, OrderSimulation};
 pub use orderbook::trade::{TradeListener, TradeResult};

--- a/src/orderbook/iterators.rs
+++ b/src/orderbook/iterators.rs
@@ -1,0 +1,205 @@
+//! Functional-style iterators for order book analysis
+//!
+//! This module provides efficient, lazy iterators for analyzing order book depth
+//! and structure without unnecessary allocations. All iterators support standard
+//! iterator combinators and can short-circuit early.
+
+use crossbeam_skiplist::SkipMap;
+use pricelevel::{PriceLevel, Side};
+use std::sync::Arc;
+
+/// Information about a price level including price, quantity, and cumulative depth
+#[derive(Debug, Clone)]
+pub struct LevelInfo {
+    /// The price of this level (in price units)
+    pub price: u64,
+
+    /// Total quantity at this price level (in units)
+    pub quantity: u64,
+
+    /// Cumulative depth up to and including this level (in units)
+    pub cumulative_depth: u64,
+}
+
+/// Iterator over price levels with cumulative depth tracking
+///
+/// Iterates through price levels in price-priority order (best to worst),
+/// maintaining cumulative depth as it goes. This is useful for analyzing
+/// market depth distribution and finding liquidity thresholds.
+pub struct LevelsWithCumulativeDepth<'a> {
+    iter: Box<dyn Iterator<Item = crossbeam_skiplist::map::Entry<'a, u64, Arc<PriceLevel>>> + 'a>,
+    cumulative_depth: u64,
+}
+
+impl<'a> LevelsWithCumulativeDepth<'a> {
+    /// Creates a new iterator over levels with cumulative depth
+    ///
+    /// # Arguments
+    /// - `price_levels`: Reference to the SkipMap of price levels
+    /// - `side`: Side to iterate (Buy for bids, Sell for asks)
+    pub fn new(price_levels: &'a SkipMap<u64, Arc<PriceLevel>>, side: Side) -> Self {
+        let iter: Box<dyn Iterator<Item = _> + 'a> = match side {
+            Side::Buy => Box::new(price_levels.iter().rev()), // Highest to lowest
+            Side::Sell => Box::new(price_levels.iter()),      // Lowest to highest
+        };
+
+        Self {
+            iter,
+            cumulative_depth: 0,
+        }
+    }
+}
+
+impl<'a> Iterator for LevelsWithCumulativeDepth<'a> {
+    type Item = LevelInfo;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|entry| {
+            let price = *entry.key();
+            let quantity = entry.value().total_quantity();
+            self.cumulative_depth = self.cumulative_depth.saturating_add(quantity);
+
+            LevelInfo {
+                price,
+                quantity,
+                cumulative_depth: self.cumulative_depth,
+            }
+        })
+    }
+}
+
+/// Iterator over price levels until a target depth is reached
+///
+/// Stops automatically when the cumulative depth reaches or exceeds the target.
+/// Useful for analyzing how many levels are needed to fill a specific quantity.
+pub struct LevelsUntilDepth<'a> {
+    iter: Box<dyn Iterator<Item = crossbeam_skiplist::map::Entry<'a, u64, Arc<PriceLevel>>> + 'a>,
+    target_depth: u64,
+    cumulative_depth: u64,
+    finished: bool,
+}
+
+impl<'a> LevelsUntilDepth<'a> {
+    /// Creates a new iterator that stops at target depth
+    ///
+    /// # Arguments
+    /// - `price_levels`: Reference to the SkipMap of price levels
+    /// - `side`: Side to iterate (Buy for bids, Sell for asks)
+    /// - `target_depth`: Target cumulative depth (in units)
+    pub fn new(
+        price_levels: &'a SkipMap<u64, Arc<PriceLevel>>,
+        side: Side,
+        target_depth: u64,
+    ) -> Self {
+        let iter: Box<dyn Iterator<Item = _> + 'a> = match side {
+            Side::Buy => Box::new(price_levels.iter().rev()),
+            Side::Sell => Box::new(price_levels.iter()),
+        };
+
+        Self {
+            iter,
+            target_depth,
+            cumulative_depth: 0,
+            finished: false,
+        }
+    }
+}
+
+impl<'a> Iterator for LevelsUntilDepth<'a> {
+    type Item = LevelInfo;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.finished {
+            return None;
+        }
+
+        self.iter.next().map(|entry| {
+            let price = *entry.key();
+            let quantity = entry.value().total_quantity();
+            self.cumulative_depth = self.cumulative_depth.saturating_add(quantity);
+
+            let level_info = LevelInfo {
+                price,
+                quantity,
+                cumulative_depth: self.cumulative_depth,
+            };
+
+            // Check if we've reached target depth
+            if self.cumulative_depth >= self.target_depth {
+                self.finished = true;
+            }
+
+            level_info
+        })
+    }
+}
+
+/// Iterator over price levels within a specific price range
+///
+/// Only yields levels where the price falls within [min_price, max_price] inclusive.
+/// Useful for analyzing liquidity in specific price bands.
+pub struct LevelsInRange<'a> {
+    iter: Box<dyn Iterator<Item = crossbeam_skiplist::map::Entry<'a, u64, Arc<PriceLevel>>> + 'a>,
+    min_price: u64,
+    max_price: u64,
+    finished: bool,
+}
+
+impl<'a> LevelsInRange<'a> {
+    /// Creates a new iterator over levels in a price range
+    ///
+    /// # Arguments
+    /// - `price_levels`: Reference to the SkipMap of price levels
+    /// - `side`: Side to iterate (Buy for bids, Sell for asks)
+    /// - `min_price`: Minimum price (inclusive, in price units)
+    /// - `max_price`: Maximum price (inclusive, in price units)
+    pub fn new(
+        price_levels: &'a SkipMap<u64, Arc<PriceLevel>>,
+        side: Side,
+        min_price: u64,
+        max_price: u64,
+    ) -> Self {
+        let iter: Box<dyn Iterator<Item = _> + 'a> = match side {
+            Side::Buy => Box::new(price_levels.iter().rev()),
+            Side::Sell => Box::new(price_levels.iter()),
+        };
+
+        Self {
+            iter,
+            min_price,
+            max_price,
+            finished: false,
+        }
+    }
+}
+
+impl<'a> Iterator for LevelsInRange<'a> {
+    type Item = LevelInfo;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.finished {
+            return None;
+        }
+
+        for entry in self.iter.by_ref() {
+            let price = *entry.key();
+
+            // Check if price is within range
+            if price >= self.min_price && price <= self.max_price {
+                let quantity = entry.value().total_quantity();
+
+                return Some(LevelInfo {
+                    price,
+                    quantity,
+                    cumulative_depth: 0, // Not tracked in range iterator
+                });
+            }
+
+            // For efficiency, we can stop early if we've passed the range
+            // This works because skipmap iteration is ordered
+        }
+
+        self.finished = true;
+        None
+    }
+}

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -2,6 +2,8 @@
 
 pub mod book;
 pub mod error;
+/// Functional-style iterators for order book analysis.
+pub mod iterators;
 /// Multi-book management with centralized trade event routing.
 pub mod manager;
 /// Market impact simulation and liquidity analysis.
@@ -21,6 +23,7 @@ pub mod trade;
 
 pub use book::OrderBook;
 pub use error::OrderBookError;
+pub use iterators::LevelInfo;
 pub use market_impact::{MarketImpact, OrderSimulation};
 pub use snapshot::{
     ORDERBOOK_SNAPSHOT_FORMAT_VERSION, OrderBookSnapshot, OrderBookSnapshotPackage,

--- a/src/orderbook/tests/iterator_tests.rs
+++ b/src/orderbook/tests/iterator_tests.rs
@@ -1,0 +1,342 @@
+//! Tests for functional-style order book iterators
+
+#[cfg(test)]
+mod tests {
+    use crate::OrderBook;
+    use pricelevel::{OrderId, Side, TimeInForce};
+
+    fn setup_test_book() -> OrderBook {
+        let book = OrderBook::new("TEST");
+
+        // Add buy orders at different prices
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 95, 15, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 90, 20, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 85, 25, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 80, 30, Side::Buy, TimeInForce::Gtc, None);
+
+        // Add sell orders at different prices
+        let _ = book.add_limit_order(OrderId::new(), 105, 12, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 110, 18, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 115, 24, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 120, 30, Side::Sell, TimeInForce::Gtc, None);
+
+        book
+    }
+
+    #[test]
+    fn test_levels_with_cumulative_depth_buy() {
+        let book = setup_test_book();
+
+        let levels: Vec<_> = book.levels_with_cumulative_depth(Side::Buy).collect();
+
+        assert_eq!(levels.len(), 5);
+
+        // First level (best bid)
+        assert_eq!(levels[0].price, 100);
+        assert_eq!(levels[0].quantity, 10);
+        assert_eq!(levels[0].cumulative_depth, 10);
+
+        // Second level
+        assert_eq!(levels[1].price, 95);
+        assert_eq!(levels[1].quantity, 15);
+        assert_eq!(levels[1].cumulative_depth, 25);
+
+        // Third level
+        assert_eq!(levels[2].price, 90);
+        assert_eq!(levels[2].quantity, 20);
+        assert_eq!(levels[2].cumulative_depth, 45);
+    }
+
+    #[test]
+    fn test_levels_with_cumulative_depth_sell() {
+        let book = setup_test_book();
+
+        let levels: Vec<_> = book.levels_with_cumulative_depth(Side::Sell).collect();
+
+        assert_eq!(levels.len(), 4);
+
+        // First level (best ask)
+        assert_eq!(levels[0].price, 105);
+        assert_eq!(levels[0].quantity, 12);
+        assert_eq!(levels[0].cumulative_depth, 12);
+
+        // Second level
+        assert_eq!(levels[1].price, 110);
+        assert_eq!(levels[1].quantity, 18);
+        assert_eq!(levels[1].cumulative_depth, 30);
+    }
+
+    #[test]
+    fn test_levels_with_cumulative_depth_take() {
+        let book = setup_test_book();
+
+        // Take only first 3 levels
+        let levels: Vec<_> = book
+            .levels_with_cumulative_depth(Side::Buy)
+            .take(3)
+            .collect();
+
+        assert_eq!(levels.len(), 3);
+        assert_eq!(levels[2].price, 90);
+    }
+
+    #[test]
+    fn test_levels_with_cumulative_depth_empty_book() {
+        let book: OrderBook = OrderBook::new("TEST");
+
+        let levels: Vec<_> = book.levels_with_cumulative_depth(Side::Buy).collect();
+
+        assert_eq!(levels.len(), 0);
+    }
+
+    #[test]
+    fn test_levels_until_depth_exact() {
+        let book = setup_test_book();
+
+        // Target depth of 25 should give us 2 levels (10 + 15)
+        let levels: Vec<_> = book.levels_until_depth(25, Side::Buy).collect();
+
+        assert_eq!(levels.len(), 2);
+        assert_eq!(levels[0].price, 100);
+        assert_eq!(levels[1].price, 95);
+        assert_eq!(levels[1].cumulative_depth, 25);
+    }
+
+    #[test]
+    fn test_levels_until_depth_partial() {
+        let book = setup_test_book();
+
+        // Target depth of 30 should give us 3 levels (10 + 15 + 20 = 45)
+        let levels: Vec<_> = book.levels_until_depth(30, Side::Buy).collect();
+
+        assert_eq!(levels.len(), 3);
+        assert_eq!(levels[2].cumulative_depth, 45);
+    }
+
+    #[test]
+    fn test_levels_until_depth_exceeds_available() {
+        let book = setup_test_book();
+
+        // Target depth of 1000 should give us all levels
+        let levels: Vec<_> = book.levels_until_depth(1000, Side::Buy).collect();
+
+        assert_eq!(levels.len(), 5);
+    }
+
+    #[test]
+    fn test_levels_until_depth_zero() {
+        let book = setup_test_book();
+
+        // Zero target should still return first level if it has any quantity
+        let levels: Vec<_> = book.levels_until_depth(0, Side::Buy).collect();
+
+        assert_eq!(levels.len(), 1);
+    }
+
+    #[test]
+    fn test_levels_in_range_basic() {
+        let book = setup_test_book();
+
+        // Range 85-95 should include 3 levels
+        let levels: Vec<_> = book.levels_in_range(85, 95, Side::Buy).collect();
+
+        assert_eq!(levels.len(), 3);
+        assert_eq!(levels[0].price, 95);
+        assert_eq!(levels[1].price, 90);
+        assert_eq!(levels[2].price, 85);
+    }
+
+    #[test]
+    fn test_levels_in_range_single() {
+        let book = setup_test_book();
+
+        // Exact match for one level
+        let levels: Vec<_> = book.levels_in_range(100, 100, Side::Buy).collect();
+
+        assert_eq!(levels.len(), 1);
+        assert_eq!(levels[0].price, 100);
+    }
+
+    #[test]
+    fn test_levels_in_range_no_match() {
+        let book = setup_test_book();
+
+        // Range with no levels
+        let levels: Vec<_> = book.levels_in_range(101, 104, Side::Buy).collect();
+
+        assert_eq!(levels.len(), 0);
+    }
+
+    #[test]
+    fn test_levels_in_range_partial() {
+        let book = setup_test_book();
+
+        // Range that partially overlaps
+        let levels: Vec<_> = book.levels_in_range(92, 102, Side::Buy).collect();
+
+        assert_eq!(levels.len(), 2); // 100 and 95
+        assert_eq!(levels[0].price, 100);
+        assert_eq!(levels[1].price, 95);
+    }
+
+    #[test]
+    fn test_find_level_by_quantity() {
+        let book = setup_test_book();
+
+        // Find first level with quantity > 15
+        let level = book.find_level(Side::Buy, |info| info.quantity > 15);
+
+        assert!(level.is_some());
+        let level = level.unwrap();
+        assert_eq!(level.price, 90); // First level with 20 units
+    }
+
+    #[test]
+    fn test_find_level_by_cumulative_depth() {
+        let book = setup_test_book();
+
+        // Find first level where cumulative depth exceeds 30
+        let level = book.find_level(Side::Buy, |info| info.cumulative_depth > 30);
+
+        assert!(level.is_some());
+        let level = level.unwrap();
+        assert_eq!(level.price, 90);
+        assert_eq!(level.cumulative_depth, 45);
+    }
+
+    #[test]
+    fn test_find_level_not_found() {
+        let book = setup_test_book();
+
+        // Find level with impossible condition
+        let level = book.find_level(Side::Buy, |info| info.quantity > 1000);
+
+        assert!(level.is_none());
+    }
+
+    #[test]
+    fn test_find_level_empty_book() {
+        let book: OrderBook = OrderBook::new("TEST");
+
+        let level = book.find_level(Side::Buy, |_| true);
+
+        assert!(level.is_none());
+    }
+
+    #[test]
+    fn test_iterator_composition() {
+        let book = setup_test_book();
+
+        // Complex functional pipeline
+        let total_qty: u64 = book
+            .levels_with_cumulative_depth(Side::Buy)
+            .take(3) // Only first 3 levels
+            .filter(|level| level.quantity >= 15) // Only levels with 15+ units
+            .map(|level| level.quantity)
+            .sum();
+
+        // Should sum 15 (second level) + 20 (third level) = 35
+        assert_eq!(total_qty, 35);
+    }
+
+    #[test]
+    fn test_iterator_short_circuit() {
+        let book = setup_test_book();
+
+        // Find first level and stop
+        let first = book.levels_with_cumulative_depth(Side::Buy).next();
+
+        assert!(first.is_some());
+        assert_eq!(first.unwrap().price, 100);
+    }
+
+    #[test]
+    fn test_levels_in_range_map_sum() {
+        let book = setup_test_book();
+
+        // Calculate total quantity in range
+        let total: u64 = book
+            .levels_in_range(85, 95, Side::Buy)
+            .map(|level| level.quantity)
+            .sum();
+
+        // Should sum 25 + 20 + 15 = 60
+        assert_eq!(total, 60);
+    }
+
+    #[test]
+    fn test_levels_until_depth_with_filter() {
+        let book = setup_test_book();
+
+        // Get levels until depth 50, but only those with even prices
+        let levels: Vec<_> = book
+            .levels_until_depth(50, Side::Buy)
+            .filter(|level| level.price % 2 == 0)
+            .collect();
+
+        // Should include 100, 90 (even prices reached before cumulative depth of 50)
+        // Cumulative: 100(10), 95(25), 90(45), 85(70) - stops at 85
+        // After filter: 100, 90
+        assert_eq!(levels.len(), 2);
+        assert_eq!(levels[0].price, 100);
+        assert_eq!(levels[1].price, 90);
+    }
+
+    #[test]
+    fn test_functional_style_analysis() {
+        let book = setup_test_book();
+
+        // Real-world scenario: Find average order size in top 3 levels
+        let levels: Vec<_> = book
+            .levels_with_cumulative_depth(Side::Buy)
+            .take(3)
+            .collect();
+
+        let total_qty: u64 = levels.iter().map(|l| l.quantity).sum();
+        let avg_size = total_qty as f64 / levels.len() as f64;
+
+        // (10 + 15 + 20) / 3 = 15.0
+        assert!((avg_size - 15.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_find_depth_threshold() {
+        let book = setup_test_book();
+
+        // Find price level where we have at least 40 units cumulative
+        let level = book.find_level(Side::Buy, |info| info.cumulative_depth >= 40);
+
+        assert!(level.is_some());
+        let level = level.unwrap();
+        assert_eq!(level.price, 90);
+        assert_eq!(level.cumulative_depth, 45);
+    }
+
+    #[test]
+    fn test_sell_side_iterators() {
+        let book = setup_test_book();
+
+        // Test sell side with levels_until_depth
+        let levels: Vec<_> = book.levels_until_depth(30, Side::Sell).collect();
+
+        // Should get 105 (12) + 110 (18) = 30 cumulative
+        assert_eq!(levels.len(), 2);
+        assert_eq!(levels[0].price, 105);
+        assert_eq!(levels[1].price, 110);
+        assert_eq!(levels[1].cumulative_depth, 30);
+    }
+
+    #[test]
+    fn test_count_levels() {
+        let book = setup_test_book();
+
+        // Count levels with quantity > 20
+        let count = book
+            .levels_with_cumulative_depth(Side::Buy)
+            .filter(|level| level.quantity > 20)
+            .count();
+
+        assert_eq!(count, 2); // 25 and 30
+    }
+}

--- a/src/orderbook/tests/mod.rs
+++ b/src/orderbook/tests/mod.rs
@@ -1,6 +1,7 @@
 mod book;
 mod depth_analysis;
 mod error;
+mod iterator_tests;
 mod market_impact_tests;
 mod market_metrics;
 mod matching;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -21,6 +21,9 @@ pub use crate::orderbook::OrderBook;
 pub use crate::orderbook::OrderBookError;
 pub use crate::orderbook::manager::{BookManager, BookManagerStd, BookManagerTokio};
 
+// Iterator types
+pub use crate::orderbook::iterators::LevelInfo;
+
 // Market impact and simulation types
 pub use crate::orderbook::market_impact::{MarketImpact, OrderSimulation};
 


### PR DESCRIPTION
…and examples

- Introduce `levels_with_cumulative_depth`, `levels_until_depth`, `levels_in_range`, and `find_level` methods for efficient order book depth analysis.
- Create `iterators.rs` module to encapsulate functional-style iterator implementations.
- Add `iterator_tests.rs` for comprehensive coverage of new iterators.
- Update `README.md` with new example `functional_iterators.rs` and feature documentation.
- Enhance `OrderBook` struct with methods utilizing new iterator types.

#22