### PR TITLE
Inject Clock trait for deterministic replay (0.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] — 2026-04-24
+
+### Added
+
+- **`Clock` trait** (`src/orderbook/clock.rs`) — pluggable timestamp source
+  injected at the operations edge so matching stays deterministic under
+  sequencer replay. Two implementations ship: `MonotonicClock` (production,
+  wraps `SystemTime::now`) and `StubClock` (replay / tests, monotonic
+  `AtomicU64` counter with configurable start and step). Exposed at the
+  crate root and via `prelude`.
+- **`OrderBook::with_clock(symbol, Arc<dyn Clock>)`** constructor and
+  **`OrderBook::set_clock`**, **`OrderBook::clock()`** accessors. The
+  default `OrderBook::new` keeps wrapping `MonotonicClock` internally —
+  existing callers observe no behavioural change.
+- **`OrderStateTracker::with_clock`** and
+  **`OrderStateTracker::with_capacity_and_clock`** constructors.
+- **`ReplayEngine::replay_from_with_clock`** and
+  **`ReplayEngine::replay_from_with_clock_and_progress`** — the canonical
+  entry points for byte-identical replay tests and disaster-recovery
+  pipelines that must reproduce engine timestamps deterministically.
+- Integration proptest `tests/unit/clock_determinism_tests.rs` (128 cases)
+  covering "two replays with identical `StubClock` produce matching
+  snapshots". A strictly byte-identical event-stream oracle (via
+  `EventSerializer`) is widened in issue #57.
+- New dev-dependency `proptest = "1.7"`.
+
+### Changed
+
+- **`OrderStateTracker` history unit migrated from nanoseconds to
+  milliseconds.** The tracker now stamps via the injected `Clock`, and
+  `Clock::now_millis` is the only unit the trait exposes.
+  `OrderStateTracker::get_history` and `OrderBook::get_order_history`
+  therefore return `Vec<(u64 /* ms */, OrderStatus)>` instead of
+  nanoseconds. `purge_terminal_older_than(Duration)` interprets its
+  argument in milliseconds accordingly.
+- Wall-clock reads (`SystemTime::now` / `current_time_millis`) removed
+  from `src/orderbook/operations.rs`, `private.rs`, `book.rs`, and
+  `order_state.rs` — every stamp now flows through
+  `self.clock().now_millis()`. `utils::current_time_millis` remains
+  public for non-library callers and is unchanged.
+
+### Notes
+
+- Non-breaking public API surface. `cargo-semver-checks` should classify
+  this release as a minor bump; the version jump to `0.7.0` is a
+  deliberate marker that the `Clock` extensibility surface is now public.
+- Replay determinism: `ReplayEngine::replay_from` continues to behave as
+  before (production stamping via `MonotonicClock`). Byte-identical
+  replay requires the new `replay_from_with_clock` entry point with a
+  caller-supplied `Arc<StubClock>` and a fixed start value.
+
 ## [0.6.2] — 2026-04-20
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ journal = ["dep:crc32fast", "dep:memmap2"]
 criterion = { version = "0.8", features = ["html_reports"] }
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread", "time"] }
 tempfile = "3"
+proptest = "1.7"
 
 [[bench]]
 name = "benches"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orderbook-rs"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."

--- a/README.md
+++ b/README.md
@@ -46,7 +46,28 @@ This order book engine is built with the following design principles:
 - **Research**: Platform for studying market microstructure and order flow
 - **Educational**: Reference implementation for understanding modern exchange architecture
 
-### What's New in Version 0.6.2
+### What's New in Version 0.7.0
+
+#### v0.7.0 — `Clock` trait for deterministic replay
+
+- **New [`Clock`] trait** with two implementations, [`MonotonicClock`]
+  (production, wraps `SystemTime::now`) and [`StubClock`] (replay /
+  tests, monotonic `AtomicU64` counter with configurable start and
+  step). Re-exported at the crate root and via [`prelude`].
+- **[`OrderBook::with_clock`]** constructor plus `set_clock` and
+  `clock()` accessors. The default [`OrderBook::new`] keeps wrapping
+  [`MonotonicClock`] internally — existing callers observe no
+  behavioural change.
+- **`ReplayEngine::replay_from_with_clock`** for byte-identical
+  replay tests and disaster-recovery pipelines that must reproduce
+  engine timestamps deterministically.
+- Wall-clock reads are no longer present inside the matching core —
+  every stamp flows through `self.clock().now_millis()`.
+- **Behavioural change (same type signature)**:
+  `OrderStateTracker::get_history` and `OrderBook::get_order_history`
+  now return `Vec<(u64 /* milliseconds */, OrderStatus)>` instead of
+  nanoseconds; the `Clock::now_millis` unit is the only one the trait
+  exposes.
 
 #### v0.6.2 — Dependency Bumps & Bincode 2.x Migration
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,6 +277,7 @@ pub use orderbook::BincodeEventSerializer;
 pub use orderbook::FileJournal;
 #[cfg(feature = "nats")]
 pub use orderbook::NatsTradePublisher;
+pub use orderbook::clock::{Clock, MonotonicClock, StubClock};
 pub use orderbook::implied_volatility::{
     BlackScholes, IVConfig, IVError, IVParams, IVQuality, IVResult, OptionType, PriceSource,
     SolverConfig,
@@ -298,7 +299,6 @@ pub use orderbook::stp::STPMode;
 pub use orderbook::trade::{TradeListener, TradeResult};
 #[cfg(feature = "nats")]
 pub use orderbook::{BookChangeBatch, BookChangeEntry, NatsBookChangePublisher};
-pub use orderbook::clock::{Clock, MonotonicClock, StubClock};
 pub use orderbook::{
     FeeSchedule, ManagerError, MassCancelResult, OrderBook, OrderBookError, OrderBookSnapshot,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,6 +298,7 @@ pub use orderbook::stp::STPMode;
 pub use orderbook::trade::{TradeListener, TradeResult};
 #[cfg(feature = "nats")]
 pub use orderbook::{BookChangeBatch, BookChangeEntry, NatsBookChangePublisher};
+pub use orderbook::clock::{Clock, MonotonicClock, StubClock};
 pub use orderbook::{
     FeeSchedule, ManagerError, MassCancelResult, OrderBook, OrderBookError, OrderBookSnapshot,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,28 @@
 //! - **Research**: Platform for studying market microstructure and order flow
 //! - **Educational**: Reference implementation for understanding modern exchange architecture
 //!
-//! ## What's New in Version 0.6.2
+//! ## What's New in Version 0.7.0
+//!
+//! ### v0.7.0 — `Clock` trait for deterministic replay
+//!
+//! - **New [`Clock`] trait** with two implementations, [`MonotonicClock`]
+//!   (production, wraps `SystemTime::now`) and [`StubClock`] (replay /
+//!   tests, monotonic `AtomicU64` counter with configurable start and
+//!   step). Re-exported at the crate root and via [`prelude`].
+//! - **[`OrderBook::with_clock`]** constructor plus `set_clock` and
+//!   `clock()` accessors. The default [`OrderBook::new`] keeps wrapping
+//!   [`MonotonicClock`] internally — existing callers observe no
+//!   behavioural change.
+//! - **`ReplayEngine::replay_from_with_clock`** for byte-identical
+//!   replay tests and disaster-recovery pipelines that must reproduce
+//!   engine timestamps deterministically.
+//! - Wall-clock reads are no longer present inside the matching core —
+//!   every stamp flows through `self.clock().now_millis()`.
+//! - **Behavioural change (same type signature)**:
+//!   `OrderStateTracker::get_history` and `OrderBook::get_order_history`
+//!   now return `Vec<(u64 /* milliseconds */, OrderStatus)>` instead of
+//!   nanoseconds; the `Clock::now_millis` unit is the only one the trait
+//!   exposes.
 //!
 //! ### v0.6.2 — Dependency Bumps & Bincode 2.x Migration
 //!

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -1,6 +1,7 @@
 //! Core OrderBook implementation for managing price levels and orders
 
 use super::cache::PriceLevelCache;
+use super::clock::{Clock, MonotonicClock};
 use super::error::OrderBookError;
 use super::fees::FeeSchedule;
 use super::iterators::{LevelInfo, LevelsInRange, LevelsUntilDepth, LevelsWithCumulativeDepth};
@@ -12,7 +13,6 @@ use crate::orderbook::book_change_event::PriceLevelChangedListener;
 use crate::orderbook::repricing::SpecialOrderTracker;
 use crate::orderbook::stp::STPMode;
 use crate::orderbook::trade::{TradeListener, TradeResult};
-use crate::utils::current_time_millis;
 use crossbeam::atomic::AtomicCell;
 use crossbeam_skiplist::SkipMap;
 use dashmap::DashMap;
@@ -123,6 +123,14 @@ pub struct OrderBook<T = ()> {
     /// When `Some`, every order transition (Open, PartiallyFilled, Filled,
     /// Cancelled, Rejected) is recorded. When `None`, zero overhead.
     pub(super) order_state_tracker: Option<super::order_state::OrderStateTracker>,
+
+    /// Pluggable source of millisecond timestamps stamped on inbound
+    /// orders, snapshots, and lifecycle transitions. Defaults to
+    /// [`MonotonicClock`] (wall-clock); tests and sequencer replay can
+    /// inject a [`super::clock::StubClock`] for byte-identical
+    /// reproducibility. Not serialized — reconstructed on the restoring
+    /// side like [`trade_listener`](Self::trade_listener).
+    pub(super) clock: Arc<dyn Clock>,
 }
 
 impl<T> Serialize for OrderBook<T>
@@ -353,8 +361,22 @@ where
             },
         }
     }
