### PR TITLE
Global monotonic engine_seq across outbound streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.0] — 2026-04-24
+## [0.7.0] — unreleased
 
-### Added
+> 0.7.0 is unreleased and accumulates issues #51..#60. Sub-headings
+> below group changes by feature; everything ships in the same
+> 0.7.0 publish.
+
+### Added — global `engine_seq` (#52)
+
+- **Global monotonic `engine_seq`** across every outbound stream.
+  `OrderBook<T>` gains an internal `AtomicU64` counter and two public
+  accessors: `pub fn next_engine_seq(&self) -> u64` (mints the next
+  value via `fetch_add(1, Relaxed)`) and `pub fn engine_seq(&self) -> u64`
+  (current value, used by snapshotting). The counter is incremented
+  exactly once per outbound emission, in emission order. Per-instance
+  contract — replay into a fresh book produces fresh seqs, not the
+  original ones; consumers needing the original outbound stream use
+  the journal's `SequencerEvent.sequence_num`.
+- **`engine_seq: u64` field** on every outbound event type. JSON
+  payloads are forward-compatible via `#[serde(default)]` where
+  applicable:
+  - `TradeResult.engine_seq`
+  - `TradeEvent.engine_seq`
+  - `PriceLevelChangedEvent.engine_seq`
+  - `BookChangeEntry.engine_seq` (NATS path, `Serialize`-only)
+- **Snapshot package persistence** — `OrderBookSnapshotPackage` carries
+  `engine_seq: u64` so `restore_from_snapshot_package` resumes
+  monotonicity exactly from the snapshotted point.
+- Integration proptest `tests/unit/engine_seq_monotonic_tests.rs`
+  (256 cases) asserts the cross-stream monotonicity contract.
+
+### Changed — global `engine_seq` (#52)
+
+- **`ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bumped from `1` to `2`.**
+  Snapshot packages with `version: 1` are now rejected by `validate()`
+  with the existing `Unsupported snapshot version` error. JSON payloads
+  at `version: 2` that omit `engine_seq` deserialize with `engine_seq = 0`.
+- **`BookChangeBatch.sequence`** retains its existing per-batch
+  publisher-counter semantics. Cross-stream gap detection now uses the
+  new per-event `BookChangeEntry.engine_seq` instead. Both fields ship
+  in the same payload; consumers can adopt the new field incrementally.
+
+### Added — `Clock` trait (#51)
 
 - **`Clock` trait** (`src/orderbook/clock.rs`) — pluggable timestamp source
   injected at the operations edge so matching stays deterministic under
@@ -48,13 +87,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Notes
 
-- Non-breaking public API surface. `cargo-semver-checks` should classify
-  this release as a minor bump; the version jump to `0.7.0` is a
-  deliberate marker that the `Clock` extensibility surface is now public.
-- Replay determinism: `ReplayEngine::replay_from` continues to behave as
-  before (production stamping via `MonotonicClock`). Byte-identical
+- Non-breaking public API surface for the Clock trait. The
+  `engine_seq` field adds (#52) extend public structs that consumers
+  may construct via struct literals; while `cargo-semver-checks` may
+  flag those, the `0.6.x → 0.7.x` delta in `0.x` semver permits
+  minor breaking changes.
+- Replay determinism: `ReplayEngine::replay_from` continues to behave
+  as before (production stamping via `MonotonicClock`). Byte-identical
   replay requires the new `replay_from_with_clock` entry point with a
   caller-supplied `Arc<StubClock>` and a fixed start value.
+- Snapshot format version bumped to `2`. Older `version: 1` snapshots
+  do not load. Re-snapshot under 0.7.0 to migrate.
 
 ## [0.6.2] — 2026-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,10 +87,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Notes
 
-- Non-breaking public API surface for the Clock trait. The
-  `engine_seq` field adds (#52) extend public structs that consumers
-  may construct via struct literals; while `cargo-semver-checks` may
-  flag those, the `0.6.x → 0.7.x` delta in `0.x` semver permits
+- Non-breaking public API surface for the Clock trait. Adding the
+  `engine_seq` fields extends public structs that consumers may
+  construct via struct literals; while `cargo-semver-checks`
+  may flag those, the `0.6.x → 0.7.x` delta in `0.x` semver permits
   minor breaking changes.
 - Replay determinism: `ReplayEngine::replay_from` continues to behave
   as before (production stamping via `MonotonicClock`). Byte-identical

--- a/README.md
+++ b/README.md
@@ -48,6 +48,27 @@ This order book engine is built with the following design principles:
 
 ### What's New in Version 0.7.0
 
+#### v0.7.0 — Global `engine_seq` across outbound streams
+
+- **New `OrderBook::next_engine_seq()` and `OrderBook::engine_seq()`**
+  accessors backed by an `AtomicU64` counter. Every outbound emission
+  (trade event, price-level change event) mints exactly one seq, in
+  emission order, so external consumers can perform cross-stream gap
+  detection and merge events from `TradeListener` and
+  `PriceLevelChangedListener` into a single ordered view.
+- **`engine_seq: u64` field** added to every outbound event type:
+  `TradeResult`, `TradeEvent`, `PriceLevelChangedEvent`, and the NATS
+  `BookChangeEntry`. JSON payloads are forward-compatible
+  (`#[serde(default)]` falls back to `0` for v0.6.x payloads).
+- **Snapshot format version bumped to `2`**.
+  `OrderBookSnapshotPackage` carries `engine_seq` so that
+  `restore_from_snapshot_package` resumes monotonicity exactly from the
+  snapshotted point. `version: 1` packages are rejected by `validate()`.
+- **`BookChangeBatch.sequence`** retains its existing per-batch
+  publisher-counter semantics; cross-stream gap detection moves to the
+  per-event `BookChangeEntry.engine_seq`. Both fields ship in the same
+  payload for incremental adoption.
+
 #### v0.7.0 — `Clock` trait for deterministic replay
 
 - **New [`Clock`] trait** with two implementations, [`MonotonicClock`]

