### PR TITLE
Add aggregate statistics module for OrderBook analysis, tests, docs, …

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,22 @@ Centralized trade event routing and multi-book orchestration:
 - **Standard & Tokio Support**: Synchronous and async variants
 - **Event Routing**: Centralized trade notifications across all books
 
+#### Aggregate Statistics
+
+Comprehensive statistical analysis for market condition detection:
+
+- **Depth Statistics**: `depth_statistics()` - Volume, average sizes, weighted prices, std dev
+- **Market Pressure**: `buy_sell_pressure()` - Total volume on each side
+- **Liquidity Health**: `is_thin_book()` - Detect insufficient liquidity
+- **Distribution Analysis**: `depth_distribution()` - Histogram of liquidity concentration
+- **Imbalance Detection**: `order_book_imbalance()` - Buy/sell pressure ratio (-1.0 to 1.0)
+
+**Use cases:**
+- Market condition detection and trend identification
+- Risk management and liquidity monitoring
+- Strategy adaptation based on real-time conditions
+- Trading decision support and analytics
+
 ## Performance Analysis of the OrderBook System
 
 This analyzes the performance of the OrderBook system based on tests conducted on an Apple M4 Max processor. The data comes from a High-Frequency Trading (HFT) simulation and price level distribution performance tests.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # OrderBook-rs Examples
 
-This directory contains **17 comprehensive examples** demonstrating various features and use cases of the OrderBook-rs library. Each example is designed to showcase specific functionality and best practices for different use cases from beginner tutorials to advanced performance testing.
+This directory contains **18 comprehensive examples** demonstrating various features and use cases of the OrderBook-rs library. Each example is designed to showcase specific functionality and best practices for different use cases from beginner tutorials to advanced performance testing.
 
 ## 📑 Quick Index
 
@@ -13,7 +13,8 @@ This directory contains **17 comprehensive examples** demonstrating various feat
 | `market_metrics` | Market metrics (VWAP, spread, imbalance) | 💡 Advanced |
 | `market_impact_simulation` | Pre-trade impact & risk analysis | 💡 Advanced |
 | `intelligent_order_placement` | Smart order placement for market makers | 💡 Advanced |
-| `functional_iterators` | ⭐ **New!** Functional-style depth analysis with iterators | 💡 Advanced |
+| `functional_iterators` | Functional-style depth analysis with iterators | 💡 Advanced |
+| `aggregate_statistics` | ⭐ **New!** Market condition detection & analytics | 💡 Advanced |
 | `trade_listener_demo` | Real-time trade notifications | 💡 Advanced |
 | `trade_listener_channels` | Multi-book trade routing | 💡 Advanced |
 | `orderbook_snapshot_restore` | State persistence & recovery | 💡 Advanced |
@@ -240,6 +241,61 @@ cargo run --bin functional_iterators
 - Zero-allocation data processing
 - Building efficient analysis pipelines
 - Short-circuit optimization strategies
+
+---
+
+### 📊 Aggregate Statistics (`aggregate_statistics.rs`)
+
+⭐ **New!** Comprehensive statistical analysis for market condition detection and decision support.
+
+```bash
+cargo run --bin aggregate_statistics
+```
+
+**Features demonstrated:**
+- `depth_statistics()` - Comprehensive depth metrics (volume, avg sizes, weighted prices, std dev)
+- `buy_sell_pressure()` - Market pressure indicators
+- `is_thin_book()` - Liquidity health checks
+- `depth_distribution()` - Histogram of liquidity concentration
+- `order_book_imbalance()` - Buy/sell pressure ratio
+
+**Key concepts:**
+- **Depth Statistics**: Volume distribution, size variability, weighted averages
+- **Market Pressure**: Total volume on each side as sentiment indicators
+- **Liquidity Health**: Detecting thin books and insufficient depth
+- **Distribution Analysis**: Visualizing liquidity concentration across price ranges
+- **Imbalance Detection**: Identifying directional bias in the book
+
+**Use cases:**
+- **Market Condition Detection**: Identify trends, pressure, and sentiment
+- **Risk Management**: Monitor liquidity health and volatility
+- **Strategy Adaptation**: Adjust parameters based on real-time conditions
+- **Decision Support**: Data-driven trading decisions
+- **Analytics & Reporting**: Generate market quality metrics
+
+**Practical applications:**
+- Determine safe order sizes based on depth statistics
+- Assess market conditions before trading
+- Detect liquidity risks and thin book warnings
+- Analyze distribution of liquidity across price bands
+- Identify directional opportunities from imbalance
+- Risk assessment using level size variability
+
+**Metrics provided:**
+- **Volume metrics**: Total, average, min, max per level
+- **Price metrics**: Weighted average prices
+- **Variability metrics**: Standard deviation of level sizes
+- **Pressure metrics**: Buy vs sell volume comparison
+- **Distribution metrics**: Liquidity histogram by price bins
+- **Imbalance metrics**: Directional bias (-1.0 to 1.0)
+
+**What you'll learn:**
+- Statistical analysis of order book depth
+- Market condition detection techniques
+- Liquidity risk assessment methods
+- Distribution analysis for concentration detection
+- Practical trading decision workflows
+- Risk management using quantitative metrics
 
 ---
 
@@ -619,16 +675,17 @@ cargo run --bin prelude_demo
 ---
 
 ### 💡 For Advanced Features