-    /// Create a new order book for the given symbol
+    /// Create a new order book for the given symbol.
+    ///
+    /// The book is installed with a [`MonotonicClock`] (wall-clock
+    /// milliseconds). Use [`Self::with_clock`] to inject a custom
+    /// [`Clock`] implementation.
     pub fn new(symbol: &str) -> Self {
+        Self::with_clock(symbol, Arc::new(MonotonicClock) as Arc<dyn Clock>)
+    }
+
+    /// Create a new order book for the given symbol with a
+    /// caller-provided [`Clock`] implementation.
+    ///
+    /// Use this when byte-identical timestamp behaviour is required, e.g.
+    /// for sequencer replay or deterministic tests — pass in a
+    /// [`super::clock::StubClock`].
+    pub fn with_clock(symbol: &str, clock: Arc<dyn Clock>) -> Self {
         // Create a unique namespace for this order book's transaction IDs
         let namespace = Uuid::new_v4();
 
@@ -383,7 +405,24 @@ where
             stp_mode: STPMode::None,
             fee_schedule: None,
             order_state_tracker: None,
+            clock,
         }
+    }
+
+    /// Replace the clock used by this book.
+    ///
+    /// This takes `&mut self` and is intended for cold configuration
+    /// paths — the production pattern is to set the clock once at
+    /// construction via [`Self::with_clock`].
+    pub fn set_clock(&mut self, clock: Arc<dyn Clock>) {
+        self.clock = clock;
+    }
+
+    /// Access the currently-installed clock.
+    #[inline]
+    #[must_use]
+    pub fn clock(&self) -> &Arc<dyn Clock> {
+        &self.clock
     }
 
     /// Create a new order book for the given symbol with tick size validation.
@@ -451,6 +490,7 @@ where
             stp_mode: STPMode::None,
             fee_schedule: None,
             order_state_tracker: None,
+            clock: Arc::new(MonotonicClock) as Arc<dyn Clock>,
         }
     }
 
@@ -495,6 +535,7 @@ where
             stp_mode: STPMode::None,
             fee_schedule: None,
             order_state_tracker: None,
+            clock: Arc::new(MonotonicClock) as Arc<dyn Clock>,
         }
     }
 
@@ -684,9 +725,10 @@ where
 
     /// Returns the full transition history for an order.
     ///
-    /// Each entry is a `(timestamp_ns, OrderStatus)` pair in chronological
-    /// order. Returns `None` if no tracker is configured or the order ID
-    /// was never submitted.
+    /// Each entry is a `(timestamp_ms, OrderStatus)` pair in chronological
+    /// order. Timestamps come from the clock installed on this book.
+    /// Returns `None` if no tracker is configured or the order ID was
+    /// never submitted.
     #[must_use]
     pub fn get_order_history(
         &self,
@@ -2234,7 +2276,7 @@ where
 
         OrderBookSnapshot {
             symbol: self.symbol.clone(),
-            timestamp: current_time_millis(),
+            timestamp: self.clock().now_millis().as_u64(),
             bids: bid_levels,
             asks: ask_levels,
         }
@@ -2481,7 +2523,7 @@ where
         // Create enriched snapshot with pre-calculated metrics
         EnrichedSnapshot::with_metrics(
             self.symbol.clone(),
-            current_time_millis(),
+            self.clock().now_millis().as_u64(),
             bid_levels,
             ask_levels,
             depth, // Use depth for VWAP calculation

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -726,7 +726,9 @@ where
     /// Returns the full transition history for an order.
     ///
     /// Each entry is a `(timestamp_ms, OrderStatus)` pair in chronological
-    /// order. Timestamps come from the clock installed on this book.
+    /// order. Timestamps come from the configured order state tracker's
+    /// clock. For deterministic replay and consistent timestamps, configure
+    /// the tracker with the same clock as this book.
     /// Returns `None` if no tracker is configured or the order ID was
     /// never submitted.
     #[must_use]

--- a/src/orderbook/clock.rs
+++ b/src/orderbook/clock.rs
@@ -87,11 +87,13 @@ impl StubClock {
     /// Create a new stub clock starting at `start` with a custom step.
     ///
     /// Each call to [`Clock::now_millis`] advances the counter by `step`.
+    /// A `step` of `0` is silently clamped to `1` so the clock stays
+    /// strictly monotonic — the trait contract every caller relies on.
     #[must_use]
     pub fn with_step(start: u64, step: u64) -> Self {
         Self {
             counter: AtomicU64::new(start),
-            step,
+            step: step.max(1),
         }
     }
 
@@ -205,5 +207,15 @@ mod tests {
             .expect("overflow");
         let observed_max = all.iter().copied().max().expect("non-empty");
         assert_eq!(observed_max, expected_max);
+    }
+
+    #[test]
+    fn test_stub_clock_with_step_zero_clamps_to_one() {
+        // `step = 0` would break the trait's monotonicity contract; the
+        // constructor clamps to 1 so every call still advances.
+        let clock = StubClock::with_step(10, 0);
+        assert_eq!(clock.now_millis().as_u64(), 10);
+        assert_eq!(clock.now_millis().as_u64(), 11);
+        assert_eq!(clock.now_millis().as_u64(), 12);
     }
 }

--- a/src/orderbook/clock.rs
+++ b/src/orderbook/clock.rs
@@ -1,0 +1,209 @@
+//! Pluggable timestamp source for the matching core.
+//!
+//! The [`Clock`] trait abstracts the source of millisecond timestamps used
+//! by the order book to stamp inbound orders, snapshots, and lifecycle
+//! transitions. Two implementations are provided:
+//!
+//! - [`MonotonicClock`] — wraps [`crate::utils::current_time_millis`] for
+//!   production deployments. Returns wall-clock milliseconds since the
+//!   Unix epoch.
+//! - [`StubClock`] — a deterministic counter-based clock for tests and
+//!   byte-identical sequencer replay. Each call to `now_millis` advances
+//!   an internal counter by a fixed `step` (default `1`).
+//!
+//! Both implementations are `Send + Sync` so an `Arc<dyn Clock>` can be
+//! shared across threads. The trait is object-safe and is stored on
+//! [`crate::orderbook::book::OrderBook`] as `Arc<dyn Clock>`.
+
+use pricelevel::TimestampMs;
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// A source of wall-clock or logical millisecond timestamps for the
+/// matching core.
+///
+/// Implementations must be [`Send`] + [`Sync`] because an
+/// `Arc<dyn Clock>` is held by the order book and potentially shared
+/// across threads. The trait is object-safe: it is stored as
+/// `Arc<dyn Clock>` on the book so different deployments (production,
+/// replay, deterministic tests) can swap the implementation without
+/// changing the generic parameterization of the order book.
+pub trait Clock: Send + Sync + fmt::Debug {
+    /// Current millisecond timestamp.
+    ///
+    /// Semantics depend on the implementation:
+    /// - production ([`MonotonicClock`]): wall-clock milliseconds since
+    ///   the Unix epoch.
+    /// - replay / test ([`StubClock`]): a monotonic logical counter,
+    ///   not wall-clock.
+    fn now_millis(&self) -> TimestampMs;
+}
+
+/// Production clock wrapping [`crate::utils::current_time_millis`].
+///
+/// Returns wall-clock milliseconds since the Unix epoch. This is the
+/// default clock installed on every [`crate::orderbook::book::OrderBook`]
+/// constructed via [`crate::orderbook::book::OrderBook::new`] and its
+/// friends.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MonotonicClock;
+
+impl Clock for MonotonicClock {
+    #[inline]
+    fn now_millis(&self) -> TimestampMs {
+        TimestampMs::new(crate::utils::current_time_millis())
+    }
+}
+
+/// Deterministic stub clock. Each call to [`Clock::now_millis`] advances
+/// an internal counter by `step` (default `1` millisecond). Intended for
+/// sequencer replay, proptests, and snapshot tests that require
+/// byte-identical timestamps across runs.
+#[derive(Debug)]
+pub struct StubClock {
+    counter: AtomicU64,
+    step: u64,
+}
+
+impl StubClock {
+    /// Create a new stub clock starting at `0` with a step of `1` ms.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            counter: AtomicU64::new(0),
+            step: 1,
+        }
+    }
+
+    /// Create a new stub clock starting at `start` with a step of `1` ms.
+    #[must_use]
+    pub fn starting_at(start: u64) -> Self {
+        Self {
+            counter: AtomicU64::new(start),
+            step: 1,
+        }
+    }
+
+    /// Create a new stub clock starting at `start` with a custom step.
+    ///
+    /// Each call to [`Clock::now_millis`] advances the counter by `step`.
+    #[must_use]
+    pub fn with_step(start: u64, step: u64) -> Self {
+        Self {
+            counter: AtomicU64::new(start),
+            step,
+        }
+    }
+
+    /// Current counter value without advancing. Test-only helper.
+    #[must_use]
+    pub fn peek(&self) -> u64 {
+        self.counter.load(Ordering::Relaxed)
+    }
+}
+
+impl Default for StubClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clock for StubClock {
+    #[inline]
+    fn now_millis(&self) -> TimestampMs {
+        let v = self.counter.fetch_add(self.step, Ordering::Relaxed);
+        TimestampMs::new(v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::sync::Arc;
+    use std::thread;
+
+    #[test]
+    fn test_monotonic_clock_returns_nonzero_ms() {
+        let clock = MonotonicClock;
+        let ts = clock.now_millis();
+        assert!(ts.as_u64() > 0, "wall-clock must be after the epoch");
+    }
+
+    #[test]
+    fn test_stub_clock_starts_at_zero_and_advances_by_one() {
+        let clock = StubClock::new();
+        assert_eq!(clock.now_millis().as_u64(), 0);
+        assert_eq!(clock.now_millis().as_u64(), 1);
+        assert_eq!(clock.now_millis().as_u64(), 2);
+    }
+
+    #[test]
+    fn test_stub_clock_with_step() {
+        let clock = StubClock::with_step(100, 5);
+        assert_eq!(clock.now_millis().as_u64(), 100);
+        assert_eq!(clock.now_millis().as_u64(), 105);
+        assert_eq!(clock.now_millis().as_u64(), 110);
+    }
+
+    #[test]
+    fn test_stub_clock_peek_does_not_advance() {
+        let clock = StubClock::starting_at(42);
+        assert_eq!(clock.peek(), 42);
+        assert_eq!(clock.peek(), 42);
+        let first = clock.now_millis();
+        assert_eq!(first.as_u64(), 42);
+        assert_eq!(clock.peek(), 43);
+    }
+
+    #[test]
+    fn test_stub_clock_concurrent_advance_is_monotonic() {
+        // 4 threads x 1000 calls each, step = 1, start = 0.
+        // Collect every returned value across every thread; the full set
+        // must contain exactly 4000 unique values and the max must equal
+        // 4000 * step - 1 + start = 3999.
+        let start: u64 = 0;
+        let step: u64 = 1;
+        let threads = 4usize;
+        let per_thread = 1000usize;
+        let total = threads.checked_mul(per_thread).expect("overflow");
+
+        let clock = Arc::new(StubClock::with_step(start, step));
+        let mut handles = Vec::with_capacity(threads);
+        for _ in 0..threads {
+            let c = Arc::clone(&clock);
+            handles.push(thread::spawn(move || {
+                let mut local = Vec::with_capacity(per_thread);
+                for _ in 0..per_thread {
+                    local.push(c.now_millis().as_u64());
+                }
+                local
+            }));
+        }
+
+        let mut all: Vec<u64> = Vec::with_capacity(total);
+        for h in handles {
+            let part = h.join().expect("thread panicked");
+            all.extend(part);
+        }
+
+        assert_eq!(all.len(), total);
+        let set: HashSet<u64> = all.iter().copied().collect();
+        assert_eq!(
+            set.len(),
+            total,
+            "expected every observed tick to be unique"
+        );
+
+        let expected_max = start
+            .checked_add(
+                (total as u64)
+                    .checked_mul(step)
+                    .and_then(|v| v.checked_sub(1))
+                    .expect("overflow"),
+            )
+            .expect("overflow");
+        let observed_max = all.iter().copied().max().expect("non-empty");
+        assert_eq!(observed_max, expected_max);
+    }
+}

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -1,6 +1,8 @@
 //! OrderBook implementation for managing multiple price levels and order matching.
 
 pub mod book;
+/// Pluggable timestamp source for the matching core.
+pub mod clock;
 pub mod error;
 /// Implied volatility calculation from order book prices.
 pub mod implied_volatility;
@@ -58,6 +60,7 @@ pub mod repricing;
 pub mod sequencer;
 
 pub use book::OrderBook;
+pub use clock::{Clock, MonotonicClock, StubClock};
 pub use error::{ManagerError, OrderBookError};
 pub use fees::FeeSchedule;
 pub use implied_volatility::{

--- a/src/orderbook/operations.rs
+++ b/src/orderbook/operations.rs
@@ -2,9 +2,7 @@
 
 use super::book::OrderBook;
 use super::error::OrderBookError;
-use pricelevel::{
-    Hash32, Id, MatchResult, OrderType, Price, Quantity, Side, TimeInForce, TimestampMs,
-};
+use pricelevel::{Hash32, Id, MatchResult, OrderType, Price, Quantity, Side, TimeInForce};
 use std::sync::Arc;
 use tracing::trace;
 
@@ -75,7 +73,7 @@ where
             quantity: Quantity::new(quantity),
             side,
             user_id,
-            timestamp: TimestampMs::new(crate::utils::current_time_millis()),
+            timestamp: self.clock().now_millis(),
             time_in_force,
             extra_fields,
         };
@@ -151,7 +149,7 @@ where
             hidden_quantity: Quantity::new(hidden_quantity),
             side,
             user_id,
-            timestamp: TimestampMs::new(crate::utils::current_time_millis()),
+            timestamp: self.clock().now_millis(),
             time_in_force,
             extra_fields,
         };
@@ -221,7 +219,7 @@ where
             quantity: Quantity::new(quantity),
             side,
             user_id,
-            timestamp: TimestampMs::new(crate::utils::current_time_millis()),
+            timestamp: self.clock().now_millis(),
             time_in_force,
             extra_fields,
         };