--- a/benches/serialization.rs
+++ b/benches/serialization.rs
@@ -19,6 +19,7 @@ fn make_book_change() -> PriceLevelChangedEvent {
         side: Side::Buy,
         price: 50_000_000,
         quantity: 1_000,
+        engine_seq: 0,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,27 @@
 //!
 //! ## What's New in Version 0.7.0
 //!
+//! ### v0.7.0 — Global `engine_seq` across outbound streams
+//!
+//! - **New `OrderBook::next_engine_seq()` and `OrderBook::engine_seq()`**
+//!   accessors backed by an `AtomicU64` counter. Every outbound emission
+//!   (trade event, price-level change event) mints exactly one seq, in
+//!   emission order, so external consumers can perform cross-stream gap
+//!   detection and merge events from `TradeListener` and
+//!   `PriceLevelChangedListener` into a single ordered view.
+//! - **`engine_seq: u64` field** added to every outbound event type:
+//!   `TradeResult`, `TradeEvent`, `PriceLevelChangedEvent`, and the NATS
+//!   `BookChangeEntry`. JSON payloads are forward-compatible
+//!   (`#[serde(default)]` falls back to `0` for v0.6.x payloads).
+//! - **Snapshot format version bumped to `2`**.
+//!   `OrderBookSnapshotPackage` carries `engine_seq` so that
+//!   `restore_from_snapshot_package` resumes monotonicity exactly from the
+//!   snapshotted point. `version: 1` packages are rejected by `validate()`.
+//! - **`BookChangeBatch.sequence`** retains its existing per-batch
+//!   publisher-counter semantics; cross-stream gap detection moves to the
+//!   per-event `BookChangeEntry.engine_seq`. Both fields ship in the same
+//!   payload for incremental adoption.
+//!
 //! ### v0.7.0 — `Clock` trait for deterministic replay
 //!
 //! - **New [`Clock`] trait** with two implementations, [`MonotonicClock`]

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -66,6 +66,13 @@ pub struct OrderBook<T = ()> {
     #[allow(dead_code)]
     pub(super) next_order_id: AtomicU64,
 
+    /// Strictly monotonic sequence counter minted by [`Self::next_engine_seq`]
+    /// and stamped on every outbound event (`TradeResult`,
+    /// `PriceLevelChangedEvent`) so consumers can perform cross-stream gap
+    /// detection and temporal ordering. Per `OrderBook<T>` instance — replay
+    /// into a fresh book yields fresh seqs, not the originals.
+    pub(super) engine_seq: AtomicU64,
+
     /// The last price at which a trade occurred
     pub(super) last_trade_price: AtomicCell<u128>,
 
@@ -388,6 +395,7 @@ where
             user_orders: DashMap::new(),
             transaction_id_generator: UuidGenerator::new(namespace),
             next_order_id: AtomicU64::new(1),
+            engine_seq: AtomicU64::new(0),
             last_trade_price: AtomicCell::new(0),
             has_traded: AtomicBool::new(false),
             market_close_timestamp: AtomicU64::new(0),
@@ -423,6 +431,30 @@ where
     #[must_use]
     pub fn clock(&self) -> &Arc<dyn Clock> {
         &self.clock
+    }
+
+    /// Mint the next monotonic outbound sequence number.
+    ///
+    /// Called exactly once per outbound event (trade emission, price-level
+    /// change emission). Internally an `AtomicU64::fetch_add(1, Relaxed)` —
+    /// strict total order across all events of this `OrderBook<T>` instance.
+    ///
+    /// The contract is **per-instance**, not per-journal-stream: replay into
+    /// a fresh book produces fresh seqs, not the original ones. Consumers
+    /// that need to replay the exact original outbound stream should use
+    /// the journal's `sequence_num` + `timestamp_ns` instead.
+    #[inline]
+    pub fn next_engine_seq(&self) -> u64 {
+        self.engine_seq.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Current value of the engine sequence counter without advancing.
+    ///
+    /// Used by snapshotting to capture the counter for later restore.
+    #[inline]
+    #[must_use]
+    pub fn engine_seq(&self) -> u64 {
+        self.engine_seq.load(Ordering::Acquire)
     }
 
     /// Create a new order book for the given symbol with tick size validation.
@@ -473,6 +505,7 @@ where
             user_orders: DashMap::new(),
             transaction_id_generator: UuidGenerator::new(namespace),
             next_order_id: AtomicU64::new(1),
+            engine_seq: AtomicU64::new(0),
             last_trade_price: AtomicCell::new(0),
             has_traded: AtomicBool::new(false),
             market_close_timestamp: AtomicU64::new(0),
@@ -518,6 +551,7 @@ where
             user_orders: DashMap::new(),
             transaction_id_generator: UuidGenerator::new(namespace),
             next_order_id: AtomicU64::new(1),
+            engine_seq: AtomicU64::new(0),
             last_trade_price: AtomicCell::new(0),
             has_traded: AtomicBool::new(false),
             market_close_timestamp: AtomicU64::new(0),

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -32,6 +32,17 @@ use uuid::Uuid;
 /// One basis point = 0.01% = 0.0001
 const DEFAULT_BASIS_POINTS_MULTIPLIER: f64 = 10_000.0;
 
+/// Single source of truth for minting the next outbound `engine_seq`.
+///
+/// Both [`OrderBook::next_engine_seq`] and the matching helper in
+/// `super::matching::OrderBook::process_level_match` route through this
+/// function so the contract (`fetch_add(1, Relaxed)`) cannot drift between
+/// emission paths.
+#[inline]
+pub(super) fn mint_engine_seq(counter: &AtomicU64) -> u64 {
+    counter.fetch_add(1, Ordering::Relaxed)
+}
+
 /// The OrderBook manages a collection of price levels for both bid and ask sides.
 /// It supports adding, cancelling, and matching orders with lock-free operations where possible.
 pub struct OrderBook<T = ()> {
@@ -445,7 +456,7 @@ where
     /// the journal's `sequence_num` + `timestamp_ns` instead.
     #[inline]
     pub fn next_engine_seq(&self) -> u64 {
-        self.engine_seq.fetch_add(1, Ordering::Relaxed)
+        mint_engine_seq(&self.engine_seq)
     }
 
     /// Current value of the engine sequence counter without advancing.

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -2195,11 +2195,12 @@ where
         if !match_result.trades().as_vec().is_empty()
             && let Some(ref listener) = self.trade_listener
         {
-            let trade_result = TradeResult::with_fees(
+            let mut trade_result = TradeResult::with_fees(
                 self.symbol.clone(),
                 match_result.clone(),
                 self.fee_schedule,
             );
+            trade_result.engine_seq = self.next_engine_seq();
             listener(&trade_result);
         }
 
@@ -2270,11 +2271,12 @@ where
         if !match_result.trades().as_vec().is_empty()
             && let Some(ref listener) = self.trade_listener
         {
-            let trade_result = TradeResult::with_fees(
+            let mut trade_result = TradeResult::with_fees(
                 self.symbol.clone(),
                 match_result.clone(),
                 self.fee_schedule,
             );
+            trade_result.engine_seq = self.next_engine_seq();
             listener(&trade_result);
         }
 

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -2339,6 +2339,7 @@ where
         package.lot_size = self.lot_size;
         package.min_order_size = self.min_order_size;
         package.max_order_size = self.max_order_size;
+        package.engine_seq = self.engine_seq();
         Ok(package)
     }
 
@@ -2364,6 +2365,7 @@ where
         let lot_size = package.lot_size;
         let min_order_size = package.min_order_size;
         let max_order_size = package.max_order_size;
+        let engine_seq = package.engine_seq;
 
         self.restore_from_snapshot(package.into_snapshot()?)?;
 
@@ -2374,6 +2376,12 @@ where
         self.lot_size = lot_size;
         self.min_order_size = min_order_size;
         self.max_order_size = max_order_size;
+
+        // Restore the engine's outbound monotonic counter so that the
+        // first `next_engine_seq()` call on this restored book returns
+        // exactly the snapshotted value, preserving cross-snapshot
+        // monotonicity for downstream consumers.
+        self.engine_seq.store(engine_seq, Ordering::Release);
 
         Ok(())
     }

--- a/src/orderbook/book_change_event.rs
+++ b/src/orderbook/book_change_event.rs
@@ -1,3 +1,13 @@
+//! Price-level change events emitted by the order book.
+//!
+//! Each [`PriceLevelChangedEvent`] carries an `engine_seq` minted by
+//! `OrderBook::next_engine_seq` immediately before emission. The same
+//! counter is shared with `TradeResult`, so the union of trade events
+//! and price-level events emitted by a single `OrderBook<T>` instance
+//! is **strictly monotonic** in `engine_seq`. Consumers can use this
+//! cross-stream invariant for gap detection and temporal ordering
+//! without correlating two independent counters.
+
 use pricelevel::Side;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -17,6 +27,15 @@ pub struct PriceLevelChangedEvent {
 
     /// latest visible quantity of the order book at this price level
     pub quantity: u64,
+
+    /// Strictly monotonic global engine sequence number for this event.
+    /// See [`crate::orderbook::trade::TradeResult::engine_seq`] for the
+    /// full cross-stream monotonicity contract.
+    ///
+    /// Defaults to `0` when deserializing payloads from format versions
+    /// that pre-date `engine_seq` so existing consumers keep parsing.
+    #[serde(default)]
+    pub engine_seq: u64,
 }
 
 /// A thread-safe listener callback for price level change events.
@@ -25,3 +44,68 @@ pub struct PriceLevelChangedEvent {
 /// a price level in the order book changes (e.g., order added, cancelled,
 /// matched, or updated).
 pub type PriceLevelChangedListener = Arc<dyn Fn(PriceLevelChangedEvent) + Send + Sync>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_event(engine_seq: u64) -> PriceLevelChangedEvent {
+        PriceLevelChangedEvent {
+            side: Side::Buy,
+            price: 50_000,
+            quantity: 250,
+            engine_seq,
+        }
+    }
+
+    #[test]
+    fn test_engine_seq_default_zero_via_struct_literal() {
+        let event = PriceLevelChangedEvent {
+            side: Side::Sell,
+            price: 1,
+            quantity: 1,
+            engine_seq: 0,
+        };
+        assert_eq!(event.engine_seq, 0);
+    }
+
+    #[test]
+    fn test_json_roundtrip_preserves_engine_seq() {
+        let event = sample_event(123);
+        let bytes = serde_json::to_vec(&event).expect("serialize event");
+        let decoded: PriceLevelChangedEvent =
+            serde_json::from_slice(&bytes).expect("deserialize event");
+        assert_eq!(decoded, event);
+        assert_eq!(decoded.engine_seq, 123);
+    }
+
+    #[test]
+    fn test_json_missing_engine_seq_defaults_zero() {
+        // Construct a JSON payload that lacks the engine_seq field, which
+        // models a payload produced by an earlier crate version.
+        let json = r#"{"side":"Buy","price":42,"quantity":10}"#;
+        let decoded: PriceLevelChangedEvent =
+            serde_json::from_str(json).expect("deserialize legacy event");
+        assert_eq!(
+            decoded.engine_seq, 0,
+            "missing engine_seq must default to 0 via #[serde(default)]"
+        );
+        assert_eq!(decoded.price, 42);
+        assert_eq!(decoded.quantity, 10);
+    }
+
+    #[cfg(feature = "bincode")]
+    #[test]
+    fn test_bincode_roundtrip_preserves_engine_seq() {
+        use bincode::config::standard;
+        use bincode::serde::{decode_from_slice, encode_to_vec};
+
+        let event = sample_event(9_000);
+        let bytes = encode_to_vec(&event, standard()).expect("bincode encode");
+        let (decoded, consumed): (PriceLevelChangedEvent, usize) =
+            decode_from_slice(&bytes, standard()).expect("bincode decode");
+        assert_eq!(consumed, bytes.len(), "no trailing bytes expected");
+        assert_eq!(decoded, event);
+        assert_eq!(decoded.engine_seq, 9_000);
+    }
+}

--- a/src/orderbook/manager.rs
+++ b/src/orderbook/manager.rs
@@ -201,6 +201,7 @@ where
                 symbol: trade_result.symbol.clone(),
                 trade_result: trade_result.clone(),
                 timestamp: crate::current_time_millis(),
+                engine_seq: trade_result.engine_seq,
             };
 
             if let Err(e) = sender.send(trade_event) {
@@ -387,6 +388,7 @@ where
                 symbol: trade_result.symbol.clone(),
                 trade_result: trade_result.clone(),
                 timestamp: crate::current_time_millis(),
+                engine_seq: trade_result.engine_seq,
             };
 
             if let Err(e) = sender.send(trade_event) {

--- a/src/orderbook/mass_cancel.rs
+++ b/src/orderbook/mass_cancel.rs
@@ -143,17 +143,21 @@ where
         // 2. Emit PriceLevelChangedEvent (qty → 0) for every affected level
         if let Some(ref listener) = self.price_level_changed_listener {
             for entry in self.bids.iter() {
+                let engine_seq = self.next_engine_seq();
                 listener(PriceLevelChangedEvent {
                     side: Side::Buy,
                     price: *entry.key(),
                     quantity: 0,
+                    engine_seq,
                 });
             }
             for entry in self.asks.iter() {
+                let engine_seq = self.next_engine_seq();
                 listener(PriceLevelChangedEvent {
                     side: Side::Sell,
                     price: *entry.key(),
                     quantity: 0,
+                    engine_seq,
                 });
             }
         }

--- a/src/orderbook/matching.rs
+++ b/src/orderbook/matching.rs
@@ -11,7 +11,7 @@ use crate::orderbook::stp::{STPAction, check_stp_at_level};
 use crate::{OrderBook, OrderBookError};
 use either::Either;
 use pricelevel::{Hash32, Id, MatchResult, OrderUpdate, Side};
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 impl<T> OrderBook<T>
 where
@@ -164,6 +164,7 @@ where
                                 &self.last_trade_price,
                                 &self.has_traded,
                                 &self.price_level_changed_listener,
+                                &self.engine_seq,
                                 &mut empty_price_levels,
                             );
                             // Correct remaining: process_level_match set it to
@@ -224,6 +225,7 @@ where
                                 &self.last_trade_price,
                                 &self.has_traded,
                                 &self.price_level_changed_listener,
+                                &self.engine_seq,
                                 &mut empty_price_levels,
                             );
                             // Correct remaining: process_level_match set it to
@@ -269,6 +271,7 @@ where
                 &self.last_trade_price,
                 &self.has_traded,
                 &self.price_level_changed_listener,
+                &self.engine_seq,
                 &mut empty_price_levels,
             );
 
@@ -348,6 +351,7 @@ where
         price_level_changed_listener: &Option<
             crate::orderbook::book_change_event::PriceLevelChangedListener,
         >,
+        engine_seq_counter: &AtomicU64,
         empty_price_levels: &mut Vec<u128>,
     ) {
         // Process trades if any occurred
@@ -365,10 +369,12 @@ where
 
             // Notify price level changes
             if let Some(listener) = price_level_changed_listener {
+                let engine_seq = engine_seq_counter.fetch_add(1, Ordering::Relaxed);
                 listener(PriceLevelChangedEvent {
                     side: side.opposite(),
                     price: price_level.price(),
                     quantity: price_level.visible_quantity(),
+                    engine_seq,
                 });
             }
         }