-1. **`functional_iterators.rs`** - ⭐ **New!** Functional-style depth analysis with iterators
-2. **`intelligent_order_placement.rs`** - Smart order placement for market makers
-3. **`market_impact_simulation.rs`** - Pre-trade impact & risk analysis
-4. **`market_metrics.rs`** - Market metrics (VWAP, spread, imbalance)
-5. **`depth_analysis.rs`** - Market depth and liquidity analysis
-6. **`trade_listener_demo.rs`** - Real-time event notifications
-7. **`trade_listener_channels.rs`** - Multi-book trade routing
-8. **`orderbook_snapshot_restore.rs`** - State persistence and recovery
+1. **`aggregate_statistics.rs`** - ⭐ **New!** Market condition detection & analytics
+2. **`functional_iterators.rs`** - Functional-style depth analysis with iterators
+3. **`intelligent_order_placement.rs`** - Smart order placement for market makers
+4. **`market_impact_simulation.rs`** - Pre-trade impact & risk analysis
+5. **`market_metrics.rs`** - Market metrics (VWAP, spread, imbalance)
+6. **`depth_analysis.rs`** - Market depth and liquidity analysis
+7. **`trade_listener_demo.rs`** - Real-time event notifications
+8. **`trade_listener_channels.rs`** - Multi-book trade routing
+9. **`orderbook_snapshot_restore.rs`** - State persistence and recovery
 
-**Use these to:** Build market-making bots, optimize order placement, implement advanced trading strategies, assess pre-trade risk, manage multiple order books, generate trading signals, perform efficient depth analysis.
+**Use these to:** Build market-making bots, optimize order placement, implement advanced trading strategies, assess pre-trade risk, manage multiple order books, generate trading signals, perform efficient depth analysis, detect market conditions.
 
 ---
 
@@ -708,12 +765,13 @@ For detailed API documentation, see:
 2. Study `basic_orderbook` for comprehensive coverage
 3. Run `market_trades_demo` to see trades in action
 4. Learn `market_metrics` for trading signals and risk management
-5. Explore `functional_iterators` for efficient depth analysis
-6. Study `market_impact_simulation` for pre-trade risk assessment
-7. Review `intelligent_order_placement` for market making strategies
-8. Analyze `depth_analysis` for advanced liquidity analysis
-9. Try `multi_threaded_orderbook` to understand concurrency
-10. Dive into `orderbook_hft_simulation` for realistic scenarios
+5. Explore `aggregate_statistics` for market condition detection
+6. Review `functional_iterators` for efficient depth analysis
+7. Study `market_impact_simulation` for pre-trade risk assessment
+8. Analyze `intelligent_order_placement` for market making strategies
+9. Review `depth_analysis` for advanced liquidity analysis
+10. Try `multi_threaded_orderbook` to understand concurrency
+11. Dive into `orderbook_hft_simulation` for realistic scenarios
 
 **Performance testing:**
 - Always use `--release` flag for accurate benchmarks