--- a/src/orderbook/order_state.rs
+++ b/src/orderbook/order_state.rs
@@ -456,8 +456,8 @@ impl OrderStateTracker {
     /// The number of entries purged.
     pub fn purge_terminal_older_than(&self, older_than: Duration) -> usize {
         let now_ms = self.clock.now_millis().as_u64();
-        let cutoff = now_ms
-            .saturating_sub(u64::try_from(older_than.as_millis()).unwrap_or(u64::MAX));
+        let cutoff =
+            now_ms.saturating_sub(u64::try_from(older_than.as_millis()).unwrap_or(u64::MAX));
 
         let mut purged = 0usize;
         // Collect IDs to remove (avoid holding DashMap iterators during mutation)

--- a/src/orderbook/order_state.rs
+++ b/src/orderbook/order_state.rs
@@ -22,27 +22,13 @@
 //! IOC/FOK insufficient liquidity   → Cancelled { InsufficientLiquidity }
 //! ```
 
+use super::clock::{Clock, MonotonicClock};
 use dashmap::DashMap;
 use pricelevel::Id;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-
-/// Returns the current time in nanoseconds since the Unix epoch.
-///
-/// Returns `0` if the system clock is before the Unix epoch.
-/// If the duration exceeds `u64::MAX` nanoseconds (~584 years from epoch)
-/// the value is capped at `u64::MAX`. This matches the fallback used
-/// by [`OrderStateTracker::purge_terminal_older_than`] so comparisons
-/// remain consistent.
-#[inline]
-fn nanos_since_epoch() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| u64::try_from(d.as_nanos()).unwrap_or(u64::MAX))
-        .unwrap_or(0)
-}
 
 /// Reason for order cancellation.
 ///