--- a/src/orderbook/matching.rs
+++ b/src/orderbook/matching.rs
@@ -369,7 +369,7 @@ where
 
             // Notify price level changes
             if let Some(listener) = price_level_changed_listener {
-                let engine_seq = engine_seq_counter.fetch_add(1, Ordering::Relaxed);
+                let engine_seq = super::book::mint_engine_seq(engine_seq_counter);
                 listener(PriceLevelChangedEvent {
                     side: side.opposite(),
                     price: price_level.price(),

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -204,10 +204,12 @@ where
                         {
                             // notify price level changes
                             if let Some(ref listener) = self.price_level_changed_listener {
+                                let engine_seq = self.next_engine_seq();
                                 listener(PriceLevelChangedEvent {
                                     side,
                                     price: price_level.price(),
                                     quantity: price_level.visible_quantity(),
+                                    engine_seq,
                                 })
                             }
                             result = Some(Arc::new(self.convert_from_unit_type(&order)));
@@ -304,10 +306,12 @@ where
                                 && let Ok(updated_order) = result
                                 && updated_order.is_some()
                             {
+                                let engine_seq = self.next_engine_seq();
                                 listener(PriceLevelChangedEvent {
                                     side,
                                     price: price_level.price(),
                                     quantity: price_level.visible_quantity(),
+                                    engine_seq,
                                 })
                             }
                             is_empty = price_level.order_count() == 0;
@@ -490,10 +494,12 @@ where
                     if result.is_some()
                         && let Some(ref listener) = self.price_level_changed_listener
                     {
+                        let engine_seq = self.next_engine_seq();
                         listener(PriceLevelChangedEvent {
                             side,
                             price: price_level.price(),
                             quantity: price_level.visible_quantity(),
+                            engine_seq,
                         })
                     }
 
@@ -711,11 +717,12 @@ where
         if !match_result.trades().as_vec().is_empty()
             && let Some(ref listener) = self.trade_listener
         {
-            let trade_result = TradeResult::with_fees(
+            let mut trade_result = TradeResult::with_fees(
                 self.symbol.clone(),
                 match_result.clone(),
                 self.fee_schedule,
             );
+            trade_result.engine_seq = self.next_engine_seq();
             listener(&trade_result) // emit trade events to listener
         }
 
@@ -767,10 +774,12 @@ where
             let unit_order_arc = price_level.value().add_order(unit_order);
             // notify price level changes
             if let Some(ref listener) = self.price_level_changed_listener {
+                let engine_seq = self.next_engine_seq();
                 listener(PriceLevelChangedEvent {
                     side,
                     price: level.price(),
                     quantity: level.visible_quantity(),
+                    engine_seq,
                 })
             }
             self.order_locations

--- a/src/orderbook/nats_book_change.rs
+++ b/src/orderbook/nats_book_change.rs
@@ -57,14 +57,20 @@ const DEFAULT_MIN_PUBLISH_INTERVAL_MS: u64 = 0;
 /// A batched order book change payload published to NATS JetStream.
 ///
 /// Each batch contains one or more [`BookChangeEntry`] values collected within
-/// the configured batch window. Consumers use the `sequence` field for ordering
-/// and gap detection.
+/// the configured batch window. Consumers use [`BookChangeBatch::sequence`]
+/// (the publisher's per-batch counter) for batch-level ordering, and
+/// [`BookChangeEntry::engine_seq`] for per-event gap detection across all
+/// outbound streams of the source `OrderBook<T>`.
 #[derive(Debug, Clone, Serialize)]
 pub struct BookChangeBatch {
     /// The symbol this batch belongs to.
     pub symbol: String,
 
-    /// Monotonically increasing sequence number for this batch.
+    /// Monotonically increasing **publisher-side** sequence number for this
+    /// batch. Independent of [`BookChangeEntry::engine_seq`]: batches are
+    /// minted by the NATS publisher when it flushes, while each entry's
+    /// `engine_seq` was minted by the upstream `OrderBook<T>` at emission
+    /// time.
     pub sequence: u64,
 
     /// Unix timestamp in milliseconds when the batch was flushed.
@@ -88,6 +94,12 @@ pub struct BookChangeEntry {
 
     /// The new visible quantity at this price level after the change.
     pub quantity: u64,
+
+    /// Strictly monotonic global engine sequence number for this entry.
+    /// Inherited from [`PriceLevelChangedEvent::engine_seq`] at conversion
+    /// time. Independent of [`BookChangeBatch::sequence`] (which is the
+    /// publisher's per-batch counter).
+    pub engine_seq: u64,
 }
 
 impl From<PriceLevelChangedEvent> for BookChangeEntry {
@@ -97,6 +109,7 @@ impl From<PriceLevelChangedEvent> for BookChangeEntry {
             side: event.side,
             price: event.price,
             quantity: event.quantity,
+            engine_seq: event.engine_seq,
         }
     }
 }
@@ -674,11 +687,16 @@ mod tests {
             side: Side::Buy,
             price: 50_000,
             quantity: 100,
+            engine_seq: 7,
         };
         let entry = BookChangeEntry::from(event);
         assert_eq!(entry.side, Side::Buy);
         assert_eq!(entry.price, 50_000);
         assert_eq!(entry.quantity, 100);
+        assert_eq!(
+            entry.engine_seq, 7,
+            "BookChangeEntry must propagate engine_seq from the source event"
+        );
     }
 
     #[test]
@@ -687,12 +705,14 @@ mod tests {
             side: Side::Buy,
             price: 50_000,
             quantity: 100,
+            engine_seq: 11,
         };
         let result = serde_json::to_value(&entry);
         assert!(result.is_ok());
         let value = result.unwrap_or(serde_json::Value::Null);
         assert_eq!(value.get("price").and_then(|v| v.as_u64()), Some(50_000));
         assert_eq!(value.get("quantity").and_then(|v| v.as_u64()), Some(100));
+        assert_eq!(value.get("engine_seq").and_then(|v| v.as_u64()), Some(11));
         assert!(value.get("side").is_some());
     }
 
@@ -708,11 +728,13 @@ mod tests {
                     side: Side::Buy,
                     price: 50_000,
                     quantity: 100,
+                    engine_seq: 1,
                 },
                 BookChangeEntry {
                     side: Side::Sell,
                     price: 50_100,
                     quantity: 200,
+                    engine_seq: 2,
                 },
             ],
         };
@@ -738,6 +760,7 @@ mod tests {
                 side: Side::Sell,
                 price: 2_000,
                 quantity: 50,
+                engine_seq: 3,
             }],
         };
         let json = serde_json::to_value(&batch);
