### PR TITLE
Operational kill switch with halt-and-drain semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > below group changes by feature; everything ships in the same
 > 0.7.0 publish.
 
+### Added — kill switch (#53)
+
+- **Operational kill switch** on `OrderBook<T>`. New `AtomicBool` on
+  the book and three public methods:
+  `pub fn engage_kill_switch(&self)`,
+  `pub fn release_kill_switch(&self)`,
+  `pub fn is_kill_switch_engaged(&self) -> bool`.
+  While engaged, every public `submit_market_order*`, `add_order`,
+  and non-`Cancel` `update_order` call returns the new
+  `OrderBookError::KillSwitchActive` variant before any matching, fee,
+  or STP work happens — at the cost of a single
+  `AtomicBool::load(Relaxed)` on the gate. Cancel and mass-cancel
+  paths are explicitly **not** gated so operators can drain the
+  resting book in an orderly way. Idempotent.
+- **`OrderBookError::KillSwitchActive`** — new typed reject variant.
+  Additive on the existing `#[non_exhaustive]` enum.
+- **Snapshot persistence**. `OrderBookSnapshotPackage` carries
+  `kill_switch_engaged: bool` (with `#[serde(default)]` for JSON
+  forward-compat). `restore_from_snapshot_package` resumes the
+  operational state. Snapshot format version stays at `2` — the
+  field is purely additive.
+- **`OrderStateTracker` integration**. When a tracker is configured
+  on the book and a kill-switched submit / modify is rejected, the
+  engine records `OrderStatus::Rejected { reason: "kill switch active" }`
+  via the existing `OrderStateTracker::transition`. A future typed
+  `RejectReason` (issue #55) will replace the string code.
+- New example: `examples/src/bin/kill_switch_drain.rs` — operator
+  halt-and-drain demo. Run with
+  `cargo run --bin kill_switch_drain --manifest-path examples/Cargo.toml`.
+- Integration tests: `tests/unit/kill_switch_tests.rs` covers every
+  gated and non-gated entry point plus snapshot round-trip and
+  legacy v2 payload (without the new field) defaulting to `false`.
+
+### Notes — kill switch
+
+- The low-level `OrderBook::match_market_order` /
+  `OrderBook::match_limit_order` entry points are **not** gated.
+  Production flow goes through the `submit_*` / `add_order` /
+  `update_order` public surface; this is documented in the rustdoc on
+  `engage_kill_switch`.
+- The kill switch is operator-driven, not journaled. A book restored
+  via `ReplayEngine::replay_from*` starts with the kill switch
+  disengaged regardless of the original journal author's state.
+  Snapshot/restore preserves it; replay does not.
+
 ### Added — global `engine_seq` (#52)
 
 - **Global monotonic `engine_seq`** across every outbound stream.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,28 @@ This order book engine is built with the following design principles:
 
 ### What's New in Version 0.7.0
 
+#### v0.7.0 — Operational kill switch
+
+- **New `OrderBook::engage_kill_switch()`,
+  `OrderBook::release_kill_switch()`, and
+  `OrderBook::is_kill_switch_engaged()`** — atomic operational halt
+  for new flow. While engaged, every `submit_market_order*`,
+  `add_order`, and non-`Cancel` `update_order` call returns the new
+  [`OrderBookError::KillSwitchActive`] variant before any matching,
+  fee, or STP work happens. Cancel and mass-cancel paths are
+  explicitly **not** gated so operators can drain the resting book.
+  The flag persists across snapshot/restore.
+- **`OrderBookError::KillSwitchActive`** — new typed reject variant
+  on the existing `#[non_exhaustive]` enum.
+- **`OrderBookSnapshotPackage.kill_switch_engaged: bool`** —
+  operational state persists across snapshot/restore. Snapshot
+  format version stays at `2`; the field is additive via
+  `#[serde(default)]`.
+- When an `OrderStateTracker` is configured, kill-switched
+  rejections are recorded as
+  `OrderStatus::Rejected { reason: "kill switch active" }`.
+- Example: `examples/src/bin/kill_switch_drain.rs`.
+
 #### v0.7.0 — Global `engine_seq` across outbound streams
 
 - **New `OrderBook::next_engine_seq()` and `OrderBook::engine_seq()`**

--- a/examples/src/bin/kill_switch_drain.rs
+++ b/examples/src/bin/kill_switch_drain.rs
@@ -1,0 +1,128 @@
+// examples/src/bin/kill_switch_drain.rs
+//
+// Operator-style demo of the kill switch (issue #53).
+//
+// Walks through the canonical halt-and-drain sequence:
+//   1. Build a book and seed it with resting limit orders.
+//   2. Engage the kill switch.
+//   3. Demonstrate that submit / add_order are rejected while
+//      cancel and mass-cancel keep working.
+//   4. Drain the resting book via `cancel_all_orders`.
+//   5. Release the kill switch and submit a fresh order to confirm
+//      normal flow has resumed.
+
+use orderbook_rs::{OrderBook, OrderBookError};
+use pricelevel::{
+    Hash32, Id, OrderType, Price, Quantity, Side, TimeInForce, TimestampMs, setup_logger,
+};
+use tracing::{info, warn};
+
+fn main() {
+    let _ = setup_logger();
+    info!("Kill switch drain example");
+
+    let book = OrderBook::<()>::new("BTC/USD");
+
+    seed_resting_orders(&book);
+    info!(
+        "Seeded book with {} resting orders",
+        book.get_all_orders().len()
+    );
+
+    info!("Engaging kill switch — new flow should be halted");
+    book.engage_kill_switch();
+    assert!(book.is_kill_switch_engaged());
+
+    demo_submit_rejected_while_engaged(&book);
+    demo_cancel_still_works_while_engaged(&book);
+    drain_remaining_book(&book);
+
+    info!("Releasing kill switch — book should accept new flow again");
+    book.release_kill_switch();
+    assert!(!book.is_kill_switch_engaged());
+
+    demo_submit_succeeds_after_release(&book);
+
+    info!("Kill switch drain example complete");
+}
+
+fn seed_resting_orders(book: &OrderBook<()>) {
+    let user = Hash32::zero();
+    let timestamp = TimestampMs::new(0);
+
+    let orders: [(u64, u128, u64, Side); 4] = [
+        (1, 100, 10, Side::Buy),
+        (2, 99, 5, Side::Buy),
+        (3, 101, 7, Side::Sell),
+        (4, 102, 4, Side::Sell),
+    ];
+
+    for (id, price, qty, side) in orders {
+        let order = OrderType::Standard {
+            id: Id::from_u64(id),
+            price: Price::new(price),
+            quantity: Quantity::new(qty),
+            side,
+            time_in_force: TimeInForce::Gtc,
+            user_id: user,
+            timestamp,
+            extra_fields: (),
+        };
+        if let Err(err) = book.add_order(order) {
+            warn!("seed add_order failed: {err}");
+        }
+    }
+}
+
+fn demo_submit_rejected_while_engaged(book: &OrderBook<()>) {
+    let order = OrderType::Standard {
+        id: Id::from_u64(99),
+        price: Price::new(100),
+        quantity: Quantity::new(1),
+        side: Side::Buy,
+        time_in_force: TimeInForce::Gtc,
+        user_id: Hash32::zero(),
+        timestamp: TimestampMs::new(0),
+        extra_fields: (),
+    };
+
+    match book.add_order(order) {
+        Err(OrderBookError::KillSwitchActive) => {
+            info!("add_order correctly rejected with KillSwitchActive");
+        }
+        other => warn!("expected KillSwitchActive, got {other:?}"),
+    }
+}
+
+fn demo_cancel_still_works_while_engaged(book: &OrderBook<()>) {
+    match book.cancel_order(Id::from_u64(2)) {
+        Ok(_) => info!("cancel_order(id=2) succeeded while kill switch engaged"),
+        Err(err) => warn!("cancel_order failed unexpectedly: {err}"),
+    }
+}
+
+fn drain_remaining_book(book: &OrderBook<()>) {
+    let result = book.cancel_all_orders();
+    info!(
+        "cancel_all_orders drained {} remaining order(s) while kill switch engaged",
+        result.cancelled_count()
+    );
+}
+
+fn demo_submit_succeeds_after_release(book: &OrderBook<()>) {
+    let order = OrderType::Standard {
+        id: Id::from_u64(100),
+        price: Price::new(100),
+        quantity: Quantity::new(3),
+        side: Side::Buy,
+        time_in_force: TimeInForce::Gtc,
+        user_id: Hash32::zero(),
+        timestamp: TimestampMs::new(0),
+        extra_fields: (),
+    };
+
+    match book.add_order(order) {
+        Ok(_) => info!("post-release add_order succeeded as expected"),
+        Err(err) => warn!("post-release add_order failed: {err}"),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,28 @@
 //!
 //! ## What's New in Version 0.7.0
 //!
+//! ### v0.7.0 — Operational kill switch
+//!
+//! - **New `OrderBook::engage_kill_switch()`,
+//!   `OrderBook::release_kill_switch()`, and
+//!   `OrderBook::is_kill_switch_engaged()`** — atomic operational halt
+//!   for new flow. While engaged, every `submit_market_order*`,
+//!   `add_order`, and non-`Cancel` `update_order` call returns the new
+//!   [`OrderBookError::KillSwitchActive`] variant before any matching,
+//!   fee, or STP work happens. Cancel and mass-cancel paths are
+//!   explicitly **not** gated so operators can drain the resting book.
+//!   The flag persists across snapshot/restore.
+//! - **`OrderBookError::KillSwitchActive`** — new typed reject variant
+//!   on the existing `#[non_exhaustive]` enum.
+//! - **`OrderBookSnapshotPackage.kill_switch_engaged: bool`** —
+//!   operational state persists across snapshot/restore. Snapshot
+//!   format version stays at `2`; the field is additive via
+//!   `#[serde(default)]`.
+//! - When an `OrderStateTracker` is configured, kill-switched
+//!   rejections are recorded as
+//!   `OrderStatus::Rejected { reason: "kill switch active" }`.
+//! - Example: `examples/src/bin/kill_switch_drain.rs`.
+//!
 //! ### v0.7.0 — Global `engine_seq` across outbound streams
 //!
 //! - **New `OrderBook::next_engine_seq()` and `OrderBook::engine_seq()`**

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -2416,6 +2416,7 @@ where
         package.min_order_size = self.min_order_size;
         package.max_order_size = self.max_order_size;
         package.engine_seq = self.engine_seq();
+        package.kill_switch_engaged = self.is_kill_switch_engaged();
         Ok(package)
     }
 
@@ -2428,8 +2429,15 @@ where
     ///
     /// This restores both the order data and the configuration fields
     /// (`fee_schedule`, `stp_mode`, `tick_size`, `lot_size`,
-    /// `min_order_size`, `max_order_size`) that were captured by
+    /// `min_order_size`, `max_order_size`, `engine_seq`,
+    /// `kill_switch_engaged`) that were captured by
     /// [`create_snapshot_package`](Self::create_snapshot_package).
+    ///
+    /// The kill-switch flag is operator-driven and not journaled by
+    /// the sequencer; it travels with snapshot packages only. Replay
+    /// (`ReplayEngine::replay_from*`) starts a fresh book with
+    /// `kill_switch_engaged = false`, and operators must engage it
+    /// explicitly post-replay if needed.
     pub fn restore_from_snapshot_package(
         &mut self,
         package: OrderBookSnapshotPackage,
@@ -2442,6 +2450,7 @@ where
         let min_order_size = package.min_order_size;
         let max_order_size = package.max_order_size;
         let engine_seq = package.engine_seq;
+        let kill_switch_engaged = package.kill_switch_engaged;
 
         self.restore_from_snapshot(package.into_snapshot()?)?;
 
@@ -2458,6 +2467,12 @@ where
         // exactly the snapshotted value, preserving cross-snapshot
         // monotonicity for downstream consumers.
         self.engine_seq.store(engine_seq, Ordering::Release);
+
+        // Restore the operational kill-switch flag so that a book
+        // recovered from disaster snapshot resumes in the same
+        // operational mode it was halted in.
+        self.kill_switch
+            .store(kill_switch_engaged, Ordering::Relaxed);
 
         Ok(())
     }

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -518,11 +518,7 @@ where
     /// construction); on the cold rejection path the tracker reason
     /// string is constructed via `to_string`.
     #[inline]
-    #[allow(dead_code)]
-    pub(super) fn check_kill_switch_or_reject(
-        &self,
-        order_id: Id,
-    ) -> Result<(), OrderBookError> {
+    pub(super) fn check_kill_switch_or_reject(&self, order_id: Id) -> Result<(), OrderBookError> {
         if self.is_kill_switch_engaged() {
             self.track_state(
                 order_id,

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -512,6 +512,18 @@ where
     /// recording an `OrderStatus::Rejected` transition for `order_id`
     /// when an order state tracker is configured.
     ///
+    /// Use this from **new-flow** entry points (`submit_*`, `add_order`,
+    /// `add_*_with_user`) where `order_id` identifies an order that has
+    /// not yet entered the book — the `Rejected` lifecycle status is
+    /// then accurate and consistent with its documented "rejected during
+    /// validation, never entered" semantic.
+    ///
+    /// For modify / replace paths against orders already resting in the
+    /// book, use [`Self::check_kill_switch`] instead — recording
+    /// `Rejected` against a live order would corrupt the lifecycle
+    /// state (the order remains active, the modification is what was
+    /// rejected).
+    ///
     /// Returns `Err(OrderBookError::KillSwitchActive)` when engaged so
     /// callers can early-return before any matching, fee, or STP work.
     /// Allocation-free on the happy path (no tracker write, no error
@@ -526,6 +538,22 @@ where
                     reason: "kill switch active".to_string(),
                 },
             );
+            return Err(OrderBookError::KillSwitchActive);
+        }
+        Ok(())
+    }
+
+    /// Reject the current operation if the kill switch is engaged
+    /// **without** recording a tracker transition.
+    ///
+    /// Use this from modify / replace paths (`update_order` non-`Cancel`
+    /// variants) where the existing order remains live — recording it
+    /// as `Rejected` would conflict with the documented terminal-state
+    /// semantic (`Rejected` means "never entered the book"). Only the
+    /// modification is rejected; the underlying order stays as-is.
+    #[inline]
+    pub(super) fn check_kill_switch(&self) -> Result<(), OrderBookError> {
+        if self.is_kill_switch_engaged() {
             return Err(OrderBookError::KillSwitchActive);
         }
         Ok(())

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -84,6 +84,15 @@ pub struct OrderBook<T = ()> {
     /// into a fresh book yields fresh seqs, not the originals.
     pub(super) engine_seq: AtomicU64,
 
+    /// Operational kill switch. When `true`, every public `submit_*`,
+    /// `add_order`, and non-cancel `update_order` call short-circuits with
+    /// [`OrderBookError::KillSwitchActive`] before any matching, fee, STP,
+    /// or allocation work happens. Cancel and mass-cancel paths are
+    /// explicitly **not** gated so operators can drain the resting book.
+    /// Persisted across snapshot/restore via
+    /// [`OrderBookSnapshotPackage::kill_switch_engaged`](super::snapshot::OrderBookSnapshotPackage::kill_switch_engaged).
+    pub(super) kill_switch: AtomicBool,
+
     /// The last price at which a trade occurred
     pub(super) last_trade_price: AtomicCell<u128>,
 
@@ -407,6 +416,7 @@ where
             transaction_id_generator: UuidGenerator::new(namespace),
             next_order_id: AtomicU64::new(1),
             engine_seq: AtomicU64::new(0),
+            kill_switch: AtomicBool::new(false),
             last_trade_price: AtomicCell::new(0),
             has_traded: AtomicBool::new(false),
             market_close_timestamp: AtomicU64::new(0),
@@ -468,6 +478,63 @@ where
         self.engine_seq.load(Ordering::Acquire)
     }
 
+    /// Engage the kill switch. While engaged, every public `submit_*`,
+    /// `add_order`, and non-cancel `update_order` call returns
+    /// [`OrderBookError::KillSwitchActive`] before any matching, fee,
+    /// or STP work happens. Cancel and mass-cancel paths are
+    /// explicitly **not** gated so operators can drain the resting book.
+    ///
+    /// The flag persists across snapshot/restore. Idempotent — calling
+    /// while already engaged is a no-op.
+    ///
+    /// Note: the low-level [`Self::match_market_order`] /
+    /// [`Self::match_limit_order`] entry points are not gated.
+    /// Production flow goes through the `submit_*` / `add_order` /
+    /// `update_order` public surface.
+    pub fn engage_kill_switch(&self) {
+        self.kill_switch.store(true, Ordering::Relaxed);
+    }
+
+    /// Release the kill switch and resume accepting new flow.
+    /// Idempotent.
+    pub fn release_kill_switch(&self) {
+        self.kill_switch.store(false, Ordering::Relaxed);
+    }
+
+    /// Current state of the kill switch.
+    #[inline]
+    #[must_use]
+    pub fn is_kill_switch_engaged(&self) -> bool {
+        self.kill_switch.load(Ordering::Relaxed)
+    }
+
+    /// Reject the current operation if the kill switch is engaged,
+    /// recording an `OrderStatus::Rejected` transition for `order_id`
+    /// when an order state tracker is configured.
+    ///
+    /// Returns `Err(OrderBookError::KillSwitchActive)` when engaged so
+    /// callers can early-return before any matching, fee, or STP work.
+    /// Allocation-free on the happy path (no tracker write, no error
+    /// construction); on the cold rejection path the tracker reason
+    /// string is constructed via `to_string`.
+    #[inline]
+    #[allow(dead_code)]
+    pub(super) fn check_kill_switch_or_reject(
+        &self,
+        order_id: Id,
+    ) -> Result<(), OrderBookError> {
+        if self.is_kill_switch_engaged() {
+            self.track_state(
+                order_id,
+                super::order_state::OrderStatus::Rejected {
+                    reason: "kill switch active".to_string(),
+                },
+            );
+            return Err(OrderBookError::KillSwitchActive);
+        }
+        Ok(())
+    }
+
     /// Create a new order book for the given symbol with tick size validation.
     ///
     /// Orders added to this book must have prices that are exact multiples
@@ -517,6 +584,7 @@ where
             transaction_id_generator: UuidGenerator::new(namespace),
             next_order_id: AtomicU64::new(1),
             engine_seq: AtomicU64::new(0),
+            kill_switch: AtomicBool::new(false),
             last_trade_price: AtomicCell::new(0),
             has_traded: AtomicBool::new(false),
             market_close_timestamp: AtomicU64::new(0),
@@ -563,6 +631,7 @@ where
             transaction_id_generator: UuidGenerator::new(namespace),
             next_order_id: AtomicU64::new(1),
             engine_seq: AtomicU64::new(0),
+            kill_switch: AtomicBool::new(false),
             last_trade_price: AtomicCell::new(0),
             has_traded: AtomicBool::new(false),
             market_close_timestamp: AtomicU64::new(0),

--- a/src/orderbook/book_change_event.rs
+++ b/src/orderbook/book_change_event.rs
@@ -1,6 +1,6 @@
 //! Price-level change events emitted by the order book.
 //!
-//! Each [`PriceLevelChangedEvent`] carries an `engine_seq` minted by
+//! Each `PriceLevelChangedEvent` carries an `engine_seq` minted by
 //! `OrderBook::next_engine_seq` immediately before emission. The same
 //! counter is shared with `TradeResult`, so the union of trade events
 //! and price-level events emitted by a single `OrderBook<T>` instance

--- a/src/orderbook/error.rs
+++ b/src/orderbook/error.rs
@@ -157,7 +157,10 @@ impl fmt::Display for OrderBookError {
                 write!(f, "Invalid operation: {message}")
             }
             OrderBookError::KillSwitchActive => {
-                write!(f, "kill switch active: new order entry is halted")
+                write!(
+                    f,
+                    "kill switch active: new order entry and modifications are halted"
+                )
             }
             OrderBookError::SerializationError { message } => {
                 write!(f, "Serialization error: {message}")

--- a/src/orderbook/error.rs
+++ b/src/orderbook/error.rs
@@ -42,6 +42,11 @@ pub enum OrderBookError {
         message: String,
     },
 
+    /// New flow (submit / modify / replace) is rejected because the
+    /// kill switch is engaged. Cancel and mass-cancel paths still
+    /// operate so operators can drain the book in an orderly way.
+    KillSwitchActive,
+
     /// Error while serializing snapshot data
     SerializationError {
         /// Underlying error message
@@ -150,6 +155,9 @@ impl fmt::Display for OrderBookError {
             }
             OrderBookError::InvalidOperation { message } => {
                 write!(f, "Invalid operation: {message}")
+            }
+            OrderBookError::KillSwitchActive => {
+                write!(f, "kill switch active: new order entry is halted")
             }
             OrderBookError::SerializationError { message } => {
                 write!(f, "Serialization error: {message}")
@@ -284,6 +292,7 @@ impl Clone for OrderBookError {
             OrderBookError::InvalidOperation { message } => OrderBookError::InvalidOperation {
                 message: message.clone(),
             },
+            OrderBookError::KillSwitchActive => OrderBookError::KillSwitchActive,
             OrderBookError::SerializationError { message } => OrderBookError::SerializationError {
                 message: message.clone(),
             },

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -118,10 +118,29 @@ where
     T: Clone + Send + Sync + Default + 'static,
 {
     /// Update an order's price and/or quantity
+    ///
+    /// # Errors
+    /// Returns [`OrderBookError::KillSwitchActive`] when the kill switch
+    /// is engaged and the update is anything other than
+    /// [`OrderUpdate::Cancel`]. Cancels are explicitly allowed so that
+    /// operators can drain resting orders while new flow is halted.
     pub fn update_order(
         &self,
         update: OrderUpdate,
     ) -> Result<Option<Arc<OrderType<T>>>, OrderBookError> {
+        // Gate non-cancel variants on the kill switch. Cancel passes
+        // through unchanged so operators can drain the book.
+        let gated_id = match &update {
+            OrderUpdate::Cancel { .. } => None,
+            OrderUpdate::UpdatePrice { order_id, .. }
+            | OrderUpdate::UpdateQuantity { order_id, .. }
+            | OrderUpdate::UpdatePriceAndQuantity { order_id, .. }
+            | OrderUpdate::Replace { order_id, .. } => Some(*order_id),
+        };
+        if let Some(id) = gated_id {
+            self.check_kill_switch_or_reject(id)?;
+        }
+
         self.cache.invalidate();
         trace!("Order book {}: Updating order {:?}", self.symbol, update);
         match update {
@@ -554,7 +573,13 @@ where
     }
 
     /// Add a new order to the book, automatically matching it if it's aggressive.
+    ///
+    /// # Errors
+    /// Returns [`OrderBookError::KillSwitchActive`] when the kill switch
+    /// is engaged. The check runs before any cache invalidation, STP
+    /// validation, tick/lot validation, or matching work.
     pub fn add_order(&self, mut order: OrderType<T>) -> Result<Arc<OrderType<T>>, OrderBookError> {
+        self.check_kill_switch_or_reject(order.id())?;
         self.cache.invalidate();
 
         trace!(

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -129,16 +129,20 @@ where
         update: OrderUpdate,
     ) -> Result<Option<Arc<OrderType<T>>>, OrderBookError> {
         // Gate non-cancel variants on the kill switch. Cancel passes
-        // through unchanged so operators can drain the book.
-        let gated_id = match &update {
-            OrderUpdate::Cancel { .. } => None,
-            OrderUpdate::UpdatePrice { order_id, .. }
-            | OrderUpdate::UpdateQuantity { order_id, .. }
-            | OrderUpdate::UpdatePriceAndQuantity { order_id, .. }
-            | OrderUpdate::Replace { order_id, .. } => Some(*order_id),
-        };
-        if let Some(id) = gated_id {
-            self.check_kill_switch_or_reject(id)?;
+        // through unchanged so operators can drain the book. The
+        // existing order stays live — only the modification is
+        // rejected — so we use `check_kill_switch` (no tracker
+        // recording) rather than `check_kill_switch_or_reject` (which
+        // would mark a live order as terminal-Rejected).
+        let is_modify = matches!(
+            &update,
+            OrderUpdate::UpdatePrice { .. }
+                | OrderUpdate::UpdateQuantity { .. }
+                | OrderUpdate::UpdatePriceAndQuantity { .. }
+                | OrderUpdate::Replace { .. }
+        );
+        if is_modify {
+            self.check_kill_switch()?;
         }
 
         self.cache.invalidate();

--- a/src/orderbook/operations.rs
+++ b/src/orderbook/operations.rs
@@ -234,12 +234,18 @@ where
     ///
     /// This convenience method bypasses STP (uses `Hash32::zero()`).
     /// Use [`Self::submit_market_order_with_user`] when STP is needed.
+    ///
+    /// # Errors
+    /// Returns [`OrderBookError::KillSwitchActive`] when the kill switch
+    /// is engaged. The check happens at the top of the function before
+    /// any matching, fee, or STP work.
     pub fn submit_market_order(
         &self,
         id: Id,
         quantity: u64,
         side: Side,
     ) -> Result<MatchResult, OrderBookError> {
+        self.check_kill_switch_or_reject(id)?;
         trace!("Submitting market order {} {} {}", id, quantity, side);
         OrderBook::<T>::match_market_order(self, id, quantity, side)
     }
@@ -258,7 +264,10 @@ where
     ///
     /// # Errors
     /// Returns [`OrderBookError::SelfTradePrevented`] when STP cancels the
-    /// taker before any fills occur.
+    /// taker before any fills occur. Returns
+    /// [`OrderBookError::KillSwitchActive`] when the kill switch is
+    /// engaged; the check happens at the top of the function before any
+    /// matching, fee, or STP work.
     pub fn submit_market_order_with_user(
         &self,
         id: Id,
@@ -266,6 +275,7 @@ where
         side: Side,
         user_id: Hash32,
     ) -> Result<MatchResult, OrderBookError> {
+        self.check_kill_switch_or_reject(id)?;
         trace!(
             "Submitting market order {} {} {} (user: {})",
             id, quantity, side, user_id

--- a/src/orderbook/operations.rs
+++ b/src/orderbook/operations.rs
@@ -66,6 +66,9 @@ where
         user_id: Hash32,
         extra_fields: Option<T>,
     ) -> Result<Arc<OrderType<T>>, OrderBookError> {
+        // Top-of-fn kill-switch gate so we skip the clock read and
+        // extra_fields / OrderType construction below when halted.
+        self.check_kill_switch_or_reject(id)?;
         let extra_fields: T = extra_fields.unwrap_or_default();
         let order = OrderType::Standard {
             id,
@@ -141,6 +144,9 @@ where
         user_id: Hash32,
         extra_fields: Option<T>,
     ) -> Result<Arc<OrderType<T>>, OrderBookError> {
+        // Top-of-fn kill-switch gate so we skip the clock read and
+        // extra_fields / OrderType construction below when halted.
+        self.check_kill_switch_or_reject(id)?;
         let extra_fields: T = extra_fields.unwrap_or_default();
         let order = OrderType::IcebergOrder {
             id,
@@ -212,6 +218,9 @@ where
         user_id: Hash32,
         extra_fields: Option<T>,
     ) -> Result<Arc<OrderType<T>>, OrderBookError> {
+        // Top-of-fn kill-switch gate so we skip the clock read and
+        // extra_fields / OrderType construction below when halted.
+        self.check_kill_switch_or_reject(id)?;
         let extra_fields: T = extra_fields.unwrap_or_default();
         let order = OrderType::PostOnly {
             id,

--- a/src/orderbook/snapshot.rs
+++ b/src/orderbook/snapshot.rs
@@ -203,6 +203,19 @@ pub struct OrderBookSnapshotPackage {
     /// [`OrderBookSnapshotPackage::validate`].
     #[serde(default)]
     pub engine_seq: u64,
+
+    /// Operational state of the kill switch at the time of snapshot.
+    /// Restored as-is by
+    /// [`OrderBook::restore_from_snapshot_package`](super::book::OrderBook::restore_from_snapshot_package)
+    /// so disaster-recovered books resume in the same operational mode
+    /// they were halted in.
+    ///
+    /// `#[serde(default)]` keeps the format version at `2`: payloads
+    /// written before this field existed deserialize with `false`,
+    /// matching the previous (implicit) behaviour where a restored book
+    /// always came back disengaged.
+    #[serde(default)]
+    pub kill_switch_engaged: bool,
 }
 
 impl OrderBookSnapshotPackage {
@@ -223,6 +236,7 @@ impl OrderBookSnapshotPackage {
             min_order_size: None,
             max_order_size: None,
             engine_seq: 0,
+            kill_switch_engaged: false,
         })
     }
 

--- a/src/orderbook/tests/book.rs
+++ b/src/orderbook/tests/book.rs
@@ -1341,4 +1341,38 @@ mod test_book_specific {
             "engine_seq must be strictly monotonic across all outbound streams: {observed:?}"
         );
     }
+
+    #[test]
+    fn test_kill_switch_starts_disengaged() {
+        let book = OrderBook::<()>::new("TEST");
+        assert!(!book.is_kill_switch_engaged());
+    }
+
+    #[test]
+    fn test_engage_release_round_trip() {
+        let book = OrderBook::<()>::new("TEST");
+        book.engage_kill_switch();
+        assert!(book.is_kill_switch_engaged());
+        book.release_kill_switch();
+        assert!(!book.is_kill_switch_engaged());
+    }
+
+    #[test]
+    fn test_engage_is_idempotent() {
+        let book = OrderBook::<()>::new("TEST");
+        book.engage_kill_switch();
+        book.engage_kill_switch();
+        book.engage_kill_switch();
+        assert!(book.is_kill_switch_engaged());
+    }
+
+    #[test]
+    fn test_release_is_idempotent() {
+        let book = OrderBook::<()>::new("TEST");
+        book.engage_kill_switch();
+        book.release_kill_switch();
+        book.release_kill_switch();
+        book.release_kill_switch();
+        assert!(!book.is_kill_switch_engaged());
+    }
 }

--- a/tests/unit/kill_switch_tests.rs
+++ b/tests/unit/kill_switch_tests.rs
@@ -119,6 +119,26 @@ mod tests_kill_switch {
     }
 
     #[test]
+    fn update_order_price_and_quantity_under_kill_switch_returns_kill_switch_active() {
+        let book = new_book();
+        let order_id = Id::new_uuid();
+        book.add_limit_order(order_id, 100, 10, Side::Buy, TimeInForce::Gtc, None)
+            .expect("seed bid");
+
+        book.engage_kill_switch();
+
+        let result = book.update_order(OrderUpdate::UpdatePriceAndQuantity {
+            order_id,
+            new_price: Price::new(99),
+            new_quantity: Quantity::new(7),
+        });
+        assert!(
+            matches!(result, Err(OrderBookError::KillSwitchActive)),
+            "expected KillSwitchActive, got {result:?}"
+        );
+    }
+
+    #[test]
     fn update_order_replace_under_kill_switch_returns_kill_switch_active() {
         let book = new_book();
         let order_id = Id::new_uuid();

--- a/tests/unit/kill_switch_tests.rs
+++ b/tests/unit/kill_switch_tests.rs
@@ -1,0 +1,263 @@
+//! Integration tests for the operational kill switch on `OrderBook<T>`.
+//!
+//! The kill switch halts new flow (`submit_*`, `add_order`, non-cancel
+//! `update_order`) without dropping the book, while keeping cancel and
+//! mass-cancel paths open so operators can drain the resting book.
+
+#[cfg(test)]
+mod tests_kill_switch {
+    use orderbook_rs::orderbook::order_state::{OrderStateTracker, OrderStatus};
+    use orderbook_rs::{OrderBook, OrderBookError};
+    use pricelevel::{Hash32, Id, OrderUpdate, Price, Quantity, Side, TimeInForce};
+
+    fn new_book() -> OrderBook<()> {
+        OrderBook::new("TEST")
+    }
+
+    fn book_with_tracker() -> OrderBook<()> {
+        let mut book = OrderBook::<()>::new("TEST");
+        book.set_order_state_tracker(OrderStateTracker::new());
+        book
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // Submit / add gates
+    // ───────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn submit_market_under_kill_switch_returns_kill_switch_active() {
+        let book = new_book();
+        // Seed liquidity so the only failure mode is the kill switch.
+        book.add_limit_order(Id::new_uuid(), 100, 10, Side::Sell, TimeInForce::Gtc, None)
+            .expect("seed resting ask");
+
+        book.engage_kill_switch();
+
+        let result = book.submit_market_order(Id::new_uuid(), 5, Side::Buy);
+        assert!(
+            matches!(result, Err(OrderBookError::KillSwitchActive)),
+            "expected KillSwitchActive, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn submit_market_with_user_under_kill_switch_returns_kill_switch_active() {
+        let book = new_book();
+        book.add_limit_order(Id::new_uuid(), 100, 10, Side::Sell, TimeInForce::Gtc, None)
+            .expect("seed resting ask");
+
+        book.engage_kill_switch();
+
+        let result = book.submit_market_order_with_user(
+            Id::new_uuid(),
+            5,
+            Side::Buy,
+            Hash32::new([1u8; 32]),
+        );
+        assert!(
+            matches!(result, Err(OrderBookError::KillSwitchActive)),
+            "expected KillSwitchActive, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn add_order_under_kill_switch_returns_kill_switch_active() {
+        let book = new_book();
+        book.engage_kill_switch();
+
+        let result =
+            book.add_limit_order(Id::new_uuid(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        assert!(
+            matches!(result, Err(OrderBookError::KillSwitchActive)),
+            "expected KillSwitchActive, got {result:?}"
+        );
+        assert_eq!(book.best_bid(), None, "rejected order must not rest");
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // update_order — non-cancel variants are gated, Cancel passes
+    // ───────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn update_order_price_under_kill_switch_returns_kill_switch_active() {
+        let book = new_book();
+        let order_id = Id::new_uuid();
+        book.add_limit_order(order_id, 100, 10, Side::Buy, TimeInForce::Gtc, None)
+            .expect("seed bid");
+
+        book.engage_kill_switch();
+
+        let result = book.update_order(OrderUpdate::UpdatePrice {
+            order_id,
+            new_price: Price::new(101),
+        });
+        assert!(
+            matches!(result, Err(OrderBookError::KillSwitchActive)),
+            "expected KillSwitchActive, got {result:?}"
+        );
+        // Original order untouched.
+        assert!(book.get_order(order_id).is_some());
+    }
+
+    #[test]
+    fn update_order_quantity_under_kill_switch_returns_kill_switch_active() {
+        let book = new_book();
+        let order_id = Id::new_uuid();
+        book.add_limit_order(order_id, 100, 10, Side::Buy, TimeInForce::Gtc, None)
+            .expect("seed bid");
+
+        book.engage_kill_switch();
+
+        let result = book.update_order(OrderUpdate::UpdateQuantity {
+            order_id,
+            new_quantity: Quantity::new(20),
+        });
+        assert!(
+            matches!(result, Err(OrderBookError::KillSwitchActive)),
+            "expected KillSwitchActive, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn update_order_replace_under_kill_switch_returns_kill_switch_active() {
+        let book = new_book();
+        let order_id = Id::new_uuid();
+        book.add_limit_order(order_id, 100, 10, Side::Buy, TimeInForce::Gtc, None)
+            .expect("seed bid");
+
+        book.engage_kill_switch();
+
+        let result = book.update_order(OrderUpdate::Replace {
+            order_id,
+            price: Price::new(99),
+            quantity: Quantity::new(7),
+            side: Side::Buy,
+        });
+        assert!(
+            matches!(result, Err(OrderBookError::KillSwitchActive)),
+            "expected KillSwitchActive, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn update_order_cancel_under_kill_switch_succeeds() {
+        let book = new_book();
+        let order_id = Id::new_uuid();
+        book.add_limit_order(order_id, 100, 10, Side::Buy, TimeInForce::Gtc, None)
+            .expect("seed bid");
+
+        book.engage_kill_switch();
+
+        // Cancel must pass through — operators rely on this to drain.
+        let result = book.update_order(OrderUpdate::Cancel { order_id });
+        assert!(
+            result.is_ok(),
+            "Cancel under kill switch must succeed; got {result:?}"
+        );
+        assert!(
+            book.get_order(order_id).is_none(),
+            "order must be cancelled"
+        );
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // Cancel paths are NOT gated
+    // ───────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn cancel_order_under_kill_switch_succeeds() {
+        let book = new_book();
+        let order_id = Id::new_uuid();
+        book.add_limit_order(order_id, 100, 10, Side::Buy, TimeInForce::Gtc, None)
+            .expect("seed bid");
+
+        book.engage_kill_switch();
+
+        let cancelled = book
+            .cancel_order(order_id)
+            .expect("cancel under kill switch");
+        assert!(
+            cancelled.is_some(),
+            "cancel should return the cancelled order"
+        );
+        assert!(book.get_order(order_id).is_none());
+    }
+
+    #[test]
+    fn mass_cancel_by_side_under_kill_switch_succeeds() {
+        let book = new_book();
+        for price in [99, 100, 101] {
+            book.add_limit_order(Id::new_uuid(), price, 5, Side::Buy, TimeInForce::Gtc, None)
+                .expect("seed bid");
+        }
+        book.add_limit_order(Id::new_uuid(), 110, 5, Side::Sell, TimeInForce::Gtc, None)
+            .expect("seed ask");
+
+        book.engage_kill_switch();
+
+        let result = book.cancel_orders_by_side(Side::Buy);
+        assert_eq!(result.cancelled_count(), 3, "all bids must be cancelled");
+        assert_eq!(book.best_bid(), None);
+        assert_eq!(book.best_ask(), Some(110), "ask side untouched");
+    }
+
+    #[test]
+    fn cancel_all_under_kill_switch_succeeds() {
+        let book = new_book();
+        for price in [99, 100] {
+            book.add_limit_order(Id::new_uuid(), price, 5, Side::Buy, TimeInForce::Gtc, None)
+                .expect("seed bid");
+        }
+        for price in [110, 111] {
+            book.add_limit_order(Id::new_uuid(), price, 5, Side::Sell, TimeInForce::Gtc, None)
+                .expect("seed ask");
+        }
+
+        book.engage_kill_switch();
+
+        let result = book.cancel_all_orders();
+        assert_eq!(result.cancelled_count(), 4);
+        assert_eq!(book.best_bid(), None);
+        assert_eq!(book.best_ask(), None);
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // Release resumes new flow; tracker integration
+    // ───────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn release_then_submit_succeeds() {
+        let book = new_book();
+        book.add_limit_order(Id::new_uuid(), 100, 10, Side::Sell, TimeInForce::Gtc, None)
+            .expect("seed resting ask");
+
+        book.engage_kill_switch();
+        let blocked = book.submit_market_order(Id::new_uuid(), 5, Side::Buy);
+        assert!(matches!(blocked, Err(OrderBookError::KillSwitchActive)));
+
+        book.release_kill_switch();
+        let resumed = book.submit_market_order(Id::new_uuid(), 5, Side::Buy);
+        assert!(
+            resumed.is_ok(),
+            "submit must succeed after release; got {resumed:?}"
+        );
+    }
+
+    #[test]
+    fn tracker_records_rejected_on_kill_switch() {
+        let book = book_with_tracker();
+        book.engage_kill_switch();
+
+        let order_id = Id::new_uuid();
+        let result = book.add_limit_order(order_id, 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        assert!(matches!(result, Err(OrderBookError::KillSwitchActive)));
+
+        let status = book.order_status(order_id);
+        match status {
+            Some(OrderStatus::Rejected { reason }) => {
+                assert_eq!(reason, "kill switch active");
+            }
+            other => panic!("expected Rejected with kill switch reason, got {other:?}"),
+        }
+    }
+}

--- a/tests/unit/kill_switch_tests.rs
+++ b/tests/unit/kill_switch_tests.rs
@@ -260,4 +260,73 @@ mod tests_kill_switch {
             other => panic!("expected Rejected with kill switch reason, got {other:?}"),
         }
     }
+
+    // ───────────────────────────────────────────────────────────────────
+    // Snapshot round-trip
+    // ───────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn kill_switch_state_round_trips_through_snapshot() {
+        let original = OrderBook::<()>::new("TEST");
+        original
+            .add_limit_order(Id::new_uuid(), 100, 10, Side::Buy, TimeInForce::Gtc, None)
+            .expect("seed bid");
+        original.engage_kill_switch();
+        assert!(original.is_kill_switch_engaged());
+
+        // Serialize to JSON, deserialize, restore — the canonical disaster
+        // recovery path.
+        let json = original
+            .snapshot_to_json(10)
+            .expect("serialize snapshot to json");
+
+        let mut restored = OrderBook::<()>::new("TEST");
+        restored
+            .restore_from_snapshot_json(&json)
+            .expect("restore from json");
+
+        assert!(
+            restored.is_kill_switch_engaged(),
+            "kill switch state must round-trip through snapshot/restore"
+        );
+
+        // And: the restored book actually enforces the gate.
+        let result =
+            restored.add_limit_order(Id::new_uuid(), 99, 5, Side::Buy, TimeInForce::Gtc, None);
+        assert!(
+            matches!(result, Err(OrderBookError::KillSwitchActive)),
+            "restored book with engaged kill switch must reject new flow; got {result:?}"
+        );
+    }
+
+    #[test]
+    fn legacy_v2_snapshot_without_kill_switch_field_defaults_to_false() {
+        // Build a fresh package and drop the `kill_switch_engaged` key
+        // from the JSON to simulate a v2 payload written before this
+        // field existed. `#[serde(default)]` should fill it back in
+        // with `false` on deserialization.
+        let book = OrderBook::<()>::new("TEST");
+        book.add_limit_order(Id::new_uuid(), 100, 10, Side::Buy, TimeInForce::Gtc, None)
+            .expect("seed bid");
+
+        let json = book.snapshot_to_json(10).expect("serialize");
+        let mut value: serde_json::Value = serde_json::from_str(&json).expect("parse json");
+        let obj = value.as_object_mut().expect("top level object");
+        obj.remove("kill_switch_engaged");
+        let stripped = serde_json::to_string(&value).expect("re-serialize");
+        assert!(
+            !stripped.contains("kill_switch_engaged"),
+            "preflight: stripped JSON must not carry the new field"
+        );
+
+        let mut restored = OrderBook::<()>::new("TEST");
+        restored
+            .restore_from_snapshot_json(&stripped)
+            .expect("restore stripped json");
+
+        assert!(
+            !restored.is_kill_switch_engaged(),
+            "missing field must default to false"
+        );
+    }
 }

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -7,6 +7,7 @@ mod engine_seq_monotonic_tests;
 mod filejournal_edge_case_tests;
 mod implied_volatility_tests;
 mod integration_workflow_tests;
+mod kill_switch_tests;
 mod manager_coverage_tests;
 mod mass_cancel_tests;
 mod matching_coverage_tests;


### PR DESCRIPTION
## Summary

- Adds an operational **kill switch** to `OrderBook<T>` — atomic halt for
  new flow with cancels and mass-cancels left unblocked so operators can
  drain the resting book in an orderly way.
- New public methods: `engage_kill_switch`, `release_kill_switch`,
  `is_kill_switch_engaged`. Backed by a single `AtomicBool` checked at
  the top of every gated entry point (`Ordering::Relaxed` load — ~1
  cycle, zero allocations).
- New typed reject variant `OrderBookError::KillSwitchActive` (additive
  on the existing `#[non_exhaustive]` enum).
- `OrderBookSnapshotPackage.kill_switch_engaged: bool` — operational
  state persists across snapshot/restore. Snapshot format version stays
  at `2`; the field is additive via `#[serde(default)]`.
- When an `OrderStateTracker` is configured, kill-switched rejections
  are recorded as `OrderStatus::Rejected { reason: "kill switch active" }`.
- New example `examples/src/bin/kill_switch_drain.rs` walks through the
  canonical halt-and-drain sequence.

## Gated entry points

| Entry point | Gated? |
|---|---|
| `submit_market_order` / `submit_market_order_with_user` | ✅ |
| `add_order` | ✅ |
| `update_order` (`UpdatePrice`, `UpdateQuantity`, `UpdatePriceAndQuantity`, `Replace`) | ✅ |
| `update_order` (`Cancel`) | ❌ — drain |
| `cancel_order`, `cancel_all_orders`, `cancel_orders_by_*` | ❌ — drain |
| `match_market_order*` / `match_limit_order*` (low-level) | ❌ — documented |

## Out of scope

- `OrderStateEvent` as a first-class outbound stream — deferred to a
  future issue. The tracker integration here uses the existing
  `OrderStateTracker::transition` API and a string `reason`. Issue #55
  will replace that with a typed `RejectReason`.

## Commits

```
b099fa6 docs: document kill switch in CHANGELOG and lib.rs
75888cb examples: add kill_switch_drain demo
02934a2 feat(snapshot): persist kill_switch_engaged across snapshot/restore
06e5d76 feat(orderbook): gate submit, add_order, and non-cancel update paths
b00b7f1 feat(orderbook): add KillSwitchActive variant + AtomicBool on OrderBook
```

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] `cargo test --all-features` — 570 + 25 + 390 + 44 (4 pre-existing
      ignored) = **1029** tests pass.
- [x] New unit tests in `src/orderbook/tests/book.rs`:
  - `test_kill_switch_starts_disengaged`
  - `test_engage_release_round_trip`
  - `test_engage_is_idempotent`
  - `test_release_is_idempotent`
- [x] New integration tests in `tests/unit/kill_switch_tests.rs` (14):
      submit / add_order / update_order (each variant) under
      kill switch, cancel + mass-cancel pass-through, release and
      resubmit, snapshot round-trip, legacy v2 payload defaults to
      `false`, tracker records `Rejected`.
- [x] `cargo run --bin kill_switch_drain --manifest-path examples/Cargo.toml`
      runs cleanly and prints the halt-and-drain sequence.
- [x] `cargo build --release --all-features` — clean.

## Closes

Closes #53.