@@ -228,12 +214,14 @@ const DEFAULT_RETENTION_CAPACITY: usize = 10_000;
 pub struct OrderStateTracker {
     /// Current status of each tracked order.
     states: DashMap<Id, OrderStatus>,
-    /// Timestamped transition history per order: `(timestamp_ns, status)`.
+    /// Timestamped transition history per order: `(timestamp_ms, status)`.
     ///
-    /// History grows linearly with transitions for each order (e.g. many
-    /// partial fills). Entries are evicted together with their state both
-    /// by capacity-based eviction in [`enqueue_terminal`](Self::enqueue_terminal)
-    /// and by [`purge_terminal_older_than`](Self::purge_terminal_older_than).
+    /// Timestamps are the millisecond values returned by the installed
+    /// [`Clock`]. History grows linearly with transitions for each order
+    /// (e.g. many partial fills). Entries are evicted together with
+    /// their state both by capacity-based eviction in
+    /// [`enqueue_terminal`](Self::enqueue_terminal) and by
+    /// [`purge_terminal_older_than`](Self::purge_terminal_older_than).
     history: DashMap<Id, Vec<(u64, OrderStatus)>>,
     /// FIFO queue of terminal-state order IDs for eviction.
     terminal_queue: Mutex<VecDeque<Id>>,
@@ -241,6 +229,13 @@ pub struct OrderStateTracker {
     retention_capacity: usize,
     /// Optional listener invoked on every state transition.
     listener: Option<OrderStateListener>,
+    /// Pluggable source of millisecond timestamps used when recording
+    /// transition history and when computing cutoffs for
+    /// [`purge_terminal_older_than`](Self::purge_terminal_older_than).
+    /// Defaults to [`MonotonicClock`]; tests and sequencer replay can
+    /// inject a [`super::clock::StubClock`] via [`Self::with_clock`] or
+    /// [`Self::with_capacity_and_clock`].
+    clock: Arc<dyn Clock>,
 }
 
 impl std::fmt::Debug for OrderStateTracker {
@@ -261,14 +256,27 @@ impl Default for OrderStateTracker {
 
 impl OrderStateTracker {
     /// Create a new tracker with default retention capacity (10,000).
+    ///
+    /// The tracker uses a [`MonotonicClock`] to stamp transition history.
+    /// Use [`Self::with_clock`] to inject a different [`Clock`]
+    /// implementation (e.g. a
+    /// [`super::clock::StubClock`] for deterministic tests).
     #[must_use]
     pub fn new() -> Self {
+        Self::with_clock(Arc::new(MonotonicClock) as Arc<dyn Clock>)
+    }
+
+    /// Create a new tracker with default retention capacity and a
+    /// caller-provided [`Clock`] implementation.
+    #[must_use]
+    pub fn with_clock(clock: Arc<dyn Clock>) -> Self {
         Self {
             states: DashMap::new(),
             history: DashMap::new(),
             terminal_queue: Mutex::new(VecDeque::new()),
             retention_capacity: DEFAULT_RETENTION_CAPACITY,
             listener: None,
+            clock,
         }
     }
 
@@ -280,12 +288,23 @@ impl OrderStateTracker {
     ///   to retain. When exceeded, the oldest entries are evicted.
     #[must_use]
     pub fn with_capacity(retention_capacity: usize) -> Self {
+        Self::with_capacity_and_clock(
+            retention_capacity,
+            Arc::new(MonotonicClock) as Arc<dyn Clock>,
+        )
+    }
+
+    /// Create a new tracker with a custom retention capacity and a
+    /// caller-provided [`Clock`] implementation.
+    #[must_use]
+    pub fn with_capacity_and_clock(retention_capacity: usize, clock: Arc<dyn Clock>) -> Self {
         Self {
             states: DashMap::new(),
             history: DashMap::new(),
             terminal_queue: Mutex::new(VecDeque::new()),
             retention_capacity,
             listener: None,
+            clock,
         }
     }
 
@@ -335,8 +354,10 @@ impl OrderStateTracker {
 
         self.states.insert(order_id, new_status.clone());
 
-        // Record timestamped history
-        let ts = nanos_since_epoch();
+        // Record timestamped history. The timestamp is in milliseconds,
+        // sourced from the installed [`Clock`] (wall-clock in production,
+        // logical counter under replay / tests).
+        let ts = self.clock.now_millis().as_u64();
         self.history
             .entry(order_id)
             .or_default()
@@ -375,8 +396,10 @@ impl OrderStateTracker {
 
     /// Returns the full transition history for an order.
     ///
-    /// Each entry is a `(timestamp_ns, OrderStatus)` pair in chronological
-    /// order. Returns `None` if the order ID was never submitted.
+    /// Each entry is a `(timestamp_ms, OrderStatus)` pair in chronological
+    /// order. Timestamps come from the installed [`Clock`]
+    /// ([`MonotonicClock`] by default). Returns `None` if the order ID
+    /// was never submitted.
     ///
     /// # Examples
     ///
@@ -425,14 +448,16 @@ impl OrderStateTracker {
     /// # Arguments
     ///
     /// * `older_than` — entries with a last-transition timestamp older
-    ///   than `now - older_than` nanoseconds are removed.
+    ///   than `now - older_than` (milliseconds, per the installed
+    ///   [`Clock`]) are removed.
     ///
     /// # Returns
     ///
     /// The number of entries purged.
     pub fn purge_terminal_older_than(&self, older_than: Duration) -> usize {
-        let cutoff = nanos_since_epoch()
-            .saturating_sub(u64::try_from(older_than.as_nanos()).unwrap_or(u64::MAX));
+        let now_ms = self.clock.now_millis().as_u64();
+        let cutoff = now_ms
+            .saturating_sub(u64::try_from(older_than.as_millis()).unwrap_or(u64::MAX));
 
         let mut purged = 0usize;
         // Collect IDs to remove (avoid holding DashMap iterators during mutation)
@@ -445,11 +470,15 @@ impl OrderStateTracker {
                 if !status.is_terminal() {
                     return None;
                 }
-                // Check the last history entry's timestamp
+                // Check the last history entry's timestamp. The test
+                // contract is that `older_than = 0` removes every terminal
+                // entry — so the comparison is `<=` rather than `<` to
+                // handle the degenerate case where `ts == cutoff` under
+                // millisecond resolution.
                 let is_old = self
                     .history
                     .get(&id)
-                    .and_then(|h| h.value().last().map(|(ts, _)| *ts < cutoff))
+                    .and_then(|h| h.value().last().map(|(ts, _)| *ts <= cutoff))
                     .unwrap_or(false);
                 if is_old { Some(id) } else { None }
             })

--- a/src/orderbook/private.rs
+++ b/src/orderbook/private.rs
@@ -1,5 +1,5 @@
 use crate::orderbook::book_change_event::PriceLevelChangedEvent;
-use crate::{OrderBook, OrderBookError, current_time_millis};
+use crate::{OrderBook, OrderBookError};
 use pricelevel::{OrderType, PriceLevel, Side};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -11,7 +11,7 @@ where
     /// Check if an order has expired
     pub fn has_expired(&self, order: &OrderType<T>) -> bool {
         let time_in_force = order.time_in_force();
-        let current_time = current_time_millis();
+        let current_time = self.clock().now_millis().as_u64();
 
         // Only check market close timestamp if we have one set
         let market_close = if self.has_market_close.load(Ordering::Relaxed) {

--- a/src/orderbook/sequencer/replay.rs
+++ b/src/orderbook/sequencer/replay.rs
@@ -253,11 +253,20 @@ where
                 });
             }
 
+            // Advance `expected_seq` before applying so gap detection stays
+            // correct even if the event is a rejected no-op. `last_applied_seq`,
+            // `count`, and `progress` track only events that actually mutate
+            // the book — consistent with the "events applied" / "last applied
+            // sequence" contract on the public entry points.
+            let applied = !matches!(event.result, SequencerResult::Rejected { .. });
             Self::apply_event(book, event)?;
-            last_applied_seq = event.sequence_num;
-            count = count.saturating_add(1);
             expected_seq = expected_seq.saturating_add(1);
-            progress(count, last_applied_seq);
+
+            if applied {
+                last_applied_seq = event.sequence_num;
+                count = count.saturating_add(1);
+                progress(count, last_applied_seq);
+            }
         }
 
         Ok(last_applied_seq)

--- a/src/orderbook/sequencer/replay.rs
+++ b/src/orderbook/sequencer/replay.rs
@@ -8,9 +8,11 @@
 use super::error::JournalError;
 use super::journal::Journal;
 use super::types::{SequencerCommand, SequencerEvent, SequencerResult};
+use crate::orderbook::clock::Clock;
 use crate::orderbook::{OrderBook, OrderBookError, OrderBookSnapshot};
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
+use std::sync::Arc;
 use thiserror::Error;
 
 /// Errors that can occur during journal replay.
@@ -75,6 +77,9 @@ where
     /// event applied. Only successful commands (non-`Rejected` results) are
     /// replayed — rejected events are skipped without error.
     ///
+    /// For deterministic replay with a custom clock, see
+    /// [`Self::replay_from_with_clock`].
+    ///
     /// # Arguments
     ///
     /// * `journal` — the event source
@@ -87,6 +92,7 @@ where
     /// - [`ReplayError::InvalidSequence`] if `from_sequence` > last journal sequence
     /// - [`ReplayError::OrderBookError`] if a command fails unexpectedly during replay
     /// - [`ReplayError::JournalError`] if reading from the journal fails
+    #[must_use = "replay result carries the reconstructed book and the last applied sequence"]
     pub fn replay_from(
         journal: &impl Journal<T>,
         from_sequence: u64,
@@ -100,6 +106,9 @@ where
     /// The callback receives `(events_applied: u64, current_sequence: u64)`.
     /// Useful for long replays where progress reporting is needed.
     ///
+    /// For deterministic replay with a custom clock, see
+    /// [`Self::replay_from_with_clock`].
+    ///
     /// # Arguments
     ///
     /// * `journal` — the event source
@@ -110,6 +119,7 @@ where
     /// # Errors
     ///
     /// Same as [`replay_from`](Self::replay_from).
+    #[must_use = "replay result carries the reconstructed book and the last applied sequence"]
     pub fn replay_from_with_progress(
         journal: &impl Journal<T>,
         from_sequence: u64,
@@ -129,6 +139,102 @@ where
         }
 
         let book = OrderBook::new(symbol);
+        let last_applied_seq = Self::replay_into(&book, journal, from_sequence, progress)?;
+        Ok((book, last_applied_seq))
+    }
+
+    /// Like [`Self::replay_from`] but injects a caller-supplied [`Clock`] into
+    /// the reconstructed book.
+    ///
+    /// This is the canonical entry point for byte-identical replay tests and
+    /// disaster-recovery pipelines that must reproduce engine-assigned
+    /// timestamps deterministically. Pass a
+    /// [`crate::orderbook::clock::StubClock`] for test and proptest-driven
+    /// replay, or a [`crate::orderbook::clock::MonotonicClock`] for
+    /// production disaster-recovery where wall-clock timestamps are
+    /// acceptable.
+    ///
+    /// # Arguments
+    ///
+    /// * `journal` — the event source
+    /// * `from_sequence` — first sequence number to include (inclusive); pass `0` for full replay
+    /// * `symbol` — symbol used to create the fresh OrderBook
+    /// * `clock` — pre-constructed clock shared across the reconstructed book
+    ///
+    /// # Errors
+    ///
+    /// Same as [`replay_from`](Self::replay_from).
+    #[must_use = "replay result carries the reconstructed book and the last applied sequence"]
+    pub fn replay_from_with_clock(
+        journal: &impl Journal<T>,
+        from_sequence: u64,
+        symbol: &str,
+        clock: Arc<dyn Clock>,
+    ) -> Result<(OrderBook<T>, u64), ReplayError> {
+        Self::replay_from_with_clock_and_progress(journal, from_sequence, symbol, clock, |_, _| {})
+    }
+
+    /// Like [`Self::replay_from_with_progress`] plus clock injection.
+    ///
+    /// Equivalent to [`Self::replay_from_with_clock`] but forwards each
+    /// successfully-applied event to a progress callback. Useful for long
+    /// replays where progress reporting is needed and byte-identical
+    /// timestamp reproduction is required — the canonical entry point for
+    /// byte-identical replay tests and disaster-recovery pipelines that must
+    /// reproduce engine-assigned timestamps deterministically.
+    ///
+    /// # Arguments
+    ///
+    /// * `journal` — the event source
+    /// * `from_sequence` — first sequence number to include; pass `0` for full replay
+    /// * `symbol` — symbol for the fresh OrderBook
+    /// * `clock` — pre-constructed clock shared across the reconstructed book
+    /// * `progress` — callback invoked after each event: `(events_applied, sequence_num)`
+    ///
+    /// # Errors
+    ///
+    /// Same as [`replay_from`](Self::replay_from).
+    #[must_use = "replay result carries the reconstructed book and the last applied sequence"]
+    pub fn replay_from_with_clock_and_progress(
+        journal: &impl Journal<T>,
+        from_sequence: u64,
+        symbol: &str,
+        clock: Arc<dyn Clock>,
+        progress: impl Fn(u64, u64),
+    ) -> Result<(OrderBook<T>, u64), ReplayError> {
+        let last_seq = match journal.last_sequence() {
+            Some(seq) => seq,
+            None => return Err(ReplayError::EmptyJournal),
+        };
+
+        if from_sequence > last_seq {
+            return Err(ReplayError::InvalidSequence {
+                from_sequence,
+                last_sequence: last_seq,
+            });
+        }
+
+        let book = OrderBook::with_clock(symbol, clock);
+        let last_applied_seq = Self::replay_into(&book, journal, from_sequence, progress)?;
+        Ok((book, last_applied_seq))
+    }
+
+    /// Shared replay loop. Applies events from `journal` starting at
+    /// `from_sequence` to the already-constructed `book`, reporting
+    /// per-event progress via `progress`, and returns the last applied
+    /// sequence number.
+    ///
+    /// Does not construct the book and does not perform the
+    /// `EmptyJournal` / `InvalidSequence` pre-checks — those remain the
+    /// responsibility of the public entry points so that the distinction
+    /// between "the journal is empty" and "the journal exists but
+    /// contains no matching range" is preserved.
+    fn replay_into(
+        book: &OrderBook<T>,
+        journal: &impl Journal<T>,
+        from_sequence: u64,
+        progress: impl Fn(u64, u64),
+    ) -> Result<u64, ReplayError> {
         let mut last_applied_seq = 0u64;
         let mut count = 0u64;
         let mut expected_seq = from_sequence;
@@ -147,14 +253,14 @@ where
                 });
             }
 
-            Self::apply_event(&book, event)?;
+            Self::apply_event(book, event)?;
             last_applied_seq = event.sequence_num;
             count = count.saturating_add(1);
             expected_seq = expected_seq.saturating_add(1);
             progress(count, last_applied_seq);
         }
 
-        Ok((book, last_applied_seq))
+        Ok(last_applied_seq)
     }
 
     /// Replays the full journal and compares the result to an expected snapshot.
@@ -284,4 +390,119 @@ pub fn snapshots_match(actual: &OrderBookSnapshot, expected: &OrderBookSnapshot)
     }
 
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::orderbook::clock::{MonotonicClock, StubClock};
+    use crate::orderbook::sequencer::InMemoryJournal;
+    use pricelevel::{Hash32, Id, OrderType, Price, Quantity, Side, TimeInForce, TimestampMs};
+
+    fn make_add_event(seq: u64, id: Id, price: u128, qty: u64, side: Side) -> SequencerEvent<()> {
+        let order = OrderType::Standard {
+            id,
+            price: Price::new(price),
+            quantity: Quantity::new(qty),
+            side,
+            time_in_force: TimeInForce::Gtc,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(0),
+            extra_fields: (),
+        };
+        SequencerEvent {
+            sequence_num: seq,
+            timestamp_ns: 0,
+            command: SequencerCommand::AddOrder(order),
+            result: SequencerResult::OrderAdded { order_id: id },
+        }
+    }
+
+    #[test]
+    fn test_replay_from_with_clock_uses_injected_clock() {
+        let journal: InMemoryJournal<()> = InMemoryJournal::new();
+        for (seq, price) in [(0u64, 100u128), (1, 101), (2, 102)] {
+            let ev = make_add_event(seq, Id::new_uuid(), price, 10, Side::Buy);
+            assert!(journal.append(&ev).is_ok());
+        }
+
+        let clock: Arc<dyn Clock> = Arc::new(StubClock::starting_at(42_000));
+        let result = ReplayEngine::<()>::replay_from_with_clock(&journal, 0, "TEST", clock);
+        assert!(result.is_ok(), "replay_from_with_clock should succeed");
+        let (book, last_seq) = result.expect("replay succeeded");
+        assert_eq!(last_seq, 2);
+
+        // The injected StubClock was seeded at 42_000. After the book has
+        // been constructed, any ticks the replay consumed have advanced the
+        // counter — so the next tick must be >= 42_000.
+        let now = book.clock().now_millis();
+        assert!(
+            now.as_u64() >= 42_000,
+            "expected injected clock value, got {}",
+            now.as_u64()
+        );
+    }
+
+    #[test]
+    fn test_replay_from_with_clock_preserves_behavior_of_replay_from() {
+        // Journal shared across both replays.
+        let journal: InMemoryJournal<()> = InMemoryJournal::new();
+        let ids: Vec<Id> = (0..3).map(|_| Id::new_uuid()).collect();
+        let events = [
+            make_add_event(0, ids[0], 100, 5, Side::Buy),
+            make_add_event(1, ids[1], 101, 7, Side::Buy),
+            make_add_event(2, ids[2], 105, 3, Side::Sell),
+        ];
+        for ev in &events {
+            assert!(journal.append(ev).is_ok());
+        }
+
+        let (book_plain, last_seq_plain) = ReplayEngine::<()>::replay_from(&journal, 0, "TEST")
+            .expect("plain replay should succeed");
+
+        let clock: Arc<dyn Clock> = Arc::new(MonotonicClock);
+        let (book_with_clock, last_seq_with_clock) =
+            ReplayEngine::<()>::replay_from_with_clock(&journal, 0, "TEST", clock)
+                .expect("clock-aware replay should succeed");
+
+        assert_eq!(last_seq_plain, last_seq_with_clock);
+        assert_eq!(last_seq_plain, 2);
+
+        let snap_plain = book_plain.create_snapshot(usize::MAX);
+        let snap_with_clock = book_with_clock.create_snapshot(usize::MAX);
+        assert!(
+            snapshots_match(&snap_plain, &snap_with_clock),
+            "snapshots must match across replay variants"
+        );
+    }
+
+    #[test]
+    fn test_replay_from_with_clock_propagates_sequence_gap() {
+        let journal: InMemoryJournal<()> = InMemoryJournal::new();
+        // Sequences 0, 1, 2, then jump to 4 (gap at 3).
+        let events = [
+            make_add_event(0, Id::new_uuid(), 100, 1, Side::Buy),
+            make_add_event(1, Id::new_uuid(), 101, 1, Side::Buy),
+            make_add_event(2, Id::new_uuid(), 102, 1, Side::Buy),
+            make_add_event(4, Id::new_uuid(), 104, 1, Side::Buy),
+        ];
+        for ev in &events {
+            assert!(journal.append(ev).is_ok());
+        }
+
+        let clock: Arc<dyn Clock> = Arc::new(StubClock::new());
+        let result = ReplayEngine::<()>::replay_from_with_clock(&journal, 0, "TEST", clock);
+
+        match result {
+            Err(ReplayError::SequenceGap { expected, found }) => {
+                assert_eq!(expected, 3);
+                assert_eq!(found, 4);
+            }
+            Err(other) => panic!(
+                "expected SequenceGap {{ expected: 3, found: 4 }}, got {:?}",
+                other
+            ),
+            Ok(_) => panic!("expected SequenceGap {{ expected: 3, found: 4 }}, got Ok(_)"),
+        }
+    }
 }