@@ -834,6 +857,7 @@ mod tests {
             side: Side::Buy,
             price: 42_000,
             quantity: 500,
+            engine_seq: 0,
         };
         let result = serde_json::to_value(&event);
         assert!(result.is_ok());

--- a/src/orderbook/private.rs
+++ b/src/orderbook/private.rs
@@ -56,10 +56,12 @@ where
 
         // notify price level changes
         if let Some(ref listener) = self.price_level_changed_listener {
+            let engine_seq = self.next_engine_seq();
             listener(PriceLevelChangedEvent {
                 side,
                 price: price_level.price(),
                 quantity: price_level.visible_quantity(),
+                engine_seq,
             })
         }
         // The location is stored as (price, side) for efficient retrieval in cancel_order

--- a/src/orderbook/serialization.rs
+++ b/src/orderbook/serialization.rs
@@ -270,6 +270,7 @@ mod tests {
             side: Side::Buy,
             price: 50_000_000,
             quantity: 1_000,
+            engine_seq: 0,
         }
     }
 

--- a/src/orderbook/snapshot.rs
+++ b/src/orderbook/snapshot.rs
@@ -138,7 +138,13 @@ impl OrderBookSnapshot {
 }
 
 /// Format version used for checksum-enabled order book snapshots.
-pub const ORDERBOOK_SNAPSHOT_FORMAT_VERSION: u32 = 1;
+///
+/// Bumped to `2` to accompany the addition of [`OrderBookSnapshotPackage::engine_seq`],
+/// which persists the engine's outbound monotonic counter across snapshot/restore.
+/// `version: 1` payloads are rejected by [`OrderBookSnapshotPackage::validate`]
+/// with the existing `Unsupported snapshot version` error — the format break is
+/// intentional, with no special-case migration path.
+pub const ORDERBOOK_SNAPSHOT_FORMAT_VERSION: u32 = 2;
 
 /// Wrapper that provides checksum validation for `OrderBookSnapshot` instances.
 ///
