### PR TITLE
chore(deps): bump workspace deps + migrate bincode 1 → 2 (0.6.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] — 2026-04-20
+
+### Changed
+
+- **Dependencies**: Bump workspace dependencies to latest stable
+  versions — `uuid` → `1.23`, `tokio` → `1.52`, `sha2` → `0.11`,
+  `async-nats` → `0.47`, and `bincode` → `2.0` (the crates.io `3.0.0`
+  release is a `compile_error!` stub, so `2.0` is the current usable
+  major).
+- **`bincode` migration (feature `bincode`)**: migrated the
+  `BincodeEventSerializer` and the bincode-gated sequencer tests from
+  the legacy `bincode::serialize` / `bincode::deserialize` API to the
+  serde bridge in `bincode 2.x`
+  (`bincode::serde::encode_to_vec` / `bincode::serde::decode_from_slice`
+  with `bincode::config::standard()`). The public
+  `EventSerializer` trait and the `BincodeEventSerializer` type are
+  unchanged.
+- **`sha2` 0.11 compat**: the finalized `Digest` output type no
+  longer implements `LowerHex` directly, so
+  `OrderBookSnapshotPackage::compute_checksum` now formats the hash
+  bytes explicitly.
+
+### Notes
+
+- **Wire-format change (bincode NATS payloads)**: bincode 1.x and
+  bincode 2.x produce different byte layouts. Consumers that decoded
+  NATS payloads with an older `BincodeEventSerializer` build must
+  upgrade to the new version. The on-disk journal is unaffected — it
+  uses `serde_json`, not bincode. `ORDERBOOK_SNAPSHOT_FORMAT_VERSION`
+  stays at `1`.
+- No public API changes — `0.6.2` is a compatible minor release.
+
 ## [0.6.1] — 2026-03-22
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orderbook-rs"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."
@@ -58,7 +58,7 @@ journal = ["dep:crc32fast", "dep:memmap2"]
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
-tokio = { version = "1.49", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.52", features = ["macros", "rt-multi-thread", "time"] }
 tempfile = "3"
 
 [[bench]]
@@ -85,20 +85,20 @@ members = [
 orderbook-rs = { path = "." }
 pricelevel = "0.7"
 tracing = "0.1"
-uuid = { version = "1.21", features = ["v4", "v5", "serde"] }
+uuid = { version = "1.23", features = ["v4", "v5", "serde"] }
 dashmap = "6.1"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-sha2 = "0.10"
-tokio = { version = "1.49", features = ["sync", "rt", "time"] }
+sha2 = "0.11"
+tokio = { version = "1.52", features = ["sync", "rt", "time"] }
 crossbeam-skiplist = "0.1"
 crossbeam = "0.8"
 bitflags = { version = "2.11", features = ["serde"] }
 thiserror = "2"
 either = "1.15"
 tracing-subscriber = "0.3"
-async-nats = "0.46"
+async-nats = "0.47"
 bytes = "1"
-bincode = "1"
+bincode = { version = "2.0", features = ["serde"] }
 crc32fast = "1"
 memmap2 = "0.9"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,21 @@ This order book engine is built with the following design principles:
 - **Research**: Platform for studying market microstructure and order flow
 - **Educational**: Reference implementation for understanding modern exchange architecture
 
-### What's New in Version 0.6.1
+### What's New in Version 0.6.2
+
+#### v0.6.2 — Dependency Bumps & Bincode 2.x Migration
+
+- **Dependency refresh**: `uuid` 1.23, `tokio` 1.52, `sha2` 0.11,
+  `async-nats` 0.47, `bincode` 2.0 (crates.io `bincode 3.0.0` is a
+  `compile_error!` stub, so `2.0` is the current usable major).
+- **Bincode API migration** (feature `bincode`): the
+  `BincodeEventSerializer` now uses `bincode::serde::encode_to_vec`
+  / `decode_from_slice` with `bincode::config::standard()`. The
+  public trait and type surface are unchanged.
+- **Wire-format note**: bincode 1.x and 2.x produce different byte
+  layouts on the NATS transport path. The on-disk journal uses
+  `serde_json` and is unaffected (`ORDERBOOK_SNAPSHOT_FORMAT_VERSION`
+  stays at `1`).
 
 #### v0.6.1 — NATS Integration, Sequencer & Order State
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,21 @@
 //! - **Research**: Platform for studying market microstructure and order flow
 //! - **Educational**: Reference implementation for understanding modern exchange architecture
 //!
-//! ## What's New in Version 0.6.1
+//! ## What's New in Version 0.6.2
+//!
+//! ### v0.6.2 — Dependency Bumps & Bincode 2.x Migration
+//!
+//! - **Dependency refresh**: `uuid` 1.23, `tokio` 1.52, `sha2` 0.11,
+//!   `async-nats` 0.47, `bincode` 2.0 (crates.io `bincode 3.0.0` is a
+//!   `compile_error!` stub, so `2.0` is the current usable major).
+//! - **Bincode API migration** (feature `bincode`): the
+//!   `BincodeEventSerializer` now uses `bincode::serde::encode_to_vec`
+//!   / `decode_from_slice` with `bincode::config::standard()`. The
+//!   public trait and type surface are unchanged.
+//! - **Wire-format note**: bincode 1.x and 2.x produce different byte
+//!   layouts on the NATS transport path. The on-disk journal uses
+//!   `serde_json` and is unaffected (`ORDERBOOK_SNAPSHOT_FORMAT_VERSION`
+//!   stays at `1`).
 //!
 //! ### v0.6.1 — NATS Integration, Sequencer & Order State
 //!

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -1708,18 +1708,15 @@ where
 
         // For bids: iterate from highest to lowest (reverse)
         // For asks: iterate from lowest to highest (forward)
-        let mut current_position = 1;
-
         let iter = match side {
             Side::Buy => Either::Left(price_levels.iter().rev()),
             Side::Sell => Either::Right(price_levels.iter()),
         };
 
-        for entry in iter {
+        for (current_position, entry) in (1usize..).zip(iter) {
             if current_position == position {
                 return Some(*entry.key());
             }
-            current_position += 1;
         }
 
         None

--- a/src/orderbook/serialization.rs
+++ b/src/orderbook/serialization.rs
@@ -191,8 +191,10 @@ impl BincodeEventSerializer {
 #[cfg(feature = "bincode")]
 impl EventSerializer for BincodeEventSerializer {
     fn serialize_trade(&self, trade: &TradeResult) -> Result<Vec<u8>, SerializationError> {
-        bincode::serialize(trade).map_err(|e| SerializationError {
-            message: e.to_string(),
+        bincode::serde::encode_to_vec(trade, bincode::config::standard()).map_err(|e| {
+            SerializationError {
+                message: e.to_string(),
+            }
         })
     }
 
@@ -200,22 +202,31 @@ impl EventSerializer for BincodeEventSerializer {
         &self,
         event: &PriceLevelChangedEvent,
     ) -> Result<Vec<u8>, SerializationError> {
-        bincode::serialize(event).map_err(|e| SerializationError {
-            message: e.to_string(),
+        bincode::serde::encode_to_vec(event, bincode::config::standard()).map_err(|e| {
+            SerializationError {
+                message: e.to_string(),
+            }
         })
     }
 
     fn deserialize_trade(&self, data: &[u8]) -> Result<TradeResult, SerializationError> {
-        bincode::deserialize(data).map_err(|e| SerializationError {
-            message: e.to_string(),
-        })
+        bincode::serde::decode_from_slice::<TradeResult, _>(data, bincode::config::standard())
+            .map(|(value, _)| value)
+            .map_err(|e| SerializationError {
+                message: e.to_string(),
+            })
     }
 
     fn deserialize_book_change(
         &self,
         data: &[u8],
     ) -> Result<PriceLevelChangedEvent, SerializationError> {
-        bincode::deserialize(data).map_err(|e| SerializationError {
+        bincode::serde::decode_from_slice::<PriceLevelChangedEvent, _>(
+            data,
+            bincode::config::standard(),
+        )
+        .map(|(value, _)| value)
+        .map_err(|e| SerializationError {
             message: e.to_string(),
         })
     }

--- a/src/orderbook/serialization.rs
+++ b/src/orderbook/serialization.rs
@@ -210,25 +210,42 @@ impl EventSerializer for BincodeEventSerializer {
     }
 
     fn deserialize_trade(&self, data: &[u8]) -> Result<TradeResult, SerializationError> {
-        bincode::serde::decode_from_slice::<TradeResult, _>(data, bincode::config::standard())
-            .map(|(value, _)| value)
-            .map_err(|e| SerializationError {
-                message: e.to_string(),
-            })
+        let (value, bytes_read) =
+            bincode::serde::decode_from_slice::<TradeResult, _>(data, bincode::config::standard())
+                .map_err(|e| SerializationError {
+                    message: e.to_string(),
+                })?;
+        if bytes_read != data.len() {
+            return Err(SerializationError {
+                message: format!(
+                    "trailing bytes after trade payload: consumed {bytes_read} of {}",
+                    data.len()
+                ),
+            });
+        }
+        Ok(value)
     }
 
     fn deserialize_book_change(
         &self,
         data: &[u8],
     ) -> Result<PriceLevelChangedEvent, SerializationError> {
-        bincode::serde::decode_from_slice::<PriceLevelChangedEvent, _>(
+        let (value, bytes_read) = bincode::serde::decode_from_slice::<PriceLevelChangedEvent, _>(
             data,
             bincode::config::standard(),
         )
-        .map(|(value, _)| value)
         .map_err(|e| SerializationError {
             message: e.to_string(),
-        })
+        })?;
+        if bytes_read != data.len() {
+            return Err(SerializationError {
+                message: format!(
+                    "trailing bytes after book-change payload: consumed {bytes_read} of {}",
+                    data.len()
+                ),
+            });
+        }
+        Ok(value)
     }
 
     #[inline]

--- a/src/orderbook/snapshot.rs
+++ b/src/orderbook/snapshot.rs
@@ -258,7 +258,14 @@ impl OrderBookSnapshotPackage {
         hasher.update(payload);
 
         let checksum_bytes = hasher.finalize();
-        Ok(format!("{:x}", checksum_bytes))
+        let mut out = String::with_capacity(checksum_bytes.len() * 2);
+        for byte in checksum_bytes.iter() {
+            use std::fmt::Write;
+            write!(&mut out, "{byte:02x}").map_err(|error| OrderBookError::SerializationError {
+                message: error.to_string(),
+            })?;
+        }
+        Ok(out)
     }
 }
 

--- a/tests/unit/sequencer_types_tests.rs
+++ b/tests/unit/sequencer_types_tests.rs
@@ -213,12 +213,13 @@ mod tests_sequencer_types {
             let cmd: SequencerCommand<()> = SequencerCommand::CancelAll;
             let bytes = bincode::serde::encode_to_vec(&cmd, bincode::config::standard());
             assert!(bytes.is_ok());
+            let payload = bytes.unwrap_or_default();
             let decoded: Result<(SequencerCommand<()>, usize), _> =
-                bincode::serde::decode_from_slice(
-                    &bytes.unwrap_or_default(),
-                    bincode::config::standard(),
-                );
+                bincode::serde::decode_from_slice(&payload, bincode::config::standard());
             assert!(decoded.is_ok());
+            if let Ok((_, bytes_read)) = &decoded {
+                assert_eq!(*bytes_read, payload.len(), "trailing bytes in payload");
+            }
             assert!(matches!(
                 decoded
                     .map(|(cmd, _)| cmd)
@@ -232,12 +233,13 @@ mod tests_sequencer_types {
             let cmd: SequencerCommand<()> = SequencerCommand::CancelBySide { side: Side::Buy };
             let bytes = bincode::serde::encode_to_vec(&cmd, bincode::config::standard());
             assert!(bytes.is_ok());
+            let payload = bytes.unwrap_or_default();
             let decoded: Result<(SequencerCommand<()>, usize), _> =
-                bincode::serde::decode_from_slice(
-                    &bytes.unwrap_or_default(),
-                    bincode::config::standard(),
-                );
+                bincode::serde::decode_from_slice(&payload, bincode::config::standard());
             assert!(decoded.is_ok());
+            if let Ok((_, bytes_read)) = decoded {
+                assert_eq!(bytes_read, payload.len(), "trailing bytes in payload");
+            }
         }
 
         #[test]
@@ -246,12 +248,13 @@ mod tests_sequencer_types {
             let cmd: SequencerCommand<()> = SequencerCommand::CancelByUser { user_id };
             let bytes = bincode::serde::encode_to_vec(&cmd, bincode::config::standard());
             assert!(bytes.is_ok());
+            let payload = bytes.unwrap_or_default();
             let decoded: Result<(SequencerCommand<()>, usize), _> =
-                bincode::serde::decode_from_slice(
-                    &bytes.unwrap_or_default(),
-                    bincode::config::standard(),
-                );
+                bincode::serde::decode_from_slice(&payload, bincode::config::standard());
             assert!(decoded.is_ok());
+            if let Ok((_, bytes_read)) = decoded {
+                assert_eq!(bytes_read, payload.len(), "trailing bytes in payload");
+            }
         }
 
         #[test]
@@ -263,12 +266,13 @@ mod tests_sequencer_types {
             };
             let bytes = bincode::serde::encode_to_vec(&cmd, bincode::config::standard());
             assert!(bytes.is_ok());
+            let payload = bytes.unwrap_or_default();
             let decoded: Result<(SequencerCommand<()>, usize), _> =
-                bincode::serde::decode_from_slice(
-                    &bytes.unwrap_or_default(),
-                    bincode::config::standard(),
-                );
+                bincode::serde::decode_from_slice(&payload, bincode::config::standard());
             assert!(decoded.is_ok());
+            if let Ok((_, bytes_read)) = decoded {
+                assert_eq!(bytes_read, payload.len(), "trailing bytes in payload");
+            }
         }
 
         #[test]
@@ -278,11 +282,13 @@ mod tests_sequencer_types {
             };
             let bytes = bincode::serde::encode_to_vec(&result, bincode::config::standard());
             assert!(bytes.is_ok());
-            let decoded: Result<(SequencerResult, usize), _> = bincode::serde::decode_from_slice(
-                &bytes.unwrap_or_default(),
-                bincode::config::standard(),
-            );
+            let payload = bytes.unwrap_or_default();
+            let decoded: Result<(SequencerResult, usize), _> =
+                bincode::serde::decode_from_slice(&payload, bincode::config::standard());
             assert!(decoded.is_ok());
+            if let Ok((_, bytes_read)) = decoded {
+                assert_eq!(bytes_read, payload.len(), "trailing bytes in payload");
+            }
         }
 
         #[test]
@@ -296,12 +302,12 @@ mod tests_sequencer_types {
             );
             let bytes = bincode::serde::encode_to_vec(&event, bincode::config::standard());
             assert!(bytes.is_ok());
-            let decoded: Result<(SequencerEvent<()>, usize), _> = bincode::serde::decode_from_slice(
-                &bytes.unwrap_or_default(),
-                bincode::config::standard(),
-            );
+            let payload = bytes.unwrap_or_default();
+            let decoded: Result<(SequencerEvent<()>, usize), _> =
+                bincode::serde::decode_from_slice(&payload, bincode::config::standard());
             assert!(decoded.is_ok());
-            if let Ok((evt, _)) = decoded {
+            if let Ok((evt, bytes_read)) = decoded {
+                assert_eq!(bytes_read, payload.len(), "trailing bytes in payload");
                 assert_eq!(evt.sequence_num, 10);
             }
         }

--- a/tests/unit/sequencer_types_tests.rs
+++ b/tests/unit/sequencer_types_tests.rs
@@ -211,13 +211,18 @@ mod tests_sequencer_types {
         #[test]
         fn bincode_roundtrip_cancel_all() {
             let cmd: SequencerCommand<()> = SequencerCommand::CancelAll;
-            let bytes = bincode::serialize(&cmd);
+            let bytes = bincode::serde::encode_to_vec(&cmd, bincode::config::standard());
             assert!(bytes.is_ok());
-            let decoded: Result<SequencerCommand<()>, _> =
-                bincode::deserialize(&bytes.unwrap_or_default());
+            let decoded: Result<(SequencerCommand<()>, usize), _> =
+                bincode::serde::decode_from_slice(
+                    &bytes.unwrap_or_default(),
+                    bincode::config::standard(),
+                );
             assert!(decoded.is_ok());
             assert!(matches!(
-                decoded.unwrap_or(SequencerCommand::CancelAll),
+                decoded
+                    .map(|(cmd, _)| cmd)
+                    .unwrap_or(SequencerCommand::CancelAll),
                 SequencerCommand::CancelAll
             ));
         }
@@ -225,10 +230,13 @@ mod tests_sequencer_types {
         #[test]
         fn bincode_roundtrip_cancel_by_side() {
             let cmd: SequencerCommand<()> = SequencerCommand::CancelBySide { side: Side::Buy };
-            let bytes = bincode::serialize(&cmd);
+            let bytes = bincode::serde::encode_to_vec(&cmd, bincode::config::standard());
             assert!(bytes.is_ok());
-            let decoded: Result<SequencerCommand<()>, _> =
-                bincode::deserialize(&bytes.unwrap_or_default());
+            let decoded: Result<(SequencerCommand<()>, usize), _> =
+                bincode::serde::decode_from_slice(
+                    &bytes.unwrap_or_default(),
+                    bincode::config::standard(),
+                );
             assert!(decoded.is_ok());
         }
 
@@ -236,10 +244,13 @@ mod tests_sequencer_types {
         fn bincode_roundtrip_cancel_by_user() {
             let user_id = Hash32::from([99u8; 32]);
             let cmd: SequencerCommand<()> = SequencerCommand::CancelByUser { user_id };
-            let bytes = bincode::serialize(&cmd);
+            let bytes = bincode::serde::encode_to_vec(&cmd, bincode::config::standard());
             assert!(bytes.is_ok());
-            let decoded: Result<SequencerCommand<()>, _> =
-                bincode::deserialize(&bytes.unwrap_or_default());
+            let decoded: Result<(SequencerCommand<()>, usize), _> =
+                bincode::serde::decode_from_slice(
+                    &bytes.unwrap_or_default(),
+                    bincode::config::standard(),
+                );
             assert!(decoded.is_ok());
         }
 
@@ -250,10 +261,13 @@ mod tests_sequencer_types {
                 min_price: 50,
                 max_price: 150,
             };
-            let bytes = bincode::serialize(&cmd);
+            let bytes = bincode::serde::encode_to_vec(&cmd, bincode::config::standard());
             assert!(bytes.is_ok());
-            let decoded: Result<SequencerCommand<()>, _> =
-                bincode::deserialize(&bytes.unwrap_or_default());
+            let decoded: Result<(SequencerCommand<()>, usize), _> =
+                bincode::serde::decode_from_slice(
+                    &bytes.unwrap_or_default(),
+                    bincode::config::standard(),
+                );
             assert!(decoded.is_ok());
         }
 
@@ -262,10 +276,12 @@ mod tests_sequencer_types {
             let result = SequencerResult::MassCancelled {
                 result: MassCancelResult::default(),
             };
-            let bytes = bincode::serialize(&result);
+            let bytes = bincode::serde::encode_to_vec(&result, bincode::config::standard());
             assert!(bytes.is_ok());
-            let decoded: Result<SequencerResult, _> =
-                bincode::deserialize(&bytes.unwrap_or_default());
+            let decoded: Result<(SequencerResult, usize), _> = bincode::serde::decode_from_slice(
+                &bytes.unwrap_or_default(),
+                bincode::config::standard(),
+            );
             assert!(decoded.is_ok());
         }
 
@@ -278,12 +294,14 @@ mod tests_sequencer_types {
                     result: MassCancelResult::default(),
                 },
             );
-            let bytes = bincode::serialize(&event);
+            let bytes = bincode::serde::encode_to_vec(&event, bincode::config::standard());
             assert!(bytes.is_ok());
-            let decoded: Result<SequencerEvent<()>, _> =
-                bincode::deserialize(&bytes.unwrap_or_default());
+            let decoded: Result<(SequencerEvent<()>, usize), _> = bincode::serde::decode_from_slice(
+                &bytes.unwrap_or_default(),
+                bincode::config::standard(),
+            );
             assert!(decoded.is_ok());
-            if let Ok(evt) = decoded {
+            if let Ok((evt, _)) = decoded {
                 assert_eq!(evt.sequence_num, 10);
             }
         }


### PR DESCRIPTION
## Summary

- Bumps all workspace deps to the latest stable versions (`uuid`, `tokio`, `sha2`, `async-nats`, plus patch-level refreshes).
- Migrates the `bincode`-gated event serializer from the legacy `1.x` API to the `2.x` serde bridge (`bincode::serde::encode_to_vec` / `decode_from_slice` with `bincode::config::standard()`) — `EventSerializer` trait and `BincodeEventSerializer` type surface unchanged. `bincode 3.0.0` on crates.io is a `compile_error!` stub (xkcd/2347 joke), so `2.0` is the real current usable major.
- Fixes a `sha2 0.11` compat issue in `OrderBookSnapshotPackage::compute_checksum` (finalized `Digest` output no longer implements `LowerHex`) and a new `clippy::explicit_counter_loop` warning in `OrderBook::price_for_queue_position` from the refreshed toolchain.
- Ships as `0.6.2` — no public API break, no journal format change, `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` stays at `1`.

## Wire-format note

`bincode 1.x` and `bincode 2.x` produce different byte layouts. Consumers that decoded NATS payloads with an older `BincodeEventSerializer` build must upgrade to the new version. The on-disk journal is unaffected — it uses `serde_json`, not bincode.

## Test plan

- [x] `cargo test --no-default-features`
- [x] `cargo test --features bincode`
- [x] `cargo test --features nats`
- [x] `cargo test --features journal`
- [x] `cargo test --features special_orders`
- [x] `cargo test --all-features` — 977 passed / 0 failed
- [x] `cargo bench --no-run --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `make pre-push`

Closes #49