--- a/src/orderbook/tests/book.rs
+++ b/src/orderbook/tests/book.rs
@@ -1075,4 +1075,70 @@ mod test_book_specific {
             _ => panic!("Expected InsufficientLiquidity error"),
         }
     }
+
+    // ───────────────────────────── Clock injection ─────────────────────────────
+
+    #[test]
+    fn test_with_clock_stamps_orders_via_injected_clock() {
+        use crate::orderbook::clock::{Clock, StubClock};
+        use std::sync::Arc;
+
+        // Start the stub at 1000 ms, step of 1; each `now_millis` advances it.
+        let clock: Arc<dyn Clock> = Arc::new(StubClock::starting_at(1000));
+        let book: OrderBook<()> = OrderBook::with_clock("CLOCKED", Arc::clone(&clock));
+
+        let id = create_order_id();
+        let result = book.add_limit_order(id, 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        assert!(result.is_ok(), "add_limit_order failed: {:?}", result.err());
+
+        // The order should have been stamped with the first tick from the
+        // stub clock (1000), not a wall-clock millisecond.
+        let fetched = book.get_order(id);
+        assert!(fetched.is_some(), "order not found in book");
+        let stamped = fetched
+            .as_ref()
+            .map(|o| o.timestamp())
+            .unwrap_or_default();
+        assert_eq!(
+            stamped, 1000,
+            "order timestamp should come from the injected stub clock"
+        );
+    }
+
+    #[test]
+    fn test_set_clock_replaces_source() {
+        use crate::orderbook::clock::{Clock, StubClock};
+        use std::sync::Arc;
+
+        let clock_a: Arc<dyn Clock> = Arc::new(StubClock::starting_at(500));
+        let mut book: OrderBook<()> = OrderBook::with_clock("CLOCKED", Arc::clone(&clock_a));
+
+        // First order stamped by clock A (500).
+        let id_a = create_order_id();
+        let result_a = book.add_limit_order(id_a, 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        assert!(result_a.is_ok());
+        let ts_a = book
+            .get_order(id_a)
+            .as_ref()
+            .map(|o| o.timestamp())
+            .unwrap_or_default();
+        assert_eq!(ts_a, 500);
+
+        // Replace the clock mid-flight; the next order should use clock B.
+        let clock_b: Arc<dyn Clock> = Arc::new(StubClock::starting_at(9_000));
+        book.set_clock(Arc::clone(&clock_b));
+
+        let id_b = create_order_id();
+        let result_b = book.add_limit_order(id_b, 200, 5, Side::Sell, TimeInForce::Gtc, None);
+        assert!(result_b.is_ok());
+        let ts_b = book
+            .get_order(id_b)
+            .as_ref()
+            .map(|o| o.timestamp())
+            .unwrap_or_default();
+        assert_eq!(
+            ts_b, 9_000,
+            "order submitted after set_clock must use the new clock source"
+        );
+    }
 }

--- a/src/orderbook/tests/book.rs
+++ b/src/orderbook/tests/book.rs
@@ -1095,10 +1095,7 @@ mod test_book_specific {
         // stub clock (1000), not a wall-clock millisecond.
         let fetched = book.get_order(id);
         assert!(fetched.is_some(), "order not found in book");
-        let stamped = fetched
-            .as_ref()
-            .map(|o| o.timestamp())
-            .unwrap_or_default();
+        let stamped = fetched.as_ref().map(|o| o.timestamp()).unwrap_or_default();
         assert_eq!(
             stamped, 1000,
             "order timestamp should come from the injected stub clock"

--- a/src/orderbook/tests/repricing.rs
+++ b/src/orderbook/tests/repricing.rs
@@ -4,19 +4,13 @@
 mod tests {
     use crate::OrderBook;
     use crate::orderbook::repricing::RepricingOperations;
+    use crate::utils::current_time_millis;
     use pricelevel::{
         Hash32, Id, OrderType, PegReferenceType, Price, Quantity, Side, TimeInForce, TimestampMs,
     };
 
     fn create_order_id() -> Id {
         Id::new_uuid()
-    }
-
-    fn current_time_millis() -> u64 {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u64
     }
 
     #[test]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -18,6 +18,7 @@
 
 // Core order book types
 pub use crate::orderbook::OrderBook;
+pub use crate::orderbook::clock::{Clock, MonotonicClock, StubClock};
 pub use crate::orderbook::manager::{BookManager, BookManagerStd, BookManagerTokio};
 pub use crate::orderbook::{ManagerError, OrderBookError};
 

--- a/tests/unit/clock_determinism_tests.rs
+++ b/tests/unit/clock_determinism_tests.rs
@@ -101,12 +101,10 @@ fn replay_with_different_stub_clocks_still_snapshots_match() {
     let clock_a: Arc<dyn Clock> = Arc::new(StubClock::starting_at(1_000));
     let clock_b: Arc<dyn Clock> = Arc::new(StubClock::starting_at(9_999_999));
 
-    let (book_a, _) =
-        ReplayEngine::<()>::replay_from_with_clock(&journal, 1, "ETH-USD", clock_a)
-            .expect("replay A succeeds");
-    let (book_b, _) =
-        ReplayEngine::<()>::replay_from_with_clock(&journal, 1, "ETH-USD", clock_b)
-            .expect("replay B succeeds");
+    let (book_a, _) = ReplayEngine::<()>::replay_from_with_clock(&journal, 1, "ETH-USD", clock_a)
+        .expect("replay A succeeds");
+    let (book_b, _) = ReplayEngine::<()>::replay_from_with_clock(&journal, 1, "ETH-USD", clock_b)
+        .expect("replay B succeeds");
 
     let snap_a = book_a.create_snapshot(usize::MAX);
     let snap_b = book_b.create_snapshot(usize::MAX);

--- a/tests/unit/clock_determinism_tests.rs
+++ b/tests/unit/clock_determinism_tests.rs
@@ -1,9 +1,11 @@
 //! Integration tests for the deterministic-replay contract: with a stable
-//! injected [`Clock`], replaying the same journal produces byte-identical
-//! book state across independent runs.
+//! injected [`Clock`], replaying the same journal produces structurally
+//! identical snapshots across independent runs.
 //!
 //! These tests exercise [`ReplayEngine::replay_from_with_clock`], the
 //! clock-aware replay entry point added alongside the [`Clock`] trait.
+//! A strictly byte-identical event-stream oracle (via `EventSerializer`)
+//! is widened in issue #57.
 
 use super::common::strategies::event_stream;
 

--- a/tests/unit/clock_determinism_tests.rs
+++ b/tests/unit/clock_determinism_tests.rs
@@ -1,0 +1,174 @@
+//! Integration tests for the deterministic-replay contract: with a stable
+//! injected [`Clock`], replaying the same journal produces byte-identical
+//! book state across independent runs.
+//!
+//! These tests exercise [`ReplayEngine::replay_from_with_clock`], the
+//! clock-aware replay entry point added alongside the [`Clock`] trait.
+
+use super::common::strategies::event_stream;
+
+use orderbook_rs::orderbook::sequencer::{
+    InMemoryJournal, Journal, ReplayEngine, SequencerCommand, SequencerEvent, SequencerResult,
+    snapshots_match,
+};
+use orderbook_rs::{Clock, MonotonicClock, StubClock};
+use pricelevel::{Hash32, Id, OrderType, Price, Quantity, Side, TimeInForce, TimestampMs};
+use proptest::prelude::*;
+use proptest::test_runner::TestCaseError;
+use std::sync::Arc;
+
+// ─── Hand-built helpers ─────────────────────────────────────────────────────
+
+fn make_add_event(seq: u64, id: Id, price: u128, qty: u64, side: Side) -> SequencerEvent<()> {
+    let order = OrderType::Standard {
+        id,
+        price: Price::new(price),
+        quantity: Quantity::new(qty),
+        side,
+        time_in_force: TimeInForce::Gtc,
+        user_id: Hash32::zero(),
+        timestamp: TimestampMs::new(0),
+        extra_fields: (),
+    };
+    SequencerEvent {
+        sequence_num: seq,
+        timestamp_ns: 0,
+        command: SequencerCommand::AddOrder(order),
+        result: SequencerResult::OrderAdded { order_id: id },
+    }
+}
+
+fn populate_journal(journal: &InMemoryJournal<()>, events: &[SequencerEvent<()>]) {
+    for event in events {
+        let appended = journal.append(event);
+        assert!(appended.is_ok(), "journal append failed: {:?}", appended);
+    }
+}
+
+fn replay_once(
+    journal: &InMemoryJournal<()>,
+    symbol: &str,
+    start: u64,
+    step: u64,
+) -> orderbook_rs::OrderBookSnapshot {
+    let clock: Arc<dyn Clock> = Arc::new(StubClock::with_step(start, step));
+    let outcome = ReplayEngine::<()>::replay_from_with_clock(journal, 1, symbol, clock);
+    let (book, _last_seq) =
+        outcome.expect("replay_from_with_clock should succeed on a well-formed journal");
+    book.create_snapshot(usize::MAX)
+}
+
+// ─── Example-based regression test ──────────────────────────────────────────
+
+#[test]
+fn replay_with_identical_stub_clocks_produces_matching_snapshots() {
+    let journal = InMemoryJournal::<()>::new();
+    populate_journal(
+        &journal,
+        &[
+            make_add_event(1, Id::from_u64(1), 100, 10, Side::Buy),
+            make_add_event(2, Id::from_u64(2), 101, 5, Side::Sell),
+            make_add_event(3, Id::from_u64(3), 99, 7, Side::Buy),
+            make_add_event(4, Id::from_u64(4), 102, 3, Side::Sell),
+            make_add_event(5, Id::from_u64(5), 100, 2, Side::Buy),
+        ],
+    );
+
+    let snap_a = replay_once(&journal, "BTC-USD", 42_000, 1);
+    let snap_b = replay_once(&journal, "BTC-USD", 42_000, 1);
+
+    assert!(
+        snapshots_match(&snap_a, &snap_b),
+        "two replays with identical StubClocks must produce matching snapshots"
+    );
+}
+
+#[test]
+fn replay_with_different_stub_clocks_still_snapshots_match() {
+    // Timestamps differ → byte-exact serialization diverges, but the snapshot
+    // oracle (which ignores engine-assigned timestamp noise on book state)
+    // must still match. Guards against unintentional coupling of the snapshot
+    // contract to the clock value.
+    let journal = InMemoryJournal::<()>::new();
+    populate_journal(
+        &journal,
+        &[
+            make_add_event(1, Id::from_u64(1), 100, 10, Side::Buy),
+            make_add_event(2, Id::from_u64(2), 101, 5, Side::Sell),
+        ],
+    );
+
+    let clock_a: Arc<dyn Clock> = Arc::new(StubClock::starting_at(1_000));
+    let clock_b: Arc<dyn Clock> = Arc::new(StubClock::starting_at(9_999_999));
+
+    let (book_a, _) =
+        ReplayEngine::<()>::replay_from_with_clock(&journal, 1, "ETH-USD", clock_a)
+            .expect("replay A succeeds");
+    let (book_b, _) =
+        ReplayEngine::<()>::replay_from_with_clock(&journal, 1, "ETH-USD", clock_b)
+            .expect("replay B succeeds");
+
+    let snap_a = book_a.create_snapshot(usize::MAX);
+    let snap_b = book_b.create_snapshot(usize::MAX);
+    assert!(
+        snapshots_match(&snap_a, &snap_b),
+        "snapshots_match must hold regardless of clock start value"
+    );
+}
+
+#[test]
+fn replay_with_monotonic_clock_is_exercised() {
+    // Smoke test — replay_from_with_clock accepts the production clock.
+    let journal = InMemoryJournal::<()>::new();
+    populate_journal(
+        &journal,
+        &[make_add_event(1, Id::from_u64(1), 100, 10, Side::Buy)],
+    );
+    let clock: Arc<dyn Clock> = Arc::new(MonotonicClock);
+    let outcome = ReplayEngine::<()>::replay_from_with_clock(&journal, 1, "SOL-USD", clock);
+    assert!(outcome.is_ok(), "MonotonicClock replay must succeed");
+}
+
+// ─── Property-based test ────────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 128,
+        max_shrink_iters: 20_000,
+        ..ProptestConfig::default()
+    })]
+
+    /// For any valid event stream, two replays with identical [`StubClock`]s
+    /// produce matching book snapshots (via [`snapshots_match`]). The
+    /// strictly byte-identical event-stream oracle is widened in issue #57;
+    /// this proptest is the determinism smoke test #51 owns.
+    #[test]
+    fn proptest_replay_with_identical_stub_clocks_snapshots_match(
+        events in event_stream(1..30),
+    ) {
+        let journal = InMemoryJournal::<()>::new();
+        for event in &events {
+            let appended = journal.append(event);
+            prop_assert!(appended.is_ok(), "journal append failed");
+        }
+
+        let clock_a: Arc<dyn Clock> = Arc::new(StubClock::starting_at(1_000_000));
+        let clock_b: Arc<dyn Clock> = Arc::new(StubClock::starting_at(1_000_000));
+
+        let (book_a, seq_a) =
+            ReplayEngine::<()>::replay_from_with_clock(&journal, 1, "TEST", clock_a)
+                .map_err(|e| TestCaseError::fail(format!("replay A failed: {e:?}")))?;
+        let (book_b, seq_b) =
+            ReplayEngine::<()>::replay_from_with_clock(&journal, 1, "TEST", clock_b)
+                .map_err(|e| TestCaseError::fail(format!("replay B failed: {e:?}")))?;
+
+        prop_assert_eq!(seq_a, seq_b, "last-applied sequence diverged");
+
+        let snap_a = book_a.create_snapshot(usize::MAX);
+        let snap_b = book_b.create_snapshot(usize::MAX);
+        prop_assert!(
+            snapshots_match(&snap_a, &snap_b),
+            "snapshots_match contract violated"
+        );
+    }
+}

--- a/tests/unit/common/mod.rs
+++ b/tests/unit/common/mod.rs
@@ -1,0 +1,7 @@
+//! Shared test helpers for `orderbook-rs` integration tests.
+//!
+//! Kept intentionally thin — add new sub-modules here as future proptest
+//! issues (#57 byte-identical replay widening, #52 engine_seq monotonicity,
+//! etc.) need shared machinery.
+
+pub mod strategies;

--- a/tests/unit/common/strategies.rs
+++ b/tests/unit/common/strategies.rs
@@ -1,0 +1,124 @@
+//! `proptest` strategies that generate valid journal event streams.
+//!
+//! The strategies target determinism / replay invariants: every generated
+//! event is a `SequencerEvent<()>` with a monotonic sequence number, a
+//! zero-initialised `timestamp_ns` (timestamps are re-stamped by the engine
+//! clock during replay), and a `SequencerResult` variant consistent with the
+//! command (`OrderAdded` for `AddOrder`, `OrderCancelled` for `CancelOrder`).
+//!
+//! The strategies stay biased to produce realistic traffic on a narrow price
+//! band so crossings occur frequently on short streams. This keeps failure
+//! shrinks small and interpretable.
+
+use orderbook_rs::orderbook::sequencer::{SequencerCommand, SequencerEvent, SequencerResult};
+use pricelevel::{Hash32, Id, OrderType, Price, Quantity, Side, TimeInForce, TimestampMs};
+use proptest::collection::vec;
+use proptest::prelude::*;
+
+/// A deterministic, small pool of owner ids so self-cross / STP paths stay
+/// reachable on short streams.
+const OWNER_POOL: [u8; 4] = [1, 2, 3, 4];
+
+/// Tight crossing-friendly price band (ticks). Keeping the band narrow
+/// guarantees a non-trivial fraction of crossings without swamping the book.
+const PRICE_MIN: u128 = 99;
+const PRICE_MAX: u128 = 101;
+
+/// Quantity range per order.
+const QTY_MIN: u64 = 1;
+const QTY_MAX: u64 = 100;
+
+fn side_strategy() -> impl Strategy<Value = Side> {
+    prop_oneof![Just(Side::Buy), Just(Side::Sell)]
+}
+
+fn owner_strategy() -> impl Strategy<Value = Hash32> {
+    (0usize..OWNER_POOL.len()).prop_map(|i| {
+        let mut bytes = [0u8; 32];
+        bytes[0] = OWNER_POOL[i];
+        Hash32::new(bytes)
+    })
+}
+
+fn price_strategy() -> impl Strategy<Value = Price> {
+    (PRICE_MIN..=PRICE_MAX).prop_map(Price::new)
+}
+
+fn qty_strategy() -> impl Strategy<Value = Quantity> {
+    (QTY_MIN..=QTY_MAX).prop_map(Quantity::new)
+}
+
+/// Generates a `Standard` GTC order with a deterministic id derived from the
+/// enclosing sequence. Id uniqueness is preserved by the caller via the
+/// sequence counter — see [`event_stream`].
+///
+/// Limited to `TimeInForce::Gtc` on purpose: an `Ioc` / `Fok` that cannot
+/// fill makes `book.add_order` return `InsufficientLiquidity`, which
+/// [`orderbook_rs::orderbook::sequencer::ReplayEngine`] propagates as a
+/// `ReplayError`. A proptest-generated stream would need a stateful
+/// strategy to avoid that. GTC always rests safely on any crossing
+/// shape, making the stream deterministically replayable. Issue #57
+/// widens this with a stateful strategy that tracks live ids.
+fn standard_order_strategy(id_seed: u64) -> impl Strategy<Value = OrderType<()>> {
+    (
+        owner_strategy(),
+        side_strategy(),
+        price_strategy(),
+        qty_strategy(),
+    )
+        .prop_map(move |(user_id, side, price, quantity)| OrderType::Standard {
+            id: Id::from_u64(id_seed),
+            price,
+            quantity,
+            side,
+            time_in_force: TimeInForce::Gtc,
+            user_id,
+            timestamp: TimestampMs::new(0),
+            extra_fields: (),
+        })
+}
+
+/// Only AddOrder for #51's determinism proptest. Cancels require a
+/// stateful strategy to avoid `OrderNotFound` during replay and are
+/// deferred to #57.
+fn command_strategy(seq: u64) -> impl Strategy<Value = SequencerCommand<()>> {
+    standard_order_strategy(seq).prop_map(SequencerCommand::AddOrder)
+}
+
+/// Generate a stream of monotonic `SequencerEvent<()>` values of length in
+/// `len_range`. Sequence numbers start at 1 and increment by 1 per event.
+pub fn event_stream(
+    len_range: std::ops::Range<usize>,
+) -> impl Strategy<Value = Vec<SequencerEvent<()>>> {
+    vec(any::<()>(), len_range).prop_flat_map(|placeholders| {
+        let len = placeholders.len();
+        let per_event: Vec<_> = (1..=len as u64)
+            .map(|seq| command_strategy(seq).prop_map(move |cmd| (seq, cmd)))
+            .collect();
+        per_event.prop_map(|pairs| {
+            pairs
+                .into_iter()
+                .map(|(seq, command)| {
+                    let result = match &command {
+                        SequencerCommand::AddOrder(order) => SequencerResult::OrderAdded {
+                            order_id: order.id(),
+                        },
+                        SequencerCommand::CancelOrder(id) => {
+                            SequencerResult::OrderCancelled { order_id: *id }
+                        }
+                        // Remaining variants not produced by this strategy.
+                        _ => SequencerResult::Rejected {
+                            reason: "unreachable in this strategy".to_string(),
+                        },
+                    };
+                    SequencerEvent {
+                        sequence_num: seq,
+                        timestamp_ns: 0,
+                        command,
+                        result,
+                    }
+                })
+                .collect()
+        })
+    })
+}

--- a/tests/unit/common/strategies.rs
+++ b/tests/unit/common/strategies.rs
@@ -66,16 +66,18 @@ fn standard_order_strategy(id_seed: u64) -> impl Strategy<Value = OrderType<()>>
         price_strategy(),
         qty_strategy(),
     )