@@ -184,6 +190,19 @@ pub struct OrderBookSnapshotPackage {
     /// Maximum order size active at the time of the snapshot.
     #[serde(default)]
     pub max_order_size: Option<u64>,
+
+    /// Engine sequence at the time of snapshot. Restored as the new
+    /// counter value on
+    /// [`OrderBook::restore_from_snapshot_package`](super::book::OrderBook::restore_from_snapshot_package)
+    /// so monotonicity resumes from this point on the restored book.
+    ///
+    /// `#[serde(default)]` lets `version: 2` payloads that omit the field
+    /// (e.g. older code paths constructing the package via the legacy
+    /// [`OrderBookSnapshotPackage::new`]) deserialize cleanly with `0`.
+    /// Payloads with `version: 1` are rejected by
+    /// [`OrderBookSnapshotPackage::validate`].
+    #[serde(default)]
+    pub engine_seq: u64,
 }
 
 impl OrderBookSnapshotPackage {
@@ -203,6 +222,7 @@ impl OrderBookSnapshotPackage {
             lot_size: None,
             min_order_size: None,
             max_order_size: None,
+            engine_seq: 0,
         })
     }
 

--- a/src/orderbook/tests/book.rs
+++ b/src/orderbook/tests/book.rs
@@ -1138,4 +1138,50 @@ mod test_book_specific {
             "order submitted after set_clock must use the new clock source"
         );
     }
+
+    #[test]
+    fn test_next_engine_seq_starts_at_zero_and_advances_by_one() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+        assert_eq!(book.next_engine_seq(), 0);
+        assert_eq!(book.next_engine_seq(), 1);
+        assert_eq!(book.next_engine_seq(), 2);
+        assert_eq!(book.engine_seq(), 3);
+    }
+
+    #[test]
+    fn test_next_engine_seq_is_monotonic_under_concurrent_calls() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let book: Arc<OrderBook<()>> = Arc::new(OrderBook::new("TEST"));
+        let threads = 4usize;
+        let per_thread = 1000usize;
+        let mut handles = Vec::with_capacity(threads);
+
+        for _ in 0..threads {
+            let b = Arc::clone(&book);
+            handles.push(thread::spawn(move || {
+                let mut local = Vec::with_capacity(per_thread);
+                for _ in 0..per_thread {
+                    local.push(b.next_engine_seq());
+                }
+                local
+            }));
+        }
+
+        let mut all: Vec<u64> = Vec::with_capacity(threads * per_thread);
+        for h in handles {
+            let part = h.join().expect("thread panicked");
+            all.extend(part);
+        }
+
+        use std::collections::HashSet;
+        let set: HashSet<u64> = all.iter().copied().collect();
+        assert_eq!(
+            set.len(),
+            threads * per_thread,
+            "every observed seq must be unique"
+        );
+        assert_eq!(book.engine_seq(), (threads * per_thread) as u64);
+    }
 }

--- a/src/orderbook/tests/book.rs
+++ b/src/orderbook/tests/book.rs
@@ -1184,4 +1184,161 @@ mod test_book_specific {
         );
         assert_eq!(book.engine_seq(), (threads * per_thread) as u64);
     }
+
+    #[test]
+    fn test_trade_result_carries_engine_seq() {
+        use std::sync::Arc;
+        use std::sync::Mutex;
+
+        let captured: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
+        let captured_for_listener = Arc::clone(&captured);
+        let listener: crate::orderbook::trade::TradeListener =
+            Arc::new(move |trade_result: &crate::orderbook::trade::TradeResult| {
+                if let Ok(mut guard) = captured_for_listener.lock() {
+                    guard.push(trade_result.engine_seq);
+                }
+            });
+        let mut book: OrderBook<()> = OrderBook::with_trade_listener("TEST", listener);
+        // No price-level listener so trades are the only outbound events.
+        book.remove_price_level_listener();
+
+        // Resting sell at 1000.
+        let resting_id = create_order_id();
+        book.add_limit_order(resting_id, 1000, 100, Side::Sell, TimeInForce::Gtc, None)
+            .expect("seed resting sell");
+
+        // First market buy fills.
+        let taker_a = create_order_id();
+        let _ = book
+            .match_market_order(taker_a, 10, Side::Buy)
+            .expect("first market buy");
+
+        // Resting sell again.
+        let resting_b = create_order_id();
+        book.add_limit_order(resting_b, 1000, 100, Side::Sell, TimeInForce::Gtc, None)
+            .expect("seed second resting sell");
+
+        // Second market buy fills.
+        let taker_b = create_order_id();
+        let _ = book
+            .match_market_order(taker_b, 10, Side::Buy)
+            .expect("second market buy");
+
+        let observed = captured.lock().expect("lock captured trades").clone();
+        assert_eq!(
+            observed.len(),
+            2,
+            "expected exactly two trade events, got {observed:?}"
+        );
+        assert!(
+            observed[1] > observed[0],
+            "second trade engine_seq ({}) must be > first ({}); observed: {observed:?}",
+            observed[1],
+            observed[0]
+        );
+    }
+
+    #[test]
+    fn test_price_level_event_carries_monotonic_engine_seq() {
+        use crate::orderbook::book_change_event::{
+            PriceLevelChangedEvent, PriceLevelChangedListener,
+        };
+        use std::sync::Arc;
+        use std::sync::Mutex;
+
+        let captured: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
+        let captured_for_listener = Arc::clone(&captured);
+        let listener: PriceLevelChangedListener = Arc::new(move |event: PriceLevelChangedEvent| {
+            if let Ok(mut guard) = captured_for_listener.lock() {
+                guard.push(event.engine_seq);
+            }
+        });
+        let mut book: OrderBook<()> = OrderBook::new("TEST");
+        book.set_price_level_listener(listener);
+
+        // Open two distinct price levels — each emits one event.
+        book.add_limit_order(
+            create_order_id(),
+            1000,
+            5,
+            Side::Buy,
+            TimeInForce::Gtc,
+            None,
+        )
+        .expect("first level");
+        book.add_limit_order(
+            create_order_id(),
+            1100,
+            5,
+            Side::Buy,
+            TimeInForce::Gtc,
+            None,
+        )
+        .expect("second level");
+
+        let observed = captured.lock().expect("lock captured events").clone();
+        assert_eq!(
+            observed.len(),
+            2,
+            "expected exactly two price-level events, got {observed:?}"
+        );
+        assert!(
+            observed[1] > observed[0],
+            "second price-level engine_seq ({}) must be > first ({}); observed: {observed:?}",
+            observed[1],
+            observed[0]
+        );
+    }
+
+    #[test]
+    fn test_engine_seq_strictly_monotonic_across_trade_and_book_change() {
+        use crate::orderbook::book_change_event::{
+            PriceLevelChangedEvent, PriceLevelChangedListener,
+        };
+        use crate::orderbook::trade::{TradeListener, TradeResult};
+        use std::sync::Arc;
+        use std::sync::Mutex;
+
+        let captured: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let captured_trades = Arc::clone(&captured);
+        let trade_listener: TradeListener = Arc::new(move |trade_result: &TradeResult| {
+            if let Ok(mut guard) = captured_trades.lock() {
+                guard.push(trade_result.engine_seq);
+            }
+        });
+
+        let captured_levels = Arc::clone(&captured);
+        let level_listener: PriceLevelChangedListener =
+            Arc::new(move |event: PriceLevelChangedEvent| {
+                if let Ok(mut guard) = captured_levels.lock() {
+                    guard.push(event.engine_seq);
+                }
+            });
+
+        let book: OrderBook<()> =
+            OrderBook::with_trade_and_price_level_listener("TEST", trade_listener, level_listener);
+
+        // Resting sell at 1000.
+        let resting_id = create_order_id();
+        book.add_limit_order(resting_id, 1000, 50, Side::Sell, TimeInForce::Gtc, None)
+            .expect("seed resting sell");
+
+        // Aggressive buy crosses, producing both a trade event and a
+        // price-level event (qty change at the resting level).
+        let taker = create_order_id();
+        let _ = book
+            .match_limit_order(taker, 25, Side::Buy, 1000)
+            .expect("aggressive limit cross");
+
+        let observed = captured.lock().expect("lock captured events").clone();
+        assert!(
+            observed.len() >= 2,
+            "expected at least two combined events (trade + book change), got {observed:?}"
+        );
+        assert!(
+            observed.windows(2).all(|w| w[0] < w[1]),
+            "engine_seq must be strictly monotonic across all outbound streams: {observed:?}"
+        );
+    }
 }