--- a/examples/src/bin/aggregate_statistics.rs
+++ b/examples/src/bin/aggregate_statistics.rs
@@ -1,0 +1,465 @@
+// examples/src/bin/aggregate_statistics.rs
+//
+// This example demonstrates aggregate statistics for order book analysis.
+// These statistics help quantitative traders detect market conditions,
+// identify trends and pressure, and make informed trading decisions.
+//
+// Functions demonstrated:
+// - `depth_statistics()`: Comprehensive depth metrics (volume, sizes, std dev)
+// - `buy_sell_pressure()`: Market pressure indicators
+// - `is_thin_book()`: Liquidity health check
+// - `depth_distribution()`: Histogram of liquidity distribution
+// - `order_book_imbalance()`: Buy/sell imbalance (-1.0 to 1.0)
+//
+// Run this example with:
+//   cargo run --bin aggregate_statistics
+//   (from the examples directory)
+
+use orderbook_rs::OrderBook;
+use pricelevel::{OrderId, Side, TimeInForce, setup_logger};
+use tracing::info;
+
+fn main() {
+    // Set up logging
+    setup_logger();
+    info!("Aggregate Statistics Example");
+
+    // Create order book with realistic depth
+    let book = create_orderbook_with_depth("BTC/USD");
+
+    // Display current state
+    display_book_state(&book);
+
+    // Demonstrate depth statistics
+    demo_depth_statistics(&book);
+
+    // Demonstrate market pressure analysis
+    demo_market_pressure(&book);
+
+    // Demonstrate liquidity checks
+    demo_liquidity_health(&book);
+
+    // Demonstrate distribution analysis
+    demo_depth_distribution(&book);
+
+    // Demonstrate imbalance detection
+    demo_imbalance_detection(&book);
+
+    // Practical trading scenarios
+    demo_trading_scenarios(&book);
+}
+
+fn create_orderbook_with_depth(symbol: &str) -> OrderBook {
+    info!("\n=== Creating OrderBook ===");
+    info!("Symbol: {}", symbol);
+
+    let book = OrderBook::new(symbol);
+
+    // Add buy orders with varying sizes (simulate realistic market)
+    info!("\nAdding buy orders (bids):");
+    let bid_orders = vec![
+        (50000, 10), // Best bid
+        (49980, 25),
+        (49950, 40),
+        (49920, 30),
+        (49900, 50),
+        (49880, 35),
+        (49850, 20),
+        (49800, 15),
+        (49750, 45),
+        (49700, 60),
+    ];
+
+    for (price, quantity) in bid_orders {
+        let _ = book.add_limit_order(
+            OrderId::new(),
+            price,
+            quantity,
+            Side::Buy,
+            TimeInForce::Gtc,
+            None,
+        );
+        info!("  {} @ {}", quantity, price);
+    }
+
+    // Add sell orders with varying sizes
+    info!("\nAdding sell orders (asks):");
+    let ask_orders = vec![
+        (50050, 12), // Best ask
+        (50100, 22),
+        (50150, 35),
+        (50200, 28),
+        (50250, 45),
+        (50300, 38),
+        (50350, 25),
+        (50400, 18),
+        (50450, 40),
+        (50500, 55),
+    ];
+
+    for (price, quantity) in ask_orders {
+        let _ = book.add_limit_order(
+            OrderId::new(),
+            price,
+            quantity,
+            Side::Sell,
+            TimeInForce::Gtc,
+            None,
+        );
+        info!("  {} @ {}", quantity, price);
+    }
+
+    book
+}
+
+fn display_book_state(book: &OrderBook) {
+    info!("\n=== OrderBook State ===");
+
+    if let (Some(best_bid), Some(best_ask)) = (book.best_bid(), book.best_ask()) {
+        info!("Best Bid: {}", best_bid);
+        info!("Best Ask: {}", best_ask);
+        info!("Spread: {}", best_ask - best_bid);
+        info!("Mid Price: {}", (best_bid + best_ask) / 2);
+    }
+
+    let (buy_volume, sell_volume) = book.buy_sell_pressure();
+    info!("Total Buy Volume: {}", buy_volume);
+    info!("Total Sell Volume: {}", sell_volume);
+}
+
+fn demo_depth_statistics(book: &OrderBook) {
+    info!("\n=== Depth Statistics ===");
+    info!("Analyzing top 5 levels on each side");
+
+    // Analyze bid side
+    info!("\n📊 Bid Side Statistics:");
+    let bid_stats = book.depth_statistics(Side::Buy, 5);
+
+    info!("  Total Volume: {}", bid_stats.total_volume);
+    info!("  Levels Analyzed: {}", bid_stats.levels_count);
+    info!("  Average Level Size: {:.2}", bid_stats.avg_level_size);
+    info!("  Weighted Avg Price: {:.2}", bid_stats.weighted_avg_price);
+    info!("  Min Level Size: {}", bid_stats.min_level_size);
+    info!("  Max Level Size: {}", bid_stats.max_level_size);
+    info!("  Std Dev of Sizes: {:.2}", bid_stats.std_dev_level_size);
+
+    // Analyze ask side
+    info!("\n📊 Ask Side Statistics:");
+    let ask_stats = book.depth_statistics(Side::Sell, 5);
+
+    info!("  Total Volume: {}", ask_stats.total_volume);
+    info!("  Levels Analyzed: {}", ask_stats.levels_count);
+    info!("  Average Level Size: {:.2}", ask_stats.avg_level_size);
+    info!("  Weighted Avg Price: {:.2}", ask_stats.weighted_avg_price);
+    info!("  Min Level Size: {}", ask_stats.min_level_size);
+    info!("  Max Level Size: {}", ask_stats.max_level_size);
+    info!("  Std Dev of Sizes: {:.2}", ask_stats.std_dev_level_size);
+
+    // Interpret statistics
+    info!("\n💡 Interpretation:");
+
+    if bid_stats.std_dev_level_size > bid_stats.avg_level_size * 0.5 {
+        info!("  ⚠️  High variability in bid sizes - uneven liquidity");
+    } else {
+        info!("  ✓ Consistent bid sizes - uniform liquidity");
+    }
+
+    let size_ratio = bid_stats.max_level_size as f64 / bid_stats.min_level_size as f64;
+    if size_ratio > 3.0 {
+        info!(
+            "  ⚠️  Large size ratio ({:.1}x) - some levels dominate",
+            size_ratio
+        );
+    } else {
+        info!("  ✓ Balanced level sizes (ratio: {:.1}x)", size_ratio);
+    }
+}
+
+fn demo_market_pressure(book: &OrderBook) {
+    info!("\n=== Market Pressure Analysis ===");
+
+    let (buy_pressure, sell_pressure) = book.buy_sell_pressure();
+
+    info!("Buy Pressure: {} units", buy_pressure);
+    info!("Sell Pressure: {} units", sell_pressure);
+
+    let total_pressure = buy_pressure + sell_pressure;
+    let buy_pct = (buy_pressure as f64 / total_pressure as f64) * 100.0;
+    let sell_pct = (sell_pressure as f64 / total_pressure as f64) * 100.0;
+
+    info!("\nPressure Distribution:");
+    info!("  Buy:  {:.1}%", buy_pct);
+    info!("  Sell: {:.1}%", sell_pct);
+
+    info!("\n💡 Market Sentiment:");
+    let difference = buy_pressure as i64 - sell_pressure as i64;
+    let diff_pct = (difference.abs() as f64 / total_pressure as f64) * 100.0;
+
+    if diff_pct < 10.0 {
+        info!("  → Balanced market ({:.1}% difference)", diff_pct);
+        info!("  → Expect stable prices");
+    } else if buy_pressure > sell_pressure {
+        info!("  → Buy-heavy market ({:.1}% more buy volume)", diff_pct);
+        info!("  → Potential upward pressure");
+    } else {
+        info!("  → Sell-heavy market ({:.1}% more sell volume)", diff_pct);
+        info!("  → Potential downward pressure");
+    }
+}
+
+fn demo_liquidity_health(book: &OrderBook) {
+    info!("\n=== Liquidity Health Check ===");
+
+    // Check different thresholds
+    let thresholds = vec![
+        (50, "Minimal"),
+        (100, "Low"),
+        (200, "Moderate"),
+        (500, "High"),
+    ];
+
+    info!("\nLiquidity checks (top 5 levels):");
+    for (threshold, label) in thresholds {
+        let is_thin = book.is_thin_book(threshold, 5);
+        let status = if is_thin { "❌ THIN" } else { "✓ OK" };
+        info!("  {} threshold ({} units): {}", label, threshold, status);
+    }
+
+    // Detailed analysis
+    let bid_stats = book.depth_statistics(Side::Buy, 5);
+    let ask_stats = book.depth_statistics(Side::Sell, 5);
+
+    info!("\n💡 Liquidity Assessment:");
+
+    if bid_stats.total_volume < 100 || ask_stats.total_volume < 100 {
+        info!("  ⚠️  WARNING: Thin order book detected!");
+        info!("  → High slippage risk for large orders");
+        info!("  → Consider splitting orders or waiting for better depth");
+    } else if bid_stats.total_volume < 200 || ask_stats.total_volume < 200 {
+        info!("  ⚠️  CAUTION: Moderate liquidity");
+        info!("  → Use limit orders for better execution");
+        info!("  → Monitor slippage carefully");
+    } else {
+        info!("  ✓ GOOD: Sufficient liquidity");
+        info!("  → Market orders viable for reasonable sizes");
+        info!("  → Low slippage expected");
+    }
+
+    // Check balance
+    let imbalance = (bid_stats.total_volume as i64 - ask_stats.total_volume as i64).abs() as f64
+        / (bid_stats.total_volume + ask_stats.total_volume) as f64;
+
+    if imbalance > 0.3 {
+        info!("  ⚠️  Liquidity imbalance: {:.1}%", imbalance * 100.0);
+        if bid_stats.total_volume > ask_stats.total_volume {
+            info!("  → More liquidity on bid side");
+        } else {
+            info!("  → More liquidity on ask side");
+        }
+    }
+}
+
+fn demo_depth_distribution(book: &OrderBook) {
+    info!("\n=== Depth Distribution Analysis ===");
+
+    // Analyze bid distribution
+    info!("\n📊 Bid Side Distribution (5 bins):");
+    let bid_distribution = book.depth_distribution(Side::Buy, 5);
+
+    for (i, bin) in bid_distribution.iter().enumerate() {
+        let bar_len = (bin.volume / 5).min(20) as usize;
+        let bar = "█".repeat(bar_len);
+        info!(
+            "  Bin {}: ${}-{}: {} units [{}] ({} levels)",
+            i + 1,
+            bin.min_price,
+            bin.max_price,
+            bin.volume,
+            bar,
+            bin.level_count
+        );
+    }
+
+    // Analyze ask distribution
+    info!("\n📊 Ask Side Distribution (5 bins):");
+    let ask_distribution = book.depth_distribution(Side::Sell, 5);
+
+    for (i, bin) in ask_distribution.iter().enumerate() {
+        let bar_len = (bin.volume / 5).min(20) as usize;
+        let bar = "█".repeat(bar_len);
+        info!(
+            "  Bin {}: ${}-{}: {} units [{}] ({} levels)",
+            i + 1,
+            bin.min_price,
+            bin.max_price,
+            bin.volume,
+            bar,
+            bin.level_count
+        );
+    }
+
+    // Analyze concentration
+    info!("\n💡 Distribution Analysis:");
+
+    let bid_total: u64 = bid_distribution.iter().map(|b| b.volume).sum();
+    if let Some(max_bin) = bid_distribution.iter().max_by_key(|b| b.volume) {
+        let concentration = (max_bin.volume as f64 / bid_total as f64) * 100.0;
+        info!(
+            "  Bid concentration: {:.1}% in bin ${}-{}",
+            concentration, max_bin.min_price, max_bin.max_price
+        );
+
+        if concentration > 40.0 {
+            info!("  ⚠️  High concentration - liquidity clustered");
+        } else {
+            info!("  ✓ Well-distributed liquidity");
+        }
+    }
+}
+
+fn demo_imbalance_detection(book: &OrderBook) {
+    info!("\n=== Order Book Imbalance Detection ===");
+
+    // Check imbalance at different depths
+    let depths = vec![3, 5, 10];
+
+    info!("\nImbalance at different depths:");
+    for depth in depths {
+        let imbalance = book.order_book_imbalance(depth);
+        let direction = if imbalance > 0.0 { "BUY" } else { "SELL" };
+        let strength = imbalance.abs();
+
+        let indicator = if strength > 0.5 {
+            "🔴 STRONG"
+        } else if strength > 0.2 {
+            "🟡 MODERATE"
+        } else {
+            "🟢 WEAK"
+        };
+
+        info!(
+            "  Top {} levels: {:.3} ({} {} pressure)",
+            depth, imbalance, indicator, direction
+        );
+    }
+
+    // Detailed analysis
+    let imbalance = book.order_book_imbalance(5);
+
+    info!("\n💡 Imbalance Interpretation:");
+    if imbalance.abs() < 0.1 {
+        info!("  → Balanced market");
+        info!("  → Expect range-bound trading");
+        info!("  → Good for market making");
+    } else if imbalance > 0.3 {
+        info!("  → Strong buy pressure detected");
+        info!("  → Potential bullish breakout");
+        info!("  → Consider buying or staying long");
+    } else if imbalance < -0.3 {
+        info!("  → Strong sell pressure detected");
+        info!("  → Potential bearish breakdown");
+        info!("  → Consider selling or staying short");
+    } else {
+        info!("  → Mild imbalance");
+        info!("  → Monitor for trend development");
+        info!("  → Wait for confirmation");
+    }
+}
+
+fn demo_trading_scenarios(book: &OrderBook) {
+    info!("\n=== Practical Trading Scenarios ===");
+
+    // Scenario 1: Order size decision
+    info!("\n📈 Scenario 1: Determining Safe Order Size");
+
+    let bid_stats = book.depth_statistics(Side::Buy, 5);
+    let ask_stats = book.depth_statistics(Side::Sell, 5);
+
+    let safe_buy_size = bid_stats.total_volume / 4; // 25% of depth
+    let safe_sell_size = ask_stats.total_volume / 4;
+
+    info!("  Available depth (top 5):");
+    info!("    Buy side:  {} units", bid_stats.total_volume);
+    info!("    Sell side: {} units", ask_stats.total_volume);
+    info!("  Recommended max size (25% rule):");
+    info!("    Buy orders:  {} units", safe_buy_size);
+    info!("    Sell orders: {} units", safe_sell_size);
+
+    // Scenario 2: Market condition assessment
+    info!("\n📊 Scenario 2: Market Condition Assessment");
+
+    let is_thin = book.is_thin_book(150, 5);
+    let imbalance = book.order_book_imbalance(5);
+    let (buy_pressure, sell_pressure) = book.buy_sell_pressure();
+
+    info!(
+        "  Liquidity: {}",
+        if is_thin {
+            "THIN ⚠️"
+        } else {
+            "ADEQUATE ✓"
+        }
+    );
+    info!(
+        "  Imbalance: {:.2} ({})",
+        imbalance,
+        if imbalance.abs() < 0.2 {
+            "BALANCED ✓"
+        } else {
+            "SKEWED ⚠️"
+        }
+    );
+    info!(
+        "  Pressure ratio: {:.2} (buy/sell)",
+        buy_pressure as f64 / sell_pressure as f64
+    );
+
+    info!("\n  Trading Recommendation:");
+    if is_thin {
+        info!("    → Use LIMIT ORDERS only");
+        info!("    → Split large orders");
+        info!("    → Monitor execution carefully");
+    } else if imbalance.abs() > 0.3 {
+        info!("    → Directional opportunity detected");
+        if imbalance > 0.0 {
+            info!("    → Consider BUYING (momentum trade)");
+        } else {
+            info!("    → Consider SELLING (momentum trade)");
+        }
+    } else {
+        info!("    → Market making opportunity");
+        info!("    → Place orders on both sides");
+        info!("    → Capture spread");
+    }
+
+    // Scenario 3: Risk assessment
+    info!("\n⚠️  Scenario 3: Risk Assessment");
+
+    let bid_variability = bid_stats.std_dev_level_size / bid_stats.avg_level_size;
+    let ask_variability = ask_stats.std_dev_level_size / ask_stats.avg_level_size;
+
+    info!("  Level size variability:");
+    info!("    Bid side: {:.2} (CV)", bid_variability);
+    info!("    Ask side: {:.2} (CV)", ask_variability);
+
+    if bid_variability > 0.5 || ask_variability > 0.5 {
+        info!("\n  🔴 HIGH RISK:");
+        info!("    → Uneven liquidity distribution");
+        info!("    → Potential for sudden price moves");
+        info!("    → Use wider stops");
+        info!("    → Reduce position size");
+    } else {
+        info!("\n  🟢 MODERATE RISK:");
+        info!("    → Consistent liquidity distribution");
+        info!("    → Normal market conditions");
+        info!("    → Standard risk management applies");
+    }
+
+    // Summary
+    info!("\n✨ Key Takeaways:");
+    info!("  1. Always check liquidity before trading");
+    info!("  2. Monitor imbalance for directional signals");
+    info!("  3. Adjust order size based on depth statistics");
+    info!("  4. Use distribution analysis for risk assessment");
+    info!("  5. Combine multiple indicators for better decisions");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,22 @@
 //! - **Standard & Tokio Support**: Synchronous and async variants
 //! - **Event Routing**: Centralized trade notifications across all books
 //!
+//! ### Aggregate Statistics
+//!
+//! Comprehensive statistical analysis for market condition detection:
+//!
+//! - **Depth Statistics**: `depth_statistics()` - Volume, average sizes, weighted prices, std dev
+//! - **Market Pressure**: `buy_sell_pressure()` - Total volume on each side
+//! - **Liquidity Health**: `is_thin_book()` - Detect insufficient liquidity
+//! - **Distribution Analysis**: `depth_distribution()` - Histogram of liquidity concentration
+//! - **Imbalance Detection**: `order_book_imbalance()` - Buy/sell pressure ratio (-1.0 to 1.0)
+//!
+//! **Use cases:**
+//! - Market condition detection and trend identification
+//! - Risk management and liquidity monitoring
+//! - Strategy adaptation based on real-time conditions
+//! - Trading decision support and analytics
+//!
 //! # Performance Analysis of the OrderBook System
 //!
 //! This analyzes the performance of the OrderBook system based on tests conducted on an Apple M4 Max processor. The data comes from a High-Frequency Trading (HFT) simulation and price level distribution performance tests.
@@ -204,6 +220,7 @@ mod utils;
 pub use orderbook::iterators::LevelInfo;
 pub use orderbook::manager::{BookManager, BookManagerStd, BookManagerTokio};
 pub use orderbook::market_impact::{MarketImpact, OrderSimulation};
+pub use orderbook::statistics::{DepthStats, DistributionBin};
 pub use orderbook::trade::{TradeListener, TradeResult};
 pub use orderbook::{OrderBook, OrderBookError, OrderBookSnapshot};
 pub use utils::current_time_millis;

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -9,6 +9,8 @@ pub mod manager;
 /// Market impact simulation and liquidity analysis.
 pub mod market_impact;
 pub mod matching;
+/// Aggregate statistics for order book analysis.
+pub mod statistics;
 
 mod cache;
 /// Contains the core logic for modifying the order book state, such as adding, canceling, or updating orders.
@@ -28,3 +30,4 @@ pub use market_impact::{MarketImpact, OrderSimulation};
 pub use snapshot::{
     ORDERBOOK_SNAPSHOT_FORMAT_VERSION, OrderBookSnapshot, OrderBookSnapshotPackage,
 };
+pub use statistics::{DepthStats, DistributionBin};

--- a/src/orderbook/statistics.rs
+++ b/src/orderbook/statistics.rs
@@ -1,0 +1,134 @@
+//! Aggregate statistics for order book analysis
+//!
+//! This module provides comprehensive statistical analysis of order book depth,
+//! helping quantitative traders detect market conditions, identify trends,
+//! and make informed trading decisions.
+
+use serde::{Deserialize, Serialize};
+
+/// Depth statistics for one side of the order book
+///
+/// Provides comprehensive metrics about liquidity distribution and depth
+/// characteristics. All quantities are in base units.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DepthStats {
+    /// Total volume across all analyzed levels (in units)
+    pub total_volume: u64,
+
+    /// Number of price levels analyzed
+    pub levels_count: usize,
+
+    /// Average size per level (in units)
+    pub avg_level_size: f64,
+
+    /// Volume-weighted average price (in price units)
+    pub weighted_avg_price: f64,
+
+    /// Smallest level size found (in units)
+    pub min_level_size: u64,
+
+    /// Largest level size found (in units)
+    pub max_level_size: u64,
+
+    /// Standard deviation of level sizes (in units)
+    pub std_dev_level_size: f64,
+}
+
+impl DepthStats {
+    /// Creates a new `DepthStats` with zero values
+    ///
+    /// Useful as a default when no levels exist.
+    #[must_use]
+    pub fn zero() -> Self {
+        Self {
+            total_volume: 0,
+            levels_count: 0,
+            avg_level_size: 0.0,
+            weighted_avg_price: 0.0,
+            min_level_size: 0,
+            max_level_size: 0,
+            std_dev_level_size: 0.0,
+        }
+    }
+
+    /// Returns true if statistics represent an empty order book side
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.levels_count == 0 || self.total_volume == 0
+    }
+}
+
+/// Distribution bin for depth distribution analysis
+///
+/// Represents a price range and the total volume within that range.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DistributionBin {
+    /// Minimum price of this bin (inclusive, in price units)
+    pub min_price: u64,
+
+    /// Maximum price of this bin (exclusive, in price units)
+    pub max_price: u64,
+
+    /// Total volume in this price range (in units)
+    pub volume: u64,
+
+    /// Number of price levels in this bin
+    pub level_count: usize,
+}
+
+impl DistributionBin {
+    /// Returns the midpoint price of this bin
+    #[must_use]
+    pub fn midpoint(&self) -> u64 {
+        (self.min_price + self.max_price) / 2
+    }
+
+    /// Returns the width of this bin in price units
+    #[must_use]
+    pub fn width(&self) -> u64 {
+        self.max_price.saturating_sub(self.min_price)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_depth_stats_zero() {
+        let stats = DepthStats::zero();
+
+        assert_eq!(stats.total_volume, 0);
+        assert_eq!(stats.levels_count, 0);
+        assert_eq!(stats.avg_level_size, 0.0);
+        assert!(stats.is_empty());
+    }
+
+    #[test]
+    fn test_depth_stats_not_empty() {
+        let stats = DepthStats {
+            total_volume: 100,
+            levels_count: 5,
+            avg_level_size: 20.0,
+            weighted_avg_price: 50000.0,
+            min_level_size: 10,
+            max_level_size: 30,
+            std_dev_level_size: 5.0,
+        };
+
+        assert!(!stats.is_empty());
+    }
+
+    #[test]
+    fn test_distribution_bin_midpoint() {
+        let bin = DistributionBin {
+            min_price: 100,
+            max_price: 200,
+            volume: 50,
+            level_count: 3,
+        };
+
+        assert_eq!(bin.midpoint(), 150);
+        assert_eq!(bin.width(), 100);
+    }
+}

--- a/src/orderbook/tests/mod.rs
+++ b/src/orderbook/tests/mod.rs
@@ -11,5 +11,6 @@ mod order;
 mod order_placement_tests;
 mod serialize_tests;
 mod snapshot;
+mod statistics_tests;
 mod time_in_force;
 mod uuid;

--- a/src/orderbook/tests/statistics_tests.rs
+++ b/src/orderbook/tests/statistics_tests.rs
@@ -1,0 +1,329 @@
+//! Tests for aggregate statistics and order book analysis
+
+#[cfg(test)]
+mod tests {
+    use crate::OrderBook;
+    use pricelevel::{OrderId, Side, TimeInForce};
+
+    fn setup_test_book() -> OrderBook<()> {
+        let book = OrderBook::<()>::new("TEST");
+
+        // Add buy orders with varying sizes
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 99, 20, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 98, 30, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 97, 40, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 96, 50, Side::Buy, TimeInForce::Gtc, None);
+
+        // Add sell orders with varying sizes
+        let _ = book.add_limit_order(OrderId::new(), 101, 15, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 102, 25, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 103, 35, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 104, 45, Side::Sell, TimeInForce::Gtc, None);
+
+        book
+    }
+
+    #[test]
+    fn test_depth_statistics_buy_basic() {
+        let book = setup_test_book();
+
+        let stats = book.depth_statistics(Side::Buy, 5);
+
+        assert_eq!(stats.total_volume, 150); // 10 + 20 + 30 + 40 + 50
+        assert_eq!(stats.levels_count, 5);
+        assert_eq!(stats.avg_level_size, 30.0);
+        assert_eq!(stats.min_level_size, 10);
+        assert_eq!(stats.max_level_size, 50);
+    }
+
+    #[test]
+    fn test_depth_statistics_sell_basic() {
+        let book = setup_test_book();
+
+        let stats = book.depth_statistics(Side::Sell, 4);
+
+        assert_eq!(stats.total_volume, 120); // 15 + 25 + 35 + 45
+        assert_eq!(stats.levels_count, 4);
+        assert_eq!(stats.avg_level_size, 30.0);
+        assert_eq!(stats.min_level_size, 15);
+        assert_eq!(stats.max_level_size, 45);
+    }
+
+    #[test]
+    fn test_depth_statistics_limited_levels() {
+        let book = setup_test_book();
+
+        let stats = book.depth_statistics(Side::Buy, 3);
+
+        assert_eq!(stats.total_volume, 60); // 10 + 20 + 30
+        assert_eq!(stats.levels_count, 3);
+        assert_eq!(stats.avg_level_size, 20.0);
+    }
+
+    #[test]
+    fn test_depth_statistics_all_levels() {
+        let book = setup_test_book();
+
+        let stats = book.depth_statistics(Side::Buy, 0);
+
+        assert_eq!(stats.total_volume, 150);
+        assert_eq!(stats.levels_count, 5);
+    }
+
+    #[test]
+    fn test_depth_statistics_empty_book() {
+        let book = OrderBook::<()>::new("TEST");
+
+        let stats = book.depth_statistics(Side::Buy, 10);
+
+        assert!(stats.is_empty());
+        assert_eq!(stats.total_volume, 0);
+        assert_eq!(stats.levels_count, 0);
+    }
+
+    #[test]
+    fn test_depth_statistics_weighted_avg_price() {
+        let book = setup_test_book();
+
+        let stats = book.depth_statistics(Side::Buy, 3);
+
+        // Weighted avg = (100*10 + 99*20 + 98*30) / (10 + 20 + 30)
+        // = (1000 + 1980 + 2940) / 60 = 5920 / 60 = 98.666...
+        assert!((stats.weighted_avg_price - 98.666).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_buy_sell_pressure() {
+        let book = setup_test_book();
+
+        let (buy_pressure, sell_pressure) = book.buy_sell_pressure();
+
+        assert_eq!(buy_pressure, 150); // 10 + 20 + 30 + 40 + 50
+        assert_eq!(sell_pressure, 120); // 15 + 25 + 35 + 45
+    }
+
+    #[test]
+    fn test_buy_sell_pressure_empty_book() {
+        let book = OrderBook::<()>::new("TEST");
+
+        let (buy_pressure, sell_pressure) = book.buy_sell_pressure();
+
+        assert_eq!(buy_pressure, 0);
+        assert_eq!(sell_pressure, 0);
+    }
+
+    #[test]
+    fn test_buy_sell_pressure_one_sided() {
+        let book = OrderBook::<()>::new("TEST");
+        let _ = book.add_limit_order(OrderId::new(), 100, 50, Side::Buy, TimeInForce::Gtc, None);
+
+        let (buy_pressure, sell_pressure) = book.buy_sell_pressure();
+
+        assert_eq!(buy_pressure, 50);
+        assert_eq!(sell_pressure, 0);
+    }
+
+    #[test]
+    fn test_is_thin_book_true() {
+        let book = OrderBook::<()>::new("TEST");
+        let _ = book.add_limit_order(OrderId::new(), 100, 5, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 101, 5, Side::Sell, TimeInForce::Gtc, None);
+
+        assert!(book.is_thin_book(100, 10));
+    }
+
+    #[test]
+    fn test_is_thin_book_false() {
+        let book = setup_test_book();
+
+        assert!(!book.is_thin_book(100, 10));
+    }
+
+    #[test]
+    fn test_is_thin_book_one_side_thin() {
+        let book = OrderBook::<()>::new("TEST");
+        let _ = book.add_limit_order(OrderId::new(), 100, 200, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 101, 5, Side::Sell, TimeInForce::Gtc, None);
+
+        // Sell side is thin
+        assert!(book.is_thin_book(100, 10));
+    }
+
+    #[test]
+    fn test_is_thin_book_empty() {
+        let book = OrderBook::<()>::new("TEST");
+
+        assert!(book.is_thin_book(1, 10));
+    }
+
+    #[test]
+    fn test_depth_distribution_basic() {
+        let book = setup_test_book();
+
+        let distribution = book.depth_distribution(Side::Buy, 5);
+
+        assert_eq!(distribution.len(), 5);
+
+        // Verify total volume matches
+        let total: u64 = distribution.iter().map(|bin| bin.volume).sum();
+        assert_eq!(total, 150);
+    }
+
+    #[test]
+    fn test_depth_distribution_bins() {
+        let book = OrderBook::<()>::new("TEST");
+
+        // Add orders at specific prices
+        for i in 0..10 {
+            let price = 100 - i;
+            let _ =
+                book.add_limit_order(OrderId::new(), price, 10, Side::Buy, TimeInForce::Gtc, None);
+        }
+
+        let distribution = book.depth_distribution(Side::Buy, 3);
+
+        assert_eq!(distribution.len(), 3);
+
+        // Check that bins cover the full range
+        assert_eq!(distribution[0].min_price, 91);
+        assert!(distribution.last().unwrap().max_price >= 100);
+    }
+
+    #[test]
+    fn test_depth_distribution_zero_bins() {
+        let book = setup_test_book();
+
+        let distribution = book.depth_distribution(Side::Buy, 0);
+
+        assert!(distribution.is_empty());
+    }
+
+    #[test]
+    fn test_depth_distribution_empty_book() {
+        let book = OrderBook::<()>::new("TEST");
+
+        let distribution = book.depth_distribution(Side::Buy, 5);
+
+        assert!(distribution.is_empty());
+    }
+
+    #[test]
+    fn test_depth_distribution_single_price() {
+        let book = OrderBook::<()>::new("TEST");
+        let _ = book.add_limit_order(OrderId::new(), 100, 50, Side::Buy, TimeInForce::Gtc, None);
+
+        let distribution = book.depth_distribution(Side::Buy, 3);
+
+        assert_eq!(distribution.len(), 3);
+
+        // All volume should be in the bins
+        let total: u64 = distribution.iter().map(|bin| bin.volume).sum();
+        assert_eq!(total, 50);
+    }
+
+    #[test]
+    fn test_depth_distribution_level_count() {
+        let book = OrderBook::<()>::new("TEST");
+
+        // Add multiple orders at different prices
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 99, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 98, 10, Side::Buy, TimeInForce::Gtc, None);
+
+        let distribution = book.depth_distribution(Side::Buy, 2);
+
+        // Verify level counts
+        let total_levels: usize = distribution.iter().map(|bin| bin.level_count).sum();
+        assert_eq!(total_levels, 3);
+    }
+
+    #[test]
+    fn test_depth_statistics_std_dev() {
+        let book = OrderBook::<()>::new("TEST");
+
+        // Add orders with known sizes for std dev calculation
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 99, 20, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 98, 30, Side::Buy, TimeInForce::Gtc, None);
+
+        let stats = book.depth_statistics(Side::Buy, 3);
+
+        // Mean = 20, variance = ((10-20)^2 + (20-20)^2 + (30-20)^2) / 3 = 200/3
+        // Std dev = sqrt(200/3) ≈ 8.165
+        assert!((stats.std_dev_level_size - 8.165).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_order_book_imbalance_balanced() {
+        let book = OrderBook::<()>::new("TEST");
+        let _ = book.add_limit_order(OrderId::new(), 100, 50, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 101, 50, Side::Sell, TimeInForce::Gtc, None);
+
+        let imbalance = book.order_book_imbalance(5);
+
+        assert!((imbalance - 0.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_order_book_imbalance_buy_heavy() {
+        let book = OrderBook::<()>::new("TEST");
+        let _ = book.add_limit_order(OrderId::new(), 100, 100, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 101, 50, Side::Sell, TimeInForce::Gtc, None);
+
+        let imbalance = book.order_book_imbalance(5);
+
+        // More buy volume, expect positive imbalance
+        assert!(imbalance > 0.0);
+    }
+
+    #[test]
+    fn test_order_book_imbalance_sell_heavy() {
+        let book = OrderBook::<()>::new("TEST");
+        let _ = book.add_limit_order(OrderId::new(), 100, 30, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 101, 100, Side::Sell, TimeInForce::Gtc, None);
+
+        let imbalance = book.order_book_imbalance(5);
+
+        // More sell volume, expect negative imbalance
+        assert!(imbalance < 0.0);
+    }
+
+    #[test]
+    fn test_combined_statistics_workflow() {
+        let book = setup_test_book();
+
+        // Get statistics
+        let bid_stats = book.depth_statistics(Side::Buy, 10);
+        let ask_stats = book.depth_statistics(Side::Sell, 10);
+
+        // Check market conditions
+        let _imbalance = book.order_book_imbalance(5);
+        let (buy_pressure, sell_pressure) = book.buy_sell_pressure();
+
+        // Verify consistency
+        assert_eq!(buy_pressure, bid_stats.total_volume);
+        assert_eq!(sell_pressure, ask_stats.total_volume);
+
+        // Check thin book
+        let is_thin = book.is_thin_book(1000, 5);
+        assert!(is_thin); // Total volume is 270, less than 1000
+    }
+
+    #[test]
+    fn test_depth_distribution_bins_match_range() {
+        let book = OrderBook::<()>::new("TEST");
+
+        // Add orders spanning a known range
+        let _ = book.add_limit_order(OrderId::new(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(OrderId::new(), 90, 10, Side::Buy, TimeInForce::Gtc, None);
+
+        let distribution = book.depth_distribution(Side::Buy, 2);
+
+        assert_eq!(distribution.len(), 2);
+
+        // Verify bins cover the full range
+        assert!(distribution[0].min_price <= 90);
+        assert!(distribution.last().unwrap().max_price > 100);
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -27,6 +27,9 @@ pub use crate::orderbook::iterators::LevelInfo;
 // Market impact and simulation types
 pub use crate::orderbook::market_impact::{MarketImpact, OrderSimulation};
 
+// Statistics types
+pub use crate::orderbook::statistics::{DepthStats, DistributionBin};
+
 // Trade-related types
 pub use crate::orderbook::trade::{
     TradeEvent, TradeInfo, TradeListener, TradeResult, TransactionInfo,


### PR DESCRIPTION
…and examples

- Introduce `depth_statistics`, `buy_sell_pressure`, `is_thin_book`, `depth_distribution`, and `order_book_imbalance` methods for comprehensive liquidity and market condition analysis.
- Add `statistics.rs` for core logic and `statistics_tests.rs` for full test coverage.
- Extend `OrderBook` with statistical capabilities and integrate in public API.
- Create `aggregate_statistics.rs` example demonstrating practical applications.
- Update `README.md` with new features, usage examples, and practical scenarios.

#23