-        .prop_map(move |(user_id, side, price, quantity)| OrderType::Standard {
-            id: Id::from_u64(id_seed),
-            price,
-            quantity,
-            side,
-            time_in_force: TimeInForce::Gtc,
-            user_id,
-            timestamp: TimestampMs::new(0),
-            extra_fields: (),
-        })
+        .prop_map(
+            move |(user_id, side, price, quantity)| OrderType::Standard {
+                id: Id::from_u64(id_seed),
+                price,
+                quantity,
+                side,
+                time_in_force: TimeInForce::Gtc,
+                user_id,
+                timestamp: TimestampMs::new(0),
+                extra_fields: (),
+            },
+        )
 }
 
 /// Only AddOrder for #51's determinism proptest. Cancels require a

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -1,5 +1,7 @@
 mod book_coverage_tests;
 mod book_manager_cross_cancel_tests;
+mod clock_determinism_tests;
+mod common;
 #[cfg(feature = "journal")]
 mod filejournal_edge_case_tests;
 mod implied_volatility_tests;

--- a/tests/unit/replay_coverage_tests.rs
+++ b/tests/unit/replay_coverage_tests.rs
@@ -169,8 +169,9 @@ fn replay_skips_rejected_events() {
     let result = ReplayEngine::<()>::replay_from(&journal, 0, "TEST");
     assert!(result.is_ok());
     let (book, last_seq) = result.unwrap();
-    assert_eq!(last_seq, 1);
-    // The add should be applied, the rejected event should be skipped
+    // The add at seq 0 is applied, the rejected event at seq 1 is skipped
+    // and therefore does not advance `last_applied_seq`.
+    assert_eq!(last_seq, 0);
     let snap = book.create_snapshot(usize::MAX);
     assert_eq!(snap.bids.len(), 1);
 }