--- a/src/orderbook/tests/snapshot.rs
+++ b/src/orderbook/tests/snapshot.rs
@@ -642,3 +642,178 @@ mod test_snapshot_specific {
         assert_eq!(best_ask, Some((1010, 15)));
     }
 }
+
+#[cfg(test)]
+mod test_snapshot_engine_seq {
+    use crate::DefaultOrderBook;
+    use crate::orderbook::error::OrderBookError;
+    use crate::orderbook::{ORDERBOOK_SNAPSHOT_FORMAT_VERSION, OrderBookSnapshotPackage};
+
+    /// Round-trip an engine_seq value through the snapshot package: the
+    /// counter must be restored verbatim, and the next mint must resume
+    /// from that value (i.e. return `engine_seq` then advance to
+    /// `engine_seq + 1`).
+    #[test]
+    fn test_snapshot_package_round_trips_engine_seq() {
+        let original = DefaultOrderBook::new("ESQ");
+
+        // Advance the counter past zero. After 5 calls the counter sits at 5.
+        for _ in 0..5 {
+            let _ = original.next_engine_seq();
+        }
+        assert_eq!(original.engine_seq(), 5, "counter primed to 5");
+
+        let package = original
+            .create_snapshot_package(10)
+            .expect("build snapshot package");
+        assert_eq!(
+            package.engine_seq, 5,
+            "package captures engine_seq from the source book"
+        );
+        assert_eq!(
+            package.version, ORDERBOOK_SNAPSHOT_FORMAT_VERSION,
+            "package carries the current format version"
+        );
+
+        // Round-trip via JSON.
+        let json = package.to_json().expect("serialize to json");
+        let parsed = OrderBookSnapshotPackage::from_json(&json).expect("deserialize from json");
+        assert_eq!(
+            parsed.engine_seq, 5,
+            "engine_seq survives JSON encode/decode"
+        );
+
+        // Restore into a fresh book; the counter must equal 5.
+        let mut restored = DefaultOrderBook::new("ESQ");
+        restored
+            .restore_from_snapshot_package(parsed)
+            .expect("restore from package");
+        assert_eq!(
+            restored.engine_seq(),
+            5,
+            "restored book resumes its counter at the snapshotted value"
+        );
+
+        // Next mint returns 5 (the resumed value) and advances to 6.
+        let next = restored.next_engine_seq();
+        assert_eq!(next, 5, "next_engine_seq returns the resumed value");
+        assert_eq!(
+            restored.engine_seq(),
+            6,
+            "engine_seq advances to 6 after the mint"
+        );
+    }
+
+    /// `version: 1` payloads — the legacy format that lacked `engine_seq`
+    /// — must be rejected by `validate()` with the existing
+    /// `Unsupported snapshot version` error after the bump to v2. No
+    /// special-casing.
+    #[test]
+    fn test_snapshot_package_v1_payload_rejected_by_validate() {
+        let payload = serde_json::json!({
+            "version": 1u32,
+            "snapshot": {
+                "symbol": "V1",
+                "timestamp": 0u64,
+                "bids": [],
+                "asks": []
+            },
+            "checksum": "deadbeef",
+            "fee_schedule": null,
+            "stp_mode": "None",
+            "tick_size": null,
+            "lot_size": null,
+            "min_order_size": null,
+            "max_order_size": null
+        })
+        .to_string();
+
+        let package =
+            OrderBookSnapshotPackage::from_json(&payload).expect("deserialize v1 payload");
+        assert_eq!(package.version, 1, "version field reflects the payload");
+        assert_eq!(
+            package.engine_seq, 0,
+            "missing engine_seq field defaults to 0"
+        );
+
+        let err = package
+            .validate()
+            .expect_err("v1 payload must be rejected after the v2 bump");
+
+        match err {
+            OrderBookError::InvalidOperation { message } => {
+                assert!(
+                    message.contains("Unsupported snapshot version"),
+                    "error message must mention the unsupported version, got: {message}"
+                );
+                assert!(
+                    message.contains('1'),
+                    "error message must mention version 1, got: {message}"
+                );
+                assert!(
+                    message.contains('2'),
+                    "error message must mention expected version 2, got: {message}"
+                );
+            }
+            other => panic!("expected InvalidOperation, got {other:?}"),
+        }
+    }
+
+    /// Pure serde round-trip: a package with a non-trivial `engine_seq`
+    /// value survives JSON encoding and decoding intact.
+    #[test]
+    fn test_snapshot_package_engine_seq_field_serializes_and_deserializes() {
+        let book = DefaultOrderBook::new("FLD");
+        let mut package = book
+            .create_snapshot_package(10)
+            .expect("build snapshot package");
+        package.engine_seq = 12_345;
+
+        let json = package.to_json().expect("serialize package to json");
+        let decoded =
+            OrderBookSnapshotPackage::from_json(&json).expect("deserialize package from json");
+
+        assert_eq!(
+            decoded.engine_seq, 12_345,
+            "engine_seq round-trips through JSON unchanged"
+        );
+    }
+
+    /// A `version: 2` payload that omits the `engine_seq` field entirely
+    /// (e.g. produced by a downstream consumer that constructed the
+    /// package via the legacy `OrderBookSnapshotPackage::new` entry
+    /// point) must still deserialize, falling back to `0` via
+    /// `#[serde(default)]`.
+    #[test]
+    fn test_snapshot_package_v2_payload_without_engine_seq_field_uses_default() {
+        let payload = serde_json::json!({
+            "version": ORDERBOOK_SNAPSHOT_FORMAT_VERSION,
+            "snapshot": {
+                "symbol": "V2",
+                "timestamp": 0u64,
+                "bids": [],
+                "asks": []
+            },
+            "checksum": "deadbeef",
+            "fee_schedule": null,
+            "stp_mode": "None",
+            "tick_size": null,
+            "lot_size": null,
+            "min_order_size": null,
+            "max_order_size": null
+            // engine_seq deliberately omitted — must default to 0.
+        })
+        .to_string();
+
+        let package = OrderBookSnapshotPackage::from_json(&payload)
+            .expect("deserialize v2 payload missing engine_seq");
+        assert_eq!(
+            package.version, ORDERBOOK_SNAPSHOT_FORMAT_VERSION,
+            "version field reflects the payload"
+        );
+        assert_eq!(
+            package.engine_seq, 0,
+            "omitted engine_seq must default to 0 via #[serde(default)]"
+        );
+    }
+}