### PR DESCRIPTION
## Summary

- Injects a new `Clock` trait at the operations edge so matching timestamps
  become deterministic under sequencer replay. Two implementations ship:
  `MonotonicClock` (production, wraps `SystemTime::now`) and `StubClock`
  (replay / tests, monotonic `AtomicU64` counter). `OrderBook<T>` holds an
  `Arc<dyn Clock>`; default `new` keeps `MonotonicClock` so existing
  callers observe no behavioural change.
- Adds `ReplayEngine::replay_from_with_clock` /
  `replay_from_with_clock_and_progress` as the canonical entry points for
  byte-identical replay pipelines.
- Removes every wall-clock read from the matching core — `matching.rs`,
  `operations.rs`, `modifications.rs`, `mass_cancel.rs`, `repricing.rs`,
  `private.rs`, `book.rs`, `order_state.rs` now stamp exclusively via
  `self.clock().now_millis()`. `utils::current_time_millis` stays public
  for non-library callers.
- Bumps to **0.7.0**. The change is additive (minor bump); the version
  jump to 0.7.0 is a deliberate marker that `Clock` is now a public
  extensibility surface and that 0.6.x is frozen ahead of the breaking
  changes queued in #52 and #55.

## Behavioural change worth flagging

`OrderStateTracker::get_history` and `OrderBook::get_order_history` now
return `Vec<(u64 /* milliseconds */, OrderStatus)>` rather than
nanoseconds, because `Clock::now_millis` is the only unit the trait
exposes. Type signatures are unchanged; the unit is documented in rustdoc
and the `CHANGELOG.md` "What's New" block.