--- a/src/orderbook/trade.rs
+++ b/src/orderbook/trade.rs
@@ -23,6 +23,18 @@ pub struct TradeResult {
     /// unit as the notional (price × quantity). Zero when no `FeeSchedule`
     /// is configured.
     pub total_taker_fees: i128,
+    /// Strictly monotonic global sequence number across every outbound
+    /// stream of this `OrderBook<T>` instance: the `TradeListener`
+    /// callback, the `PriceLevelChangedListener` callback, and the NATS
+    /// publishers. Use it for cross-stream gap detection and temporal
+    /// ordering. Always strictly increasing within a single book; replay
+    /// into a fresh book yields fresh seqs, not the originals. Stamped at
+    /// emission time by `OrderBook::next_engine_seq`.
+    ///
+    /// Defaults to `0` when deserializing payloads from format versions
+    /// that pre-date `engine_seq` so existing consumers keep parsing.
+    #[serde(default)]
+    pub engine_seq: u64,
 }
 
 impl TradeResult {
@@ -36,6 +48,7 @@ impl TradeResult {
             match_result,
             total_maker_fees: 0,
             total_taker_fees: 0,
+            engine_seq: 0,
         }
     }
 
@@ -81,6 +94,7 @@ impl TradeResult {
             match_result,
             total_maker_fees,
             total_taker_fees,
+            engine_seq: 0,
         }
     }
 
@@ -109,6 +123,10 @@ pub struct TradeEvent {
     pub trade_result: TradeResult,
     /// Unix timestamp in milliseconds when the trade occurred
     pub timestamp: u64,
+    /// Mirrors [`TradeResult::engine_seq`]. Exposed on the envelope so the
+    /// outbound payload carries the engine sequence directly without
+    /// forcing consumers to reach into `trade_result`.
+    pub engine_seq: u64,
 }
 
 /// Structure to store trade information for later display
@@ -289,5 +307,69 @@ mod tests {
 
         assert_eq!(info.maker_fee, -25);
         assert_eq!(info.taker_fee, 50);
+    }
+
+    #[test]
+    fn test_trade_result_engine_seq_default_zero() {
+        let mr = make_match_result_with_trades(vec![make_trade(1000, 10)]);
+        let tr = TradeResult::new("BTC/USD".to_string(), mr);
+        assert_eq!(tr.engine_seq, 0);
+    }
+
+    #[test]
+    fn test_trade_result_json_roundtrip_preserves_engine_seq() {
+        let mr = make_match_result_with_trades(vec![make_trade(1000, 10)]);
+        let mut tr = TradeResult::new("BTC/USD".to_string(), mr);
+        tr.engine_seq = 42;
+
+        let json = serde_json::to_vec(&tr).expect("serialize trade");
+        let decoded: TradeResult = serde_json::from_slice(&json).expect("deserialize trade");
+
+        assert_eq!(decoded.engine_seq, 42);
+        assert_eq!(decoded.symbol, tr.symbol);
+        assert_eq!(decoded.total_maker_fees, tr.total_maker_fees);
+        assert_eq!(decoded.total_taker_fees, tr.total_taker_fees);
+    }
+
+    #[test]
+    fn test_trade_result_json_missing_engine_seq_defaults_zero() {
+        // Build a JSON payload that mirrors the pre-engine_seq schema by
+        // first serializing a TradeResult and then stripping the field.
+        let mr = make_match_result_with_trades(vec![make_trade(1000, 10)]);
+        let mut tr = TradeResult::new("BTC/USD".to_string(), mr);
+        tr.engine_seq = 99;
+
+        let mut value: serde_json::Value =
+            serde_json::to_value(&tr).expect("serialize trade to value");
+        // Remove the field to simulate a payload from before engine_seq.
+        if let Some(map) = value.as_object_mut() {
+            map.remove("engine_seq");
+        }
+        let bytes = serde_json::to_vec(&value).expect("serialize stripped value");
+
+        let decoded: TradeResult =
+            serde_json::from_slice(&bytes).expect("deserialize stripped trade");
+        assert_eq!(
+            decoded.engine_seq, 0,
+            "missing engine_seq must default to 0 via #[serde(default)]"
+        );
+    }
+
+    #[cfg(feature = "bincode")]
+    #[test]
+    fn test_trade_result_bincode_roundtrip_preserves_engine_seq() {
+        use bincode::config::standard;
+        use bincode::serde::{decode_from_slice, encode_to_vec};
+
+        let mr = make_match_result_with_trades(vec![make_trade(1000, 10)]);
+        let mut tr = TradeResult::new("BTC/USD".to_string(), mr);
+        tr.engine_seq = 7;
+
+        let bytes = encode_to_vec(&tr, standard()).expect("bincode encode");
+        let (decoded, consumed): (TradeResult, usize) =
+            decode_from_slice(&bytes, standard()).expect("bincode decode");
+        assert_eq!(consumed, bytes.len(), "no trailing bytes expected");
+        assert_eq!(decoded.engine_seq, 7);
+        assert_eq!(decoded.symbol, tr.symbol);
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -39,6 +39,9 @@ pub use crate::orderbook::trade::{
     TradeEvent, TradeInfo, TradeListener, TradeResult, TransactionInfo,
 };
 
+// Book change event types
+pub use crate::orderbook::book_change_event::{PriceLevelChangedEvent, PriceLevelChangedListener};
+
 // Order types and enums from pricelevel
 pub use pricelevel::{Id, OrderType, Side, TimeInForce};
 

--- a/tests/unit/engine_seq_monotonic_tests.rs
+++ b/tests/unit/engine_seq_monotonic_tests.rs
@@ -26,25 +26,26 @@ fn collect_observed_engine_seqs(events: &[SequencerEvent<()>]) -> Vec<u64> {
 
     let trade_observed = Arc::clone(&observed);
     let trade_listener: TradeListener = Arc::new(move |result: &TradeResult| {
-        if let Ok(mut guard) = trade_observed.lock() {
-            guard.push(result.engine_seq);
-        }
+        let mut guard = trade_observed
+            .lock()
+            .expect("observed mutex poisoned in trade listener");
+        guard.push(result.engine_seq);
     });
 
     let price_observed = Arc::clone(&observed);
     let price_listener: PriceLevelChangedListener =
         Arc::new(move |event: PriceLevelChangedEvent| {
-            if let Ok(mut guard) = price_observed.lock() {
-                guard.push(event.engine_seq);
-            }
+            let mut guard = price_observed
+                .lock()
+                .expect("observed mutex poisoned in price listener");
+            guard.push(event.engine_seq);
         });
 
-    let mut book = OrderBook::<()>::with_trade_and_price_level_listener(
+    let book = OrderBook::<()>::with_trade_and_price_level_listener(
         "TEST",
         trade_listener,
         price_listener,
     );
-    let _ = &mut book;
 
     for event in events {
         if let SequencerCommand::AddOrder(order) = &event.command {
@@ -52,10 +53,10 @@ fn collect_observed_engine_seqs(events: &[SequencerEvent<()>]) -> Vec<u64> {
         }
     }
 
-    match observed.lock() {
-        Ok(g) => g.clone(),
-        Err(_) => Vec::new(),
-    }
+    let guard = observed
+        .lock()
+        .expect("observed mutex poisoned after replay");
+    guard.clone()
 }
 
 proptest! {

--- a/tests/unit/engine_seq_monotonic_tests.rs
+++ b/tests/unit/engine_seq_monotonic_tests.rs
@@ -1,0 +1,98 @@
+//! Property-based test for the global `engine_seq` monotonicity contract.
+//!
+//! For any random op stream applied to a fresh `OrderBook`, every observed
+//! `engine_seq` across both the trade-listener stream and the
+//! price-level-changed-listener stream must be strictly increasing under
+//! `<`. This is the single most important invariant on the outbound
+//! sequencing surface — consumers rely on it to detect gaps and to merge
+//! events from the two streams into a single ordered view.
+
+use super::common::strategies::event_stream;
+
+use orderbook_rs::OrderBook;
+use orderbook_rs::orderbook::book_change_event::{
+    PriceLevelChangedEvent, PriceLevelChangedListener,
+};
+use orderbook_rs::orderbook::sequencer::{SequencerCommand, SequencerEvent};
+use orderbook_rs::orderbook::trade::{TradeListener, TradeResult};
+use proptest::prelude::*;
+use std::sync::{Arc, Mutex};
+
+/// Replays every `AddOrder` command in `events` against a fresh `OrderBook`
+/// and returns the merged sequence of every observed `engine_seq` from both
+/// outbound streams, in the order events were emitted.
+fn collect_observed_engine_seqs(events: &[SequencerEvent<()>]) -> Vec<u64> {
+    let observed: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let trade_observed = Arc::clone(&observed);
+    let trade_listener: TradeListener = Arc::new(move |result: &TradeResult| {
+        if let Ok(mut guard) = trade_observed.lock() {
+            guard.push(result.engine_seq);
+        }
+    });
+
+    let price_observed = Arc::clone(&observed);
+    let price_listener: PriceLevelChangedListener =
+        Arc::new(move |event: PriceLevelChangedEvent| {
+            if let Ok(mut guard) = price_observed.lock() {
+                guard.push(event.engine_seq);
+            }
+        });
+
+    let mut book = OrderBook::<()>::with_trade_and_price_level_listener(
+        "TEST",
+        trade_listener,
+        price_listener,
+    );
+    let _ = &mut book;
+
+    for event in events {
+        if let SequencerCommand::AddOrder(order) = &event.command {
+            let _ = book.add_order(*order);
+        }
+    }
+
+    match observed.lock() {
+        Ok(g) => g.clone(),
+        Err(_) => Vec::new(),
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 256,
+        max_shrink_iters: 50_000,
+        ..ProptestConfig::default()
+    })]
+
+    /// For any valid op stream, every `engine_seq` observed on the merged
+    /// outbound stream (trades + price-level changes) is strictly
+    /// monotonically increasing.
+    #[test]
+    fn proptest_engine_seq_strictly_monotonic_across_streams(
+        events in event_stream(1..40),
+    ) {
+        let observed = collect_observed_engine_seqs(&events);
+
+        if observed.len() >= 2 {
+            for window in observed.windows(2) {
+                prop_assert!(
+                    window[0] < window[1],
+                    "engine_seq monotonicity violated: {} >= {} at adjacent emissions",
+                    window[0], window[1]
+                );
+            }
+        }
+    }
+
+    /// Every observed `engine_seq` is unique — the `AtomicU64::fetch_add`
+    /// contract on `next_engine_seq` guarantees this; the proptest is a
+    /// regression guard against accidental shared-counter clones.
+    #[test]
+    fn proptest_engine_seq_values_are_unique(events in event_stream(1..40)) {
+        let observed = collect_observed_engine_seqs(&events);
+
+        let unique: std::collections::HashSet<u64> = observed.iter().copied().collect();
+        prop_assert_eq!(unique.len(), observed.len(), "duplicate engine_seq emitted");
+    }
+}

--- a/tests/unit/integration_workflow_tests.rs
+++ b/tests/unit/integration_workflow_tests.rs
@@ -238,6 +238,7 @@ fn json_serializer_book_change_round_trip() {
         side: Side::Buy,
         price: 3000,
         quantity: 100,
+        engine_seq: 0,
     };
 
     let bytes = serializer.serialize_book_change(&event);

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -2,6 +2,7 @@ mod book_coverage_tests;
 mod book_manager_cross_cancel_tests;
 mod clock_determinism_tests;
 mod common;
+mod engine_seq_monotonic_tests;
 #[cfg(feature = "journal")]
 mod filejournal_edge_case_tests;
 mod implied_volatility_tests;


### PR DESCRIPTION
## Summary

- Adds a global monotonic `engine_seq: u64` counter on `OrderBook<T>` that
  is incremented exactly once per outbound emission (trade or price-level
  change) and stamped onto every outbound event type. Consumers can now
  perform cross-stream gap detection and merge events from
  `TradeListener` and `PriceLevelChangedListener` into a single ordered
  view.
- Field additions on every public outbound event:
  `TradeResult.engine_seq`, `TradeEvent.engine_seq`,
  `PriceLevelChangedEvent.engine_seq`, `BookChangeEntry.engine_seq`. JSON
  payloads are forward-compatible via `#[serde(default)]` where
  applicable.
- `OrderBookSnapshotPackage` carries `engine_seq` so
  `restore_from_snapshot_package` resumes monotonicity exactly. Snapshot
  format version bumped from `1` to `2`; `version: 1` payloads are
  rejected by `validate()` with the existing error.
- New `pub fn OrderBook::next_engine_seq(&self) -> u64` (mints next via
  `fetch_add(1, Relaxed)`) and `pub fn engine_seq(&self) -> u64` (current
  value, used by snapshotting).
- `BookChangeBatch.sequence` retains its existing per-batch
  publisher-counter semantics; cross-stream gap detection moves to the
  per-event `BookChangeEntry.engine_seq`.
- `Cargo.toml` stays at `0.7.0` per project policy — `0.7.0` is
  unreleased and accumulates issues #51..#60.

## Out of scope

- `OrderStateEvent` — the type does not exist today; emission of
  `OrderStateTracker` transitions as a third outbound stream is deferred
  to a follow-up issue.
- Replay byte-equality oracle (`EventSerializer`-based) — widened in #57.

## Commits

```
80d5ab0 docs: document engine_seq contract in CHANGELOG and lib.rs
6abc4d1 test(orderbook): proptest engine_seq is strictly monotonic
e7b5e7a feat(snapshot): persist engine_seq across snapshot/restore (format v2)
fbf6e9f feat(orderbook): add engine_seq to outbound event types
a696715 feat(orderbook): add engine_seq counter to OrderBook<T>
```

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] `cargo test --all-features` — 566 + 25 + 376 + 44 (4 pre-existing
      ignored) = **1011** tests pass.
- [x] New unit tests:
  - 2 in `OrderBook::next_engine_seq` (start-at-zero, concurrent
    monotonicity across 4 threads × 1000 calls).
  - 3 in `tests/book.rs` — trade carries seq, price-level carries seq,
    cross-stream strictly monotonic.
  - 4 in `tests/snapshot.rs` — round-trip, version-mismatch rejection,
    field round-trip, missing-field default.
  - Round-trip serde tests in `trade.rs`, `book_change_event.rs`,
    `nats_book_change.rs`.
- [x] New integration proptest
      `tests/unit/engine_seq_monotonic_tests.rs` (256 cases) covering
      cross-stream monotonicity and per-event uniqueness.
- [x] `cargo build --release --all-features` — clean.

## Snapshot format break

Snapshot packages with `version: 1` now fail `validate()`. Re-snapshot
under 0.7.0 to migrate. CHANGELOG calls this out in the Notes block.

## Closes

Closes #52.