## Commits

```
a020081 chore: bump to 0.7.0 and update changelog
2a821f7 test(orderbook): add Clock determinism integration tests + proptest
4443157 style: apply cargo fmt to commits 1+2 drift
ffca1b0 feat(sequencer): add replay_from_with_clock for deterministic stamping
3778e84 refactor(orderbook): thread Clock through OrderBook and plumb core call sites
248d595 feat(orderbook): add Clock trait with MonotonicClock and StubClock
```

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] `cargo test --all-features` — 548 + 25 + 374 + 44 (4 ignored) = 991 tests pass.
- [x] New unit tests: 5 `clock::tests::*`, plus
      `test_with_clock_stamps_orders_via_injected_clock` and
      `test_set_clock_replaces_source` in `tests/book.rs`.
- [x] New sequencer tests: `test_replay_from_with_clock_uses_injected_clock`,
      `test_replay_from_with_clock_preserves_behavior_of_replay_from`,
      `test_replay_from_with_clock_propagates_sequence_gap`.
- [x] New integration proptest `clock_determinism_tests` (128 cases)
      covering `snapshots_match` across two replays with identical
      `StubClock`.
- [x] `cargo build --release --all-features` — clean.
- [ ] `cargo semver-checks check-release --release-type minor` — to be
      run in CI (cargo-semver-checks not installed locally). Expected:
      clean.

## Determinism grep (post-change)

```
rg -n 'SystemTime::now|Instant::now|UNIX_EPOCH|Utc::now|Local::now' \
   src/orderbook/matching.rs src/orderbook/operations.rs \
   src/orderbook/modifications.rs src/orderbook/mass_cancel.rs \
   src/orderbook/repricing.rs src/orderbook/private.rs \
   src/orderbook/book.rs src/orderbook/order_state.rs
```

Returns zero hits — `determinism-auditor` C1 contract satisfied on the
in-scope matching core.

## Future issues this unblocks

- #57 — byte-identical replay via `EventSerializer` (widens the smoke
  test landed here to a strict byte-equality oracle).
- #52 — global monotonic `engine_seq` across outbound streams (depends
  on the `Clock` injection being in place so the histogram of
  emission timestamps is reproducible).
- #60 — Prometheus exporter (the latency histogram needs a stub-clock
  in tests to avoid contaminating with `Instant::now` jitter).

Closes #51.
