### PR TITLE
Pre-trade risk layer: max open, max notional, price band

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > below group changes by feature; everything ships in the same
 > 0.7.0 publish.
 
+### Added — pre-trade risk layer (#54)
+
+- **Pre-trade risk layer** on `OrderBook<T>`. New `RiskConfig` with
+  three opt-in guard-rails and three new typed reject variants on
+  `OrderBookError`:
+  - `max_open_orders_per_account: Option<u64>` →
+    `OrderBookError::RiskMaxOpenOrders { account, current, limit }`
+  - `max_notional_per_account: Option<u128>` →
+    `OrderBookError::RiskMaxNotional { account, current, attempted, limit }`
+  - `price_band_bps: Option<u32>` (with
+    `ReferencePriceSource::{LastTrade, Mid, FixedPrice(u128)}`) →
+    `OrderBookError::RiskPriceBand { submitted, reference, deviation_bps, limit_bps }`
+- **Public API on `OrderBook<T>`**:
+  `pub fn set_risk_config(&mut self, RiskConfig)`,
+  `pub fn risk_config(&self) -> Option<&RiskConfig>`,
+  `pub fn disable_risk(&mut self)`. `RiskConfig` is a builder:
+  `RiskConfig::new().with_max_open_orders_per_account(n).with_max_notional_per_account(n).with_price_band_bps(bps, source)`.
+- **Per-account counters** in `DashMap<Hash32, RiskCounters>` with
+  `open_count: AtomicU64` and `resting_notional: AtomicCell<u128>`.
+  Per-resting-order risk state in `DashMap<Id, RiskEntry>`. All hooks
+  are allocation-free on the happy path.
+- **Check ordering** on submit/add: `kill_switch → risk → STP →
+  fees → match`. Documented in the rustdoc on
+  `RiskState::check_limit_admission`.
+- **Market orders bypass the risk layer** (no submitted price, no
+  rest, no contribution to the open-order count). Kill switch still
+  gates them. Documented.
+- **Reference-price resolution** for `price_band_bps`:
+  - `LastTrade` → `last_trade_price`. Skipped (with one-time
+    `tracing::warn!`) when no trades have occurred.
+  - `Mid` → integer `(best_bid + best_ask) / 2`. One-sided book
+    falls back to `LastTrade`.
+  - `FixedPrice(p)` → caller-supplied `u128` ticks.
+- **Snapshot persistence**. `OrderBookSnapshotPackage` carries
+  `risk_config: Option<RiskConfig>` (with `#[serde(default)]` for
+  forward-compat). On restore, counters and the per-order map are
+  rebuilt by walking the snapshot's resting orders. Snapshot format
+  version stays at `2` — the field is purely additive.
+- **Crate-root re-exports**: `RiskConfig`, `RiskState`,
+  `ReferencePriceSource`. Also surfaced via `prelude`.
+- New example: `examples/src/bin/risk_limits.rs` — operator demo
+  that breaches each gate in sequence.
+- Integration tests `tests/unit/risk_layer_tests.rs` cover every
+  reject path, every state-update hook, market-order bypass, and
+  snapshot round-trip.
+
+### Notes — pre-trade risk layer
+
+- Counters are estimative. The `open_count` and `resting_notional`
+  pair is two independent atomics; no atomic snapshot of the pair is
+  taken. Under high concurrency the check may admit one order beyond
+  the limit before settling — acceptable for a guard-rail (vs. a
+  hard regulatory cap).
+- Risk config is operator-driven, not journaled. Replays via
+  `ReplayEngine::replay_from*` start with no risk gating; operators
+  re-attach config post-replay.
+- `disable_risk()` lifts the gates without dropping per-account
+  counters, so subsequent `set_risk_config(...)` calls re-engage
+  with the existing history intact.
+
 ### Added — kill switch (#53)
 
 - **Operational kill switch** on `OrderBook<T>`. New `AtomicBool` on

--- a/README.md
+++ b/README.md
@@ -48,6 +48,33 @@ This order book engine is built with the following design principles:
 
 ### What's New in Version 0.7.0
 
+#### v0.7.0 — Pre-trade risk layer
+
+- **New [`RiskConfig`]** with three opt-in guard-rails:
+  `max_open_orders_per_account`, `max_notional_per_account`, and
+  `price_band_bps` against a configurable
+  [`ReferencePriceSource`] (`LastTrade` / `Mid` / `FixedPrice`).
+  Builder pattern — `RiskConfig::new().with_*(...)` chained.
+- **Three new typed reject variants** on the existing
+  `#[non_exhaustive]` `OrderBookError`:
+  `RiskMaxOpenOrders`, `RiskMaxNotional`, `RiskPriceBand`. Each
+  carries enough context (account, current, limit, deviation) for
+  downstream consumers to act without parsing a string.
+- **`OrderBook::set_risk_config(...)` / `risk_config()` /
+  `disable_risk()`** — operator-driven gating. Check ordering on
+  submit/add: `kill_switch → risk → STP → fees → match`. Market
+  orders bypass the risk layer (no submitted price, no rest);
+  kill switch still gates them.
+- **Allocation-free** on the happy path. Per-account counters are
+  `(AtomicU64, AtomicCell<u128>)` pairs; per-order risk state is a
+  `DashMap<Id, RiskEntry>`.
+- **`OrderBookSnapshotPackage.risk_config: Option<RiskConfig>`** —
+  config persists across snapshot/restore. On restore, per-account
+  counters and the per-order map are rebuilt by walking the
+  snapshot's resting orders. Snapshot format version stays at `2`;
+  the field is additive via `#[serde(default)]`.
+- Example: `examples/src/bin/risk_limits.rs`.
+
 #### v0.7.0 — Operational kill switch
 
 - **New `OrderBook::engage_kill_switch()`,

--- a/examples/src/bin/risk_limits.rs
+++ b/examples/src/bin/risk_limits.rs
@@ -1,0 +1,159 @@
+// examples/src/bin/risk_limits.rs
+//
+// Operator-style demo of the pre-trade risk layer (issue #54).
+//
+// Configures all three guard-rails on a fresh book and submits orders
+// that breach each in sequence, then submits a clean order to confirm
+// post-rejection state is consistent.
+
+use orderbook_rs::orderbook::risk::{ReferencePriceSource, RiskConfig};
+use orderbook_rs::{OrderBook, OrderBookError};
+use pricelevel::{Hash32, Id, Side, TimeInForce, setup_logger};
+use tracing::{info, warn};
+
+fn account(byte: u8) -> Hash32 {
+    let mut bytes = [0u8; 32];
+    bytes[0] = byte;
+    Hash32::new(bytes)
+}
+
+fn main() {
+    let _ = setup_logger();
+    info!("Risk limits demo");
+
+    let mut book = OrderBook::<()>::new("BTC/USD");
+    let acct_a = account(1);
+
+    // Reference price for the band check needs at least one trade or a
+    // two-sided book. Plant a fresh trade so `LastTrade` resolves.
+    seed_reference_trade(&book);
+
+    book.set_risk_config(
+        RiskConfig::new()
+            .with_max_open_orders_per_account(2)
+            .with_max_notional_per_account(5_000)
+            .with_price_band_bps(1_000, ReferencePriceSource::LastTrade),
+    );
+
+    info!(
+        "Configured: max_open=2, max_notional=5_000, band=1000 bps vs LastTrade ({})",
+        book.last_trade_price().unwrap_or(0)
+    );
+
+    demo_max_open_breach(&book, acct_a);
+    demo_max_notional_breach(&book);
+    demo_price_band_breach(&book, acct_a);
+
+    let acct_b = account(2);
+    submit_clean_order(&book, acct_b);
+
+    info!("Risk limits demo complete");
+}
+
+fn seed_reference_trade(book: &OrderBook<()>) {
+    book.add_limit_order_with_user(
+        Id::from_u64(900),
+        100,
+        1,
+        Side::Sell,
+        TimeInForce::Gtc,
+        account(99),
+        None,
+    )
+    .expect("seed ask");
+    book.submit_market_order_with_user(Id::from_u64(901), 1, Side::Buy, account(98))
+        .expect("trade against seed ask");
+}
+
+fn demo_max_open_breach(book: &OrderBook<()>, acct: Hash32) {
+    info!("--- max_open_orders breach ---");
+    for i in 0..2 {
+        let id = Id::from_u64(100 + i);
+        match book.add_limit_order_with_user(id, 100, 1, Side::Buy, TimeInForce::Gtc, acct, None) {
+            Ok(_) => info!("admitted bid #{i}"),
+            Err(err) => warn!("unexpected reject: {err}"),
+        }
+    }
+    let third = Id::from_u64(102);
+    match book.add_limit_order_with_user(third, 100, 1, Side::Buy, TimeInForce::Gtc, acct, None) {
+        Err(OrderBookError::RiskMaxOpenOrders {
+            current,
+            limit,
+            account: a,
+        }) => {
+            info!(
+                "third bid correctly rejected: account={:?} current={current} limit={limit}",
+                a.as_bytes().first().copied().unwrap_or_default()
+            )
+        }
+        other => warn!("expected RiskMaxOpenOrders, got {other:?}"),
+    }
+
+    // Drain so the next demo starts clean.
+    let _ = book.cancel_order(Id::from_u64(100));
+    let _ = book.cancel_order(Id::from_u64(101));
+}
+
+fn demo_max_notional_breach(book: &OrderBook<()>) {
+    info!("--- max_notional breach ---");
+    let acct = account(3);
+    // Notional limit is 5_000. price * qty = 100 * 40 = 4_000 (within),
+    // then 100 * 20 = 2_000 (would push to 6_000 → reject).
+    book.add_limit_order_with_user(
+        Id::from_u64(200),
+        100,
+        40,
+        Side::Buy,
+        TimeInForce::Gtc,
+        acct,
+        None,
+    )
+    .expect("first bid within notional");
+    let next = Id::from_u64(201);
+    match book.add_limit_order_with_user(next, 100, 20, Side::Buy, TimeInForce::Gtc, acct, None) {
+        Err(OrderBookError::RiskMaxNotional {
+            current,
+            attempted,
+            limit,
+            ..
+        }) => info!(
+            "second bid correctly rejected: current={current} attempted={attempted} limit={limit}"
+        ),
+        other => warn!("expected RiskMaxNotional, got {other:?}"),
+    }
+    let _ = book.cancel_order(Id::from_u64(200));
+}
+
+fn demo_price_band_breach(book: &OrderBook<()>, acct: Hash32) {
+    info!("--- price_band breach ---");
+    // Band is 1000 bps (10%) of last_trade_price = 100, so any bid
+    // below 90 or above 110 breaches the band.
+    let off_band = Id::from_u64(300);
+    match book.add_limit_order_with_user(off_band, 50, 1, Side::Buy, TimeInForce::Gtc, acct, None) {
+        Err(OrderBookError::RiskPriceBand {
+            submitted,
+            reference,
+            deviation_bps,
+            limit_bps,
+        }) => info!(
+            "off-band bid correctly rejected: submitted={submitted} reference={reference} deviation={deviation_bps}bps limit={limit_bps}bps"
+        ),
+        other => warn!("expected RiskPriceBand, got {other:?}"),
+    }
+}
+
+fn submit_clean_order(book: &OrderBook<()>, acct: Hash32) {
+    info!("--- clean order on a fresh account ---");
+    match book.add_limit_order_with_user(
+        Id::from_u64(400),
+        100,
+        1,
+        Side::Buy,
+        TimeInForce::Gtc,
+        acct,
+        None,
+    ) {
+        Ok(_) => info!("clean order admitted"),
+        Err(err) => warn!("clean order failed: {err}"),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,6 +352,7 @@ pub use orderbook::market_impact::{MarketImpact, OrderSimulation};
 pub use orderbook::order_state::{
     CancelReason, OrderStateListener, OrderStateTracker, OrderStatus,
 };
+pub use orderbook::risk::{ReferencePriceSource, RiskConfig, RiskState};
 pub use orderbook::sequencer::{
     InMemoryJournal, Journal, JournalEntry, JournalError, JournalReadIter, ReplayEngine,
     ReplayError, SequencerCommand, SequencerEvent, SequencerResult, snapshots_match,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,33 @@
 //!
 //! ## What's New in Version 0.7.0
 //!
+//! ### v0.7.0 — Pre-trade risk layer
+//!
+//! - **New [`RiskConfig`]** with three opt-in guard-rails:
+//!   `max_open_orders_per_account`, `max_notional_per_account`, and
+//!   `price_band_bps` against a configurable
+//!   [`ReferencePriceSource`] (`LastTrade` / `Mid` / `FixedPrice`).
+//!   Builder pattern — `RiskConfig::new().with_*(...)` chained.
+//! - **Three new typed reject variants** on the existing
+//!   `#[non_exhaustive]` `OrderBookError`:
+//!   `RiskMaxOpenOrders`, `RiskMaxNotional`, `RiskPriceBand`. Each
+//!   carries enough context (account, current, limit, deviation) for
+//!   downstream consumers to act without parsing a string.
+//! - **`OrderBook::set_risk_config(...)` / `risk_config()` /
+//!   `disable_risk()`** — operator-driven gating. Check ordering on
+//!   submit/add: `kill_switch → risk → STP → fees → match`. Market
+//!   orders bypass the risk layer (no submitted price, no rest);
+//!   kill switch still gates them.
+//! - **Allocation-free** on the happy path. Per-account counters are
+//!   `(AtomicU64, AtomicCell<u128>)` pairs; per-order risk state is a
+//!   `DashMap<Id, RiskEntry>`.
+//! - **`OrderBookSnapshotPackage.risk_config: Option<RiskConfig>`** —
+//!   config persists across snapshot/restore. On restore, per-account
+//!   counters and the per-order map are rebuilt by walking the
+//!   snapshot's resting orders. Snapshot format version stays at `2`;
+//!   the field is additive via `#[serde(default)]`.
+//! - Example: `examples/src/bin/risk_limits.rs`.
+//!
 //! ### v0.7.0 — Operational kill switch
 //!
 //! - **New `OrderBook::engage_kill_switch()`,

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -4,6 +4,7 @@ use super::cache::PriceLevelCache;
 use super::clock::{Clock, MonotonicClock};
 use super::error::OrderBookError;
 use super::fees::FeeSchedule;
+use super::risk::{ReferencePriceSource, RiskConfig, RiskState};
 use super::iterators::{LevelInfo, LevelsInRange, LevelsUntilDepth, LevelsWithCumulativeDepth};
 use super::market_impact::{MarketImpact, OrderSimulation};
 use super::snapshot::{EnrichedSnapshot, MetricFlags, OrderBookSnapshot, OrderBookSnapshotPackage};
@@ -92,6 +93,15 @@ pub struct OrderBook<T = ()> {
     /// Persisted across snapshot/restore via
     /// [`OrderBookSnapshotPackage::kill_switch_engaged`](super::snapshot::OrderBookSnapshotPackage::kill_switch_engaged).
     pub(super) kill_switch: AtomicBool,
+
+    /// Pre-trade risk state: optional [`RiskConfig`] plus per-account
+    /// counters and per-order entries. When the embedded config is
+    /// `None` (default), every check is a passthrough and every hook
+    /// is a no-op. Always present so that [`Self::set_risk_config`]
+    /// can engage the gates without constructor changes. The config
+    /// is persisted across snapshot/restore; counters are rebuilt
+    /// post-restore by walking the snapshot's resting orders.
+    pub(super) risk_state: RiskState,
 
     /// The last price at which a trade occurred
     pub(super) last_trade_price: AtomicCell<u128>,
@@ -417,6 +427,7 @@ where
             next_order_id: AtomicU64::new(1),
             engine_seq: AtomicU64::new(0),
             kill_switch: AtomicBool::new(false),
+            risk_state: RiskState::new(),
             last_trade_price: AtomicCell::new(0),
             has_traded: AtomicBool::new(false),
             market_close_timestamp: AtomicU64::new(0),
@@ -559,6 +570,81 @@ where
         Ok(())
     }
 
+    /// Install or replace the active risk configuration on this book.
+    ///
+    /// Counters and per-order risk state are preserved so that history
+    /// from a previously-installed config remains consistent. Pass an
+    /// empty [`RiskConfig`] (built via [`RiskConfig::new`]) to leave
+    /// every gate disabled while keeping counters live for inspection.
+    ///
+    /// Risk gates run in the documented order
+    /// `kill_switch → risk → STP → fees → match`, before any matching,
+    /// fee, or STP work happens.
+    pub fn set_risk_config(&mut self, config: RiskConfig) {
+        self.risk_state.set_config(config);
+    }
+
+    /// Read-only access to the active risk configuration, if any.
+    #[inline]
+    #[must_use]
+    pub fn risk_config(&self) -> Option<&RiskConfig> {
+        self.risk_state.config()
+    }
+
+    /// Drop the active risk configuration. Counters and per-order risk
+    /// state are retained so a subsequent [`Self::set_risk_config`]
+    /// re-engages the gates without dropping history.
+    pub fn disable_risk(&mut self) {
+        self.risk_state.disable();
+    }
+
+    /// Resolve the reference price for the price-band check.
+    ///
+    /// `LastTrade` reads the atomic `last_trade_price` and returns
+    /// `None` when no trade has executed yet on this book. `Mid`
+    /// returns the integer midpoint of the best bid and ask when both
+    /// are present; otherwise it falls back to `LastTrade`.
+    /// `FixedPrice` always returns the operator-pinned value.
+    #[inline]
+    #[must_use]
+    pub(super) fn resolve_reference_price(
+        &self,
+        source: ReferencePriceSource,
+    ) -> Option<u128> {
+        match source {
+            ReferencePriceSource::LastTrade => self.last_trade_price(),
+            ReferencePriceSource::Mid => match (self.best_bid(), self.best_ask()) {
+                (Some(bid), Some(ask)) => Some((bid + ask) / 2),
+                _ => self.last_trade_price(),
+            },
+            ReferencePriceSource::FixedPrice(p) => Some(p),
+        }
+    }
+
+    /// Apply the pre-trade risk gates to a limit-order admission.
+    ///
+    /// Returns `Ok(())` immediately when no risk config is installed.
+    /// Otherwise resolves the reference price (when the price band is
+    /// configured) and delegates to
+    /// [`RiskState::check_limit_admission`]. Allocation-free on the
+    /// happy path; cold rejection allocates one error variant.
+    #[inline]
+    pub(super) fn check_risk_limit_admission(
+        &self,
+        account: pricelevel::Hash32,
+        price: u128,
+        quantity: u64,
+    ) -> Result<(), OrderBookError> {
+        let Some(cfg) = self.risk_state.config() else {
+            return Ok(());
+        };
+        let reference = cfg
+            .reference_price
+            .and_then(|src| self.resolve_reference_price(src));
+        self.risk_state
+            .check_limit_admission(account, price, quantity, reference)
+    }
+
     /// Create a new order book for the given symbol with tick size validation.
     ///
     /// Orders added to this book must have prices that are exact multiples
@@ -609,6 +695,7 @@ where
             next_order_id: AtomicU64::new(1),
             engine_seq: AtomicU64::new(0),
             kill_switch: AtomicBool::new(false),
+            risk_state: RiskState::new(),
             last_trade_price: AtomicCell::new(0),
             has_traded: AtomicBool::new(false),
             market_close_timestamp: AtomicU64::new(0),
@@ -656,6 +743,7 @@ where
             next_order_id: AtomicU64::new(1),
             engine_seq: AtomicU64::new(0),
             kill_switch: AtomicBool::new(false),
+            risk_state: RiskState::new(),
             last_trade_price: AtomicCell::new(0),
             has_traded: AtomicBool::new(false),
             market_close_timestamp: AtomicU64::new(0),

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -4,9 +4,9 @@ use super::cache::PriceLevelCache;
 use super::clock::{Clock, MonotonicClock};
 use super::error::OrderBookError;
 use super::fees::FeeSchedule;
-use super::risk::{ReferencePriceSource, RiskConfig, RiskState};
 use super::iterators::{LevelInfo, LevelsInRange, LevelsUntilDepth, LevelsWithCumulativeDepth};
 use super::market_impact::{MarketImpact, OrderSimulation};
+use super::risk::{ReferencePriceSource, RiskConfig, RiskState};
 use super::snapshot::{EnrichedSnapshot, MetricFlags, OrderBookSnapshot, OrderBookSnapshotPackage};
 use super::statistics::{DepthStats, DistributionBin};
 use crate::orderbook::book_change_event::PriceLevelChangedListener;
@@ -607,10 +607,7 @@ where
     /// `FixedPrice` always returns the operator-pinned value.
     #[inline]
     #[must_use]
-    pub(super) fn resolve_reference_price(
-        &self,
-        source: ReferencePriceSource,
-    ) -> Option<u128> {
+    pub(super) fn resolve_reference_price(&self, source: ReferencePriceSource) -> Option<u128> {
         match source {
             ReferencePriceSource::LastTrade => self.last_trade_price(),
             ReferencePriceSource::Mid => match (self.best_bid(), self.best_ask()) {
@@ -2533,6 +2530,7 @@ where
         package.max_order_size = self.max_order_size;
         package.engine_seq = self.engine_seq();
         package.kill_switch_engaged = self.is_kill_switch_engaged();
+        package.risk_config = self.risk_state.config().cloned();
         Ok(package)
     }
 
@@ -2567,8 +2565,26 @@ where
         let max_order_size = package.max_order_size;
         let engine_seq = package.engine_seq;
         let kill_switch_engaged = package.kill_switch_engaged;
+        let risk_config = package.risk_config.clone();
 
-        self.restore_from_snapshot(package.into_snapshot()?)?;
+        // Take ownership of the validated snapshot. We hold it locally
+        // so that the per-account risk counters can be rebuilt from
+        // `snapshot.bids` / `snapshot.asks` before
+        // `restore_from_snapshot` consumes the snapshot's level vectors.
+        let snapshot = package.into_snapshot()?;
+
+        // Rebuild per-order risk entries and per-account counters by
+        // walking the snapshot's resting orders. Done before
+        // `restore_from_snapshot` consumes the snapshot so we avoid
+        // cloning all level snapshots. The active `RiskConfig` is
+        // applied first; an absent persisted config installs the
+        // default empty config (every check is a no-op passthrough,
+        // identical to `RiskState::new` post-construction state).
+        self.risk_state.set_config(risk_config.unwrap_or_default());
+        self.risk_state
+            .rebuild_from_snapshot(&snapshot.bids, &snapshot.asks);
+
+        self.restore_from_snapshot(snapshot)?;
 
         // Apply configuration that was captured in the package.
         self.fee_schedule = fee_schedule;

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -2573,16 +2573,20 @@ where
         // `restore_from_snapshot` consumes the snapshot's level vectors.
         let snapshot = package.into_snapshot()?;
 
-        // Rebuild per-order risk entries and per-account counters by
-        // walking the snapshot's resting orders. Done before
+        // Preserve the persisted risk-installation state exactly:
+        // install + rebuild only when a config was snapshotted,
+        // otherwise explicitly disable risk so a `risk_config()` call
+        // post-restore returns `None` rather than `Some(empty)`. The
+        // rebuild walks the snapshot's resting orders before
         // `restore_from_snapshot` consumes the snapshot so we avoid
-        // cloning all level snapshots. The active `RiskConfig` is
-        // applied first; an absent persisted config installs the
-        // default empty config (every check is a no-op passthrough,
-        // identical to `RiskState::new` post-construction state).
-        self.risk_state.set_config(risk_config.unwrap_or_default());
-        self.risk_state
-            .rebuild_from_snapshot(&snapshot.bids, &snapshot.asks);
+        // cloning all level snapshots.
+        if let Some(risk_config) = risk_config {
+            self.risk_state.set_config(risk_config);
+            self.risk_state
+                .rebuild_from_snapshot(&snapshot.bids, &snapshot.asks);
+        } else {
+            self.risk_state.disable();
+        }
 
         self.restore_from_snapshot(snapshot)?;
 

--- a/src/orderbook/error.rs
+++ b/src/orderbook/error.rs
@@ -1,6 +1,6 @@
 //! Order book error types
 
-use pricelevel::{PriceLevelError, Side};
+use pricelevel::{Hash32, PriceLevelError, Side};
 use std::fmt;
 
 /// Errors that can occur within the OrderBook
@@ -112,6 +112,53 @@ pub enum OrderBookError {
         user_id: pricelevel::Hash32,
     },
 
+    /// Per-account open-order limit breached.
+    ///
+    /// Returned by limit-order admission when the requesting account
+    /// already has `current` resting orders and the configured ceiling
+    /// is `limit`. `current >= limit` always holds when this variant
+    /// is constructed.
+    RiskMaxOpenOrders {
+        /// Account that breached the limit.
+        account: Hash32,
+        /// Account's current resting-order count at check time.
+        current: u64,
+        /// Configured maximum.
+        limit: u64,
+    },
+
+    /// Per-account notional limit would be breached by this admission.
+    ///
+    /// `current + attempted > limit` always holds when this variant
+    /// is constructed. `attempted` is computed as
+    /// `submitted_quantity * submitted_price`.
+    RiskMaxNotional {
+        /// Account that breached the limit.
+        account: Hash32,
+        /// Account's current resting notional at check time (raw ticks).
+        current: u128,
+        /// Notional this submission would add (raw ticks).
+        attempted: u128,
+        /// Configured maximum (raw ticks).
+        limit: u128,
+    },
+
+    /// Submitted price exceeds the configured price band against the
+    /// reference price.
+    ///
+    /// `deviation_bps > limit_bps` always holds when this variant is
+    /// constructed.
+    RiskPriceBand {
+        /// Limit price submitted by the caller (raw ticks).
+        submitted: u128,
+        /// Resolved reference price at check time (raw ticks).
+        reference: u128,
+        /// Computed deviation in basis points. Saturates at `u32::MAX`.
+        deviation_bps: u32,
+        /// Configured maximum allowed deviation in basis points.
+        limit_bps: u32,
+    },
+
     /// Failed to publish a trade event to NATS JetStream.
     #[cfg(feature = "nats")]
     NatsPublishError {
@@ -206,6 +253,38 @@ impl fmt::Display for OrderBookError {
                 write!(
                     f,
                     "self-trade prevented ({mode}): taker {taker_order_id}, user {user_id}"
+                )
+            }
+            OrderBookError::RiskMaxOpenOrders {
+                account,
+                current,
+                limit,
+            } => {
+                write!(
+                    f,
+                    "risk: account {account} has {current} open orders (limit {limit})"
+                )
+            }
+            OrderBookError::RiskMaxNotional {
+                account,
+                current,
+                attempted,
+                limit,
+            } => {
+                write!(
+                    f,
+                    "risk: account {account} notional {current} + attempted {attempted} would exceed limit {limit}"
+                )
+            }
+            OrderBookError::RiskPriceBand {
+                submitted,
+                reference,
+                deviation_bps,
+                limit_bps,
+            } => {
+                write!(
+                    f,
+                    "risk: submitted price {submitted} deviates {deviation_bps} bps from reference {reference} (limit {limit_bps} bps)"
                 )
             }
             #[cfg(feature = "nats")]
@@ -340,6 +419,37 @@ impl Clone for OrderBookError {
                 mode: *mode,
                 taker_order_id: *taker_order_id,
                 user_id: *user_id,
+            },
+            OrderBookError::RiskMaxOpenOrders {
+                account,
+                current,
+                limit,
+            } => OrderBookError::RiskMaxOpenOrders {
+                account: *account,
+                current: *current,
+                limit: *limit,
+            },
+            OrderBookError::RiskMaxNotional {
+                account,
+                current,
+                attempted,
+                limit,
+            } => OrderBookError::RiskMaxNotional {
+                account: *account,
+                current: *current,
+                attempted: *attempted,
+                limit: *limit,
+            },
+            OrderBookError::RiskPriceBand {
+                submitted,
+                reference,
+                deviation_bps,
+                limit_bps,
+            } => OrderBookError::RiskPriceBand {
+                submitted: *submitted,
+                reference: *reference,
+                deviation_bps: *deviation_bps,
+                limit_bps: *limit_bps,
             },
             #[cfg(feature = "nats")]
             OrderBookError::NatsPublishError { message } => OrderBookError::NatsPublishError {

--- a/src/orderbook/matching.rs
+++ b/src/orderbook/matching.rs
@@ -7,6 +7,7 @@
 use crate::orderbook::book_change_event::PriceLevelChangedEvent;
 use crate::orderbook::order_state::{CancelReason, OrderStatus};
 use crate::orderbook::pool::MatchingPool;
+use crate::orderbook::risk::RiskState;
 use crate::orderbook::stp::{STPAction, check_stp_at_level};
 use crate::{OrderBook, OrderBookError};
 use either::Either;
@@ -165,6 +166,7 @@ where
                                 &self.has_traded,
                                 &self.price_level_changed_listener,
                                 &self.engine_seq,
+                                &self.risk_state,
                                 &mut empty_price_levels,
                             );
                             // Correct remaining: process_level_match set it to
@@ -226,6 +228,7 @@ where
                                 &self.has_traded,
                                 &self.price_level_changed_listener,
                                 &self.engine_seq,
+                                &self.risk_state,
                                 &mut empty_price_levels,
                             );
                             // Correct remaining: process_level_match set it to
@@ -272,6 +275,7 @@ where
                 &self.has_traded,
                 &self.price_level_changed_listener,
                 &self.engine_seq,
+                &self.risk_state,
                 &mut empty_price_levels,
             );
 
@@ -337,6 +341,11 @@ where
     ///
     /// Extracted to avoid code duplication between the normal path and
     /// the STP safe-quantity pre-match path.
+    ///
+    /// `risk_state` is threaded through so each emitted trade decrements
+    /// the maker's per-account `resting_notional` (and `open_count` on
+    /// full fill). The hook is a no-op when no `RiskConfig` is installed,
+    /// matching the rest of the risk plumbing.
     #[allow(clippy::too_many_arguments)]
     fn process_level_match(
         match_result: &mut MatchResult,
@@ -352,6 +361,7 @@ where
             crate::orderbook::book_change_event::PriceLevelChangedListener,
         >,
         engine_seq_counter: &AtomicU64,
+        risk_state: &RiskState,
         empty_price_levels: &mut Vec<u128>,
     ) {
         // Process trades if any occurred
@@ -360,11 +370,17 @@ where
             last_trade_price.store(price);
             has_traded.store(true, Ordering::Relaxed);
 
-            // Add trades to result
+            // Add trades to result and update per-account risk counters
+            // for the maker side of every trade.
             for trade in price_level_match.trades().as_vec() {
                 // add_trade returns Result in v0.7; ignore error since
                 // pricelevel already validated the quantities during matching
                 let _ = match_result.add_trade(*trade);
+                risk_state.on_fill(
+                    trade.maker_order_id(),
+                    trade.quantity().as_u64(),
+                    trade.price().as_u128(),
+                );
             }
 
             // Notify price level changes

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -78,9 +78,9 @@ pub use nats::NatsTradePublisher;
 #[cfg(feature = "nats")]
 pub use nats_book_change::{BookChangeBatch, BookChangeEntry, NatsBookChangePublisher};
 pub use order_state::{CancelReason, OrderStateListener, OrderStateTracker, OrderStatus};
-pub use risk::{ReferencePriceSource, RiskConfig, RiskState};
 #[cfg(feature = "special_orders")]
 pub use repricing::{RepricingOperations, RepricingResult, SpecialOrderTracker};
+pub use risk::{ReferencePriceSource, RiskConfig, RiskState};
 #[cfg(feature = "journal")]
 pub use sequencer::FileJournal;
 pub use sequencer::journal::{Journal, JournalEntry};

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -41,6 +41,9 @@ pub mod mass_cancel;
 /// Order state machine for explicit lifecycle tracking.
 pub mod order_state;
 
+/// Pre-trade risk layer: per-account counters, configurable limits.
+pub mod risk;
+
 /// Pluggable event serialization for NATS publishers and consumers.
 pub mod serialization;
 
@@ -75,6 +78,7 @@ pub use nats::NatsTradePublisher;
 #[cfg(feature = "nats")]
 pub use nats_book_change::{BookChangeBatch, BookChangeEntry, NatsBookChangePublisher};
 pub use order_state::{CancelReason, OrderStateListener, OrderStateTracker, OrderStatus};
+pub use risk::{ReferencePriceSource, RiskConfig, RiskState};
 #[cfg(feature = "special_orders")]
 pub use repricing::{RepricingOperations, RepricingResult, SpecialOrderTracker};
 #[cfg(feature = "journal")]

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -552,6 +552,13 @@ where
                 // Remove the order from the locations map
                 self.order_locations.remove(&order_id);
 
+                // Pre-trade risk hook: drop the per-account counter
+                // contribution before the order leaves the index. Does
+                // not depend on `cancelled_order` because the risk
+                // state already stores `account` and `remaining_qty`.
+                // No-op when no `RiskConfig` is installed.
+                self.risk_state.on_cancel(order_id);
+
                 // Remove the order from the user_orders index
                 self.untrack_user_order(cancelled_order.user_id(), &order_id);
 
@@ -821,6 +828,17 @@ where
             }
             self.order_locations
                 .insert(unit_order_arc.id(), (price, side));
+
+            // Pre-trade risk hook: register the resting order with
+            // the risk state so per-account counters are updated and
+            // future checks see the new contribution. No-op when no
+            // `RiskConfig` is installed.
+            self.risk_state.on_admission(
+                unit_order_arc.id(),
+                order.user_id(),
+                price,
+                match_result.remaining_quantity(),
+            );
 
             // Track the order in the user_orders index
             self.track_user_order(order.user_id(), unit_order_arc.id());

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -584,6 +584,14 @@ where
     /// validation, tick/lot validation, or matching work.
     pub fn add_order(&self, mut order: OrderType<T>) -> Result<Arc<OrderType<T>>, OrderBookError> {
         self.check_kill_switch_or_reject(order.id())?;
+        // Pre-trade risk gate: per-account open-orders / notional /
+        // price band. No-op when no `RiskConfig` is installed.
+        // Documented order: kill_switch → risk → STP → fees → match.
+        self.check_risk_limit_admission(
+            order.user_id(),
+            order.price().as_u128(),
+            order.total_quantity(),
+        )?;
         self.cache.invalidate();
 
         trace!(

--- a/src/orderbook/operations.rs
+++ b/src/orderbook/operations.rs
@@ -255,6 +255,11 @@ where
         side: Side,
     ) -> Result<MatchResult, OrderBookError> {
         self.check_kill_switch_or_reject(id)?;
+        // Pre-trade risk gate. Per design decision C, market orders
+        // currently bypass every check (no submitted price; no rest);
+        // the call exists to keep the gate ordering consistent across
+        // submit and add paths.
+        self.risk_state.check_market_admission(Hash32::zero())?;
         trace!("Submitting market order {} {} {}", id, quantity, side);
         OrderBook::<T>::match_market_order(self, id, quantity, side)
     }
@@ -285,6 +290,10 @@ where
         user_id: Hash32,
     ) -> Result<MatchResult, OrderBookError> {
         self.check_kill_switch_or_reject(id)?;
+        // Pre-trade risk gate. Per design decision C, market orders
+        // currently bypass every check; the call exists to keep the
+        // gate ordering consistent across submit and add paths.
+        self.risk_state.check_market_admission(user_id)?;
         trace!(
             "Submitting market order {} {} {} (user: {})",
             id, quantity, side, user_id

--- a/src/orderbook/risk.rs
+++ b/src/orderbook/risk.rs
@@ -1,0 +1,731 @@
+//! Pre-trade risk layer for `OrderBook<T>`.
+//!
+//! This module provides the operator-driven, opt-in risk gating for new
+//! flow on the order book. It is composed of:
+//!
+//! - [`RiskConfig`] — the operator-supplied limits (per-account open
+//!   orders, per-account notional, price band against a reference price).
+//! - [`ReferencePriceSource`] — selects the reference price used by the
+//!   price-band check.
+//! - [`RiskState`] — bound to an [`OrderBook`](super::book::OrderBook),
+//!   carries the optional config plus per-account counters
+//!   (`DashMap<Hash32, RiskCounters>`) and per-resting-order entries
+//!   (`DashMap<Id, RiskEntry>`). When [`RiskConfig`] is `None`, every
+//!   check returns `Ok(())` and every hook is a no-op — the engine pays
+//!   only the cost of an `Option::is_none` branch.
+//!
+//! Check ordering on submit is documented as
+//! `kill_switch → risk → STP → fees → match`.
+//!
+//! ## Decision C
+//!
+//! Market orders skip every risk check (no submitted price; no rest;
+//! no contribution to the resting open-order count). Kill switch still
+//! gates them. [`RiskState::check_market_admission`] therefore returns
+//! `Ok(())` unconditionally and exists only to keep the gate ordering
+//! consistent across submit and add paths and to leave room for a
+//! future per-account market-order rate limiter without breaking the
+//! call shape.
+
+use crate::orderbook::error::OrderBookError;
+use crossbeam::atomic::AtomicCell;
+use dashmap::DashMap;
+use pricelevel::{Hash32, Id, PriceLevelSnapshot};
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use tracing::warn;
+
+/// Source for the reference price used by the price-band check.
+///
+/// The price band rejects orders whose limit price deviates from the
+/// reference by more than the configured number of basis points.
+/// `LastTrade` and `Mid` resolve dynamically per check; `FixedPrice`
+/// is operator-pinned (e.g. an external mark price piped in).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum ReferencePriceSource {
+    /// Last executed trade price. The check is skipped when no trade
+    /// has occurred yet on this book.
+    LastTrade,
+    /// Integer midpoint `(best_bid + best_ask) / 2`. Falls back to
+    /// `LastTrade` when the book is one-sided. The check is skipped
+    /// when neither a midpoint nor a last trade is available.
+    Mid,
+    /// Caller-supplied fixed reference price (raw integer ticks). The
+    /// check always runs.
+    FixedPrice(u128),
+}
+
+/// Per-`OrderBook` risk configuration.
+///
+/// Build via [`RiskConfig::new`] and the chained `with_*` methods. Empty
+/// config (every field `None`) is a no-op passthrough — every check
+/// returns `Ok(())`. The struct is `Default` and `Serialize`/
+/// `Deserialize`, so it round-trips cleanly through the snapshot
+/// package with `#[serde(default)]`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RiskConfig {
+    /// Maximum number of resting orders a single account may have on
+    /// this book at any time. `None` disables the check.
+    pub max_open_orders_per_account: Option<u64>,
+    /// Maximum notional (`price × quantity`, in raw ticks) a single
+    /// account may have resting on this book at any time. `None`
+    /// disables the check.
+    pub max_notional_per_account: Option<u128>,
+    /// Maximum allowed deviation in basis points between an incoming
+    /// limit price and the resolved reference price. `None` (or
+    /// `reference_price = None`) disables the check.
+    pub price_band_bps: Option<u32>,
+    /// Reference price source used by the price-band check.
+    pub reference_price: Option<ReferencePriceSource>,
+}
+
+impl RiskConfig {
+    /// Construct an empty configuration with every limit disabled.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the maximum number of resting orders per account.
+    #[inline]
+    #[must_use]
+    pub fn with_max_open_orders_per_account(mut self, n: u64) -> Self {
+        self.max_open_orders_per_account = Some(n);
+        self
+    }
+
+    /// Set the maximum resting notional per account (in raw ticks).
+    #[inline]
+    #[must_use]
+    pub fn with_max_notional_per_account(mut self, n: u128) -> Self {
+        self.max_notional_per_account = Some(n);
+        self
+    }
+
+    /// Set the price-band tolerance in basis points and the reference
+    /// price source used to evaluate the band.
+    #[inline]
+    #[must_use]
+    pub fn with_price_band_bps(mut self, bps: u32, source: ReferencePriceSource) -> Self {
+        self.price_band_bps = Some(bps);
+        self.reference_price = Some(source);
+        self
+    }
+}
+
+/// Per-account counters maintained by [`RiskState`].
+///
+/// Counters are updated with `Relaxed` ordering on the hot path. They
+/// are estimative: a transient over- or under-count of one in-flight
+/// order is acceptable and does not exceed the configured limit by
+/// more than a single race window. Strict accuracy is enforced by
+/// snapshot rebuild.
+#[derive(Debug, Default)]
+pub struct RiskCounters {
+    /// Number of resting orders this account currently has on the book.
+    pub(super) open_count: AtomicU64,
+    /// Sum of `price × remaining_qty` (in raw ticks) across all of
+    /// this account's resting orders.
+    pub(super) resting_notional: AtomicCell<u128>,
+}
+
+/// Per-resting-order risk bookkeeping.
+///
+/// One entry per order admitted into the resting book. Used on cancel
+/// and fill to compute the deltas applied to per-account counters.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct RiskEntry {
+    pub(super) account: Hash32,
+    pub(super) price: u128,
+    pub(super) remaining_qty: u64,
+}
+
+/// Risk state bound to a single [`OrderBook`](super::book::OrderBook).
+///
+/// Carries the optional [`RiskConfig`], the per-account counters, the
+/// per-order entry map, and a one-shot warning latch for the
+/// "no reference price available" code path. All public operations
+/// are no-ops when `config` is `None`.
+#[derive(Debug, Default)]
+#[allow(dead_code)] // counters/orders/warned_no_reference are wired by book.rs in commits 2-3
+pub struct RiskState {
+    pub(super) config: Option<RiskConfig>,
+    pub(super) counters: DashMap<Hash32, RiskCounters>,
+    pub(super) orders: DashMap<Id, RiskEntry>,
+    pub(super) warned_no_reference: AtomicBool,
+}
+
+#[allow(dead_code)] // wired by book.rs / modifications.rs / matching.rs in commits 2-3
+impl RiskState {
+    /// Construct an empty state with no configuration installed.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Install or replace the active risk configuration. Counters and
+    /// per-order entries are preserved so that history rebuilt from a
+    /// previous configuration remains consistent.
+    pub fn set_config(&mut self, cfg: RiskConfig) {
+        self.config = Some(cfg);
+        self.warned_no_reference.store(false, Ordering::Relaxed);
+    }
+
+    /// Read-only access to the active configuration, if any.
+    #[inline]
+    #[must_use]
+    pub fn config(&self) -> Option<&RiskConfig> {
+        self.config.as_ref()
+    }
+
+    /// Drop the active configuration. Counters and per-order entries
+    /// are preserved so a subsequent [`Self::set_config`] re-engages
+    /// without dropping history.
+    pub fn disable(&mut self) {
+        self.config = None;
+    }
+
+    /// Pre-trade limit-order admission check.
+    ///
+    /// Runs three checks in order: per-account open-order count,
+    /// per-account notional, and price band. The price-band check is
+    /// skipped when `reference_price` is `None` (caller resolved no
+    /// reference; e.g. empty book and no trades yet).
+    ///
+    /// Allocation-free on the happy path. Cold rejection allocates one
+    /// error variant.
+    #[inline]
+    pub(super) fn check_limit_admission(
+        &self,
+        account: Hash32,
+        price: u128,
+        quantity: u64,
+        reference_price: Option<u128>,
+    ) -> Result<(), OrderBookError> {
+        let Some(cfg) = self.config.as_ref() else {
+            return Ok(());
+        };
+
+        // 1. Per-account open-order count.
+        if let Some(limit) = cfg.max_open_orders_per_account {
+            let current = self
+                .counters
+                .get(&account)
+                .map(|c| c.open_count.load(Ordering::Relaxed))
+                .unwrap_or(0);
+            if current >= limit {
+                return Err(OrderBookError::RiskMaxOpenOrders {
+                    account,
+                    current,
+                    limit,
+                });
+            }
+        }
+
+        // 2. Per-account notional.
+        if let Some(limit) = cfg.max_notional_per_account {
+            let current = self
+                .counters
+                .get(&account)
+                .map(|c| c.resting_notional.load())
+                .unwrap_or(0);
+            let attempted = (quantity as u128).saturating_mul(price);
+            // Check if `current + attempted` would exceed `limit`.
+            if current.saturating_add(attempted) > limit {
+                return Err(OrderBookError::RiskMaxNotional {
+                    account,
+                    current,
+                    attempted,
+                    limit,
+                });
+            }
+        }
+
+        // 3. Price band against a reference price.
+        if let (Some(bps_limit), Some(reference)) = (cfg.price_band_bps, reference_price) {
+            // Compute deviation in basis points: |submitted - reference| / reference * 10_000.
+            // Use u128 arithmetic to avoid overflow; saturate at u32::MAX.
+            if reference > 0 {
+                let diff = price.abs_diff(reference);
+                // bps = diff * 10_000 / reference
+                let bps_u128 = diff.saturating_mul(10_000) / reference;
+                let deviation_bps = if bps_u128 > u128::from(u32::MAX) {
+                    u32::MAX
+                } else {
+                    bps_u128 as u32
+                };
+                if deviation_bps > bps_limit {
+                    return Err(OrderBookError::RiskPriceBand {
+                        submitted: price,
+                        reference,
+                        deviation_bps,
+                        limit_bps: bps_limit,
+                    });
+                }
+            }
+        } else if cfg.price_band_bps.is_some()
+            && cfg.reference_price.is_some()
+            && reference_price.is_none()
+        {
+            // Band is configured but no reference is currently
+            // available (empty book + no trades). Warn once per book
+            // and skip the check.
+            if self
+                .warned_no_reference
+                .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                warn!(
+                    "risk: price-band check configured but no reference price available; \
+                     check skipped until a trade or two-sided book establishes a reference"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Pre-trade market-order admission check.
+    ///
+    /// Per design decision C, market orders skip every risk check (no
+    /// submitted price for the band, no resting contribution for the
+    /// open-order or notional counters). This helper exists to keep
+    /// the documented gate ordering consistent across submit and add
+    /// paths and reserves room for a future per-account market-order
+    /// rate limiter without breaking the call shape.
+    #[inline]
+    pub(super) fn check_market_admission(&self, _account: Hash32) -> Result<(), OrderBookError> {
+        Ok(())
+    }
+
+    /// Hook on successful admission of a resting order.
+    ///
+    /// Inserts a [`RiskEntry`] keyed by `order_id` and updates the
+    /// per-account counters. Allocation only when a new account
+    /// counter is created (first-ever order from that account on this
+    /// book) or the per-order map's bucket grows.
+    pub(super) fn on_admission(
+        &self,
+        order_id: Id,
+        account: Hash32,
+        price: u128,
+        remaining_qty: u64,
+    ) {
+        if self.config.is_none() {
+            return;
+        }
+        self.orders.insert(
+            order_id,
+            RiskEntry {
+                account,
+                price,
+                remaining_qty,
+            },
+        );
+        let counters = self.counters.entry(account).or_default();
+        counters.open_count.fetch_add(1, Ordering::Relaxed);
+        let notional_delta = (remaining_qty as u128).saturating_mul(price);
+        counters.resting_notional.fetch_add(notional_delta);
+    }
+
+    /// Hook per fill against a resting maker order.
+    ///
+    /// Decrements the maker's `remaining_qty` and the per-account
+    /// `resting_notional`. If the maker is fully filled, decrements
+    /// `open_count` and removes the entry. No-op when the maker is
+    /// not tracked (e.g. risk was disabled when the maker was
+    /// admitted, or the entry was already evicted by a prior cancel
+    /// in the same submit call).
+    pub(super) fn on_fill(&self, maker_id: Id, filled_qty: u64, maker_price: u128) {
+        if self.config.is_none() {
+            return;
+        }
+        // Read-modify-write the entry. Use `get_mut` for the partial
+        // case and `remove` for the full case to keep the map small.
+        let (account, fully_filled) = {
+            let Some(mut entry) = self.orders.get_mut(&maker_id) else {
+                return;
+            };
+            let new_remaining = entry.remaining_qty.saturating_sub(filled_qty);
+            let account = entry.account;
+            entry.remaining_qty = new_remaining;
+            (account, new_remaining == 0)
+        };
+
+        let notional_delta = (filled_qty as u128).saturating_mul(maker_price);
+
+        if let Some(counters_ref) = self.counters.get(&account) {
+            counters_ref.resting_notional.fetch_sub(notional_delta);
+            if fully_filled {
+                counters_ref.open_count.fetch_sub(1, Ordering::Relaxed);
+            }
+        }
+
+        if fully_filled {
+            self.orders.remove(&maker_id);
+        }
+    }
+
+    /// Hook on cancel of a resting order.
+    ///
+    /// Removes the entry and decrements both per-account counters
+    /// using the entry's stored `remaining_qty` and `price`. No-op
+    /// when the entry is not present.
+    pub(super) fn on_cancel(&self, order_id: Id) {
+        if self.config.is_none() {
+            return;
+        }
+        let Some((_, entry)) = self.orders.remove(&order_id) else {
+            return;
+        };
+        let notional_delta = (entry.remaining_qty as u128).saturating_mul(entry.price);
+        if let Some(counters_ref) = self.counters.get(&entry.account) {
+            counters_ref.open_count.fetch_sub(1, Ordering::Relaxed);
+            counters_ref.resting_notional.fetch_sub(notional_delta);
+        }
+    }
+
+    /// Rebuild the per-order map and per-account counters by walking
+    /// the supplied bid and ask snapshots.
+    ///
+    /// Called by `OrderBook::restore_from_snapshot_package` after the
+    /// snapshot's resting orders have been re-installed into the book.
+    /// Iteration is in input-vector order, which is deterministic and
+    /// does not affect outbound emissions.
+    pub(super) fn rebuild_from_snapshot(
+        &self,
+        bids: &[PriceLevelSnapshot],
+        asks: &[PriceLevelSnapshot],
+    ) {
+        self.orders.clear();
+        self.counters.clear();
+        for level in bids.iter().chain(asks.iter()) {
+            let price = level.price();
+            for order in level.orders() {
+                let account = order.user_id();
+                let remaining_qty = order
+                    .visible_quantity()
+                    .saturating_add(order.hidden_quantity());
+                self.orders.insert(
+                    order.id(),
+                    RiskEntry {
+                        account,
+                        price,
+                        remaining_qty,
+                    },
+                );
+                let counters = self.counters.entry(account).or_default();
+                counters.open_count.fetch_add(1, Ordering::Relaxed);
+                let notional_delta = (remaining_qty as u128).saturating_mul(price);
+                counters.resting_notional.fetch_add(notional_delta);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pricelevel::Id;
+
+    fn account(byte: u8) -> Hash32 {
+        Hash32::new([byte; 32])
+    }
+
+    #[test]
+    fn test_risk_config_builder() {
+        let cfg = RiskConfig::new()
+            .with_max_open_orders_per_account(5)
+            .with_max_notional_per_account(1_000_000)
+            .with_price_band_bps(500, ReferencePriceSource::LastTrade);
+        assert_eq!(cfg.max_open_orders_per_account, Some(5));
+        assert_eq!(cfg.max_notional_per_account, Some(1_000_000));
+        assert_eq!(cfg.price_band_bps, Some(500));
+        assert_eq!(
+            cfg.reference_price,
+            Some(ReferencePriceSource::LastTrade)
+        );
+    }
+
+    #[test]
+    fn test_risk_state_no_config_is_passthrough() {
+        let state = RiskState::new();
+        let acct = account(1);
+        let order_id = Id::new_uuid();
+
+        // Every check returns Ok.
+        assert!(
+            state
+                .check_limit_admission(acct, 100, 10, Some(100))
+                .is_ok()
+        );
+        assert!(state.check_market_admission(acct).is_ok());
+
+        // Hooks are no-ops.
+        state.on_admission(order_id, acct, 100, 10);
+        state.on_fill(order_id, 5, 100);
+        state.on_cancel(order_id);
+
+        // Counters never populated when no config is installed.
+        assert!(state.counters.is_empty());
+        assert!(state.orders.is_empty());
+    }
+
+    #[test]
+    fn test_on_admission_then_on_cancel_round_trip() {
+        let mut state = RiskState::new();
+        state.set_config(
+            RiskConfig::new()
+                .with_max_open_orders_per_account(10)
+                .with_max_notional_per_account(1_000_000),
+        );
+
+        let acct = account(2);
+        let order_id = Id::new_uuid();
+        state.on_admission(order_id, acct, 100, 10);
+
+        let counters = state
+            .counters
+            .get(&acct)
+            .expect("counters entry created on admission");
+        assert_eq!(counters.open_count.load(Ordering::Relaxed), 1);
+        assert_eq!(counters.resting_notional.load(), 1_000);
+        drop(counters);
+
+        state.on_cancel(order_id);
+        let counters = state
+            .counters
+            .get(&acct)
+            .expect("counters entry retained after cancel");
+        assert_eq!(counters.open_count.load(Ordering::Relaxed), 0);
+        assert_eq!(counters.resting_notional.load(), 0);
+        assert!(!state.orders.contains_key(&order_id));
+    }
+
+    #[test]
+    fn test_on_fill_partial_keeps_open_count() {
+        let mut state = RiskState::new();
+        state.set_config(
+            RiskConfig::new().with_max_notional_per_account(1_000_000),
+        );
+
+        let acct = account(3);
+        let order_id = Id::new_uuid();
+        state.on_admission(order_id, acct, 100, 10);
+
+        state.on_fill(order_id, 4, 100);
+
+        let counters = state
+            .counters
+            .get(&acct)
+            .expect("counters entry present");
+        assert_eq!(
+            counters.open_count.load(Ordering::Relaxed),
+            1,
+            "partial fill must not drop open_count"
+        );
+        assert_eq!(
+            counters.resting_notional.load(),
+            6 * 100,
+            "notional must be reduced by filled_qty * price"
+        );
+        let entry = state
+            .orders
+            .get(&order_id)
+            .expect("entry retained after partial fill");
+        assert_eq!(entry.remaining_qty, 6);
+    }
+
+    #[test]
+    fn test_on_fill_full_decrements_open_count() {
+        let mut state = RiskState::new();
+        state.set_config(
+            RiskConfig::new().with_max_open_orders_per_account(10),
+        );
+
+        let acct = account(4);
+        let order_id = Id::new_uuid();
+        state.on_admission(order_id, acct, 100, 10);
+
+        state.on_fill(order_id, 10, 100);
+
+        let counters = state
+            .counters
+            .get(&acct)
+            .expect("counters entry retained");
+        assert_eq!(counters.open_count.load(Ordering::Relaxed), 0);
+        assert_eq!(counters.resting_notional.load(), 0);
+        assert!(!state.orders.contains_key(&order_id));
+    }
+
+    #[test]
+    fn test_check_limit_admission_max_open_orders_breach_returns_typed_error() {
+        let mut state = RiskState::new();
+        state.set_config(
+            RiskConfig::new().with_max_open_orders_per_account(2),
+        );
+
+        let acct = account(5);
+        state.on_admission(Id::new_uuid(), acct, 100, 1);
+        state.on_admission(Id::new_uuid(), acct, 100, 1);
+
+        let err = state
+            .check_limit_admission(acct, 100, 1, Some(100))
+            .expect_err("third admission must breach max_open_orders");
+        match err {
+            OrderBookError::RiskMaxOpenOrders {
+                account: a,
+                current,
+                limit,
+            } => {
+                assert_eq!(a, acct);
+                assert_eq!(current, 2);
+                assert_eq!(limit, 2);
+            }
+            other => panic!("expected RiskMaxOpenOrders, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_check_limit_admission_max_notional_breach_returns_typed_error() {
+        let mut state = RiskState::new();
+        state.set_config(
+            RiskConfig::new().with_max_notional_per_account(1_000),
+        );
+
+        let acct = account(6);
+        // Pre-load 800 of notional.
+        state.on_admission(Id::new_uuid(), acct, 100, 8);
+
+        // Attempt to add 300 more (price=100, qty=3).
+        let err = state
+            .check_limit_admission(acct, 100, 3, Some(100))
+            .expect_err("notional should be exceeded");
+        match err {
+            OrderBookError::RiskMaxNotional {
+                account: a,
+                current,
+                attempted,
+                limit,
+            } => {
+                assert_eq!(a, acct);
+                assert_eq!(current, 800);
+                assert_eq!(attempted, 300);
+                assert_eq!(limit, 1_000);
+            }
+            other => panic!("expected RiskMaxNotional, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_check_limit_admission_price_band_breach_returns_typed_error() {
+        let mut state = RiskState::new();
+        // 100 bps = 1% band.
+        state.set_config(
+            RiskConfig::new().with_price_band_bps(100, ReferencePriceSource::LastTrade),
+        );
+
+        let acct = account(7);
+        // Reference 1_000_000, submitted 1_100_000 → +10_000 bps deviation.
+        let err = state
+            .check_limit_admission(acct, 1_100_000, 1, Some(1_000_000))
+            .expect_err("price band should be exceeded");
+        match err {
+            OrderBookError::RiskPriceBand {
+                submitted,
+                reference,
+                deviation_bps,
+                limit_bps,
+            } => {
+                assert_eq!(submitted, 1_100_000);
+                assert_eq!(reference, 1_000_000);
+                assert_eq!(deviation_bps, 1_000); // 10% = 1_000 bps
+                assert_eq!(limit_bps, 100);
+            }
+            other => panic!("expected RiskPriceBand, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_check_limit_admission_no_reference_price_skips_band_check() {
+        let mut state = RiskState::new();
+        state.set_config(
+            RiskConfig::new().with_price_band_bps(100, ReferencePriceSource::LastTrade),
+        );
+        // No reference available. Check skipped → Ok.
+        assert!(
+            state
+                .check_limit_admission(account(8), 999_999_999, 1, None)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_check_limit_admission_warns_only_once_when_no_reference_available() {
+        let mut state = RiskState::new();
+        state.set_config(
+            RiskConfig::new().with_price_band_bps(100, ReferencePriceSource::LastTrade),
+        );
+
+        let acct = account(9);
+        assert!(state.check_limit_admission(acct, 1, 1, None).is_ok());
+        assert!(
+            state.warned_no_reference.load(Ordering::Relaxed),
+            "first call without reference should flip the latch"
+        );
+        // Second call: latch already set; check still passes, no
+        // additional warning emitted (we cannot assert log count here
+        // without a tracing-subscriber harness, but the latch is the
+        // gate on the log site).
+        assert!(state.check_limit_admission(acct, 2, 2, None).is_ok());
+        assert!(state.warned_no_reference.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn test_within_limits_admission_succeeds() {
+        let mut state = RiskState::new();
+        state.set_config(
+            RiskConfig::new()
+                .with_max_open_orders_per_account(10)
+                .with_max_notional_per_account(1_000_000)
+                .with_price_band_bps(500, ReferencePriceSource::LastTrade),
+        );
+
+        let acct = account(10);
+        // Reference 100, submitted 100 → 0 bps. All checks pass.
+        assert!(
+            state
+                .check_limit_admission(acct, 100, 5, Some(100))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_disable_keeps_counters() {
+        let mut state = RiskState::new();
+        state.set_config(
+            RiskConfig::new().with_max_open_orders_per_account(10),
+        );
+
+        let acct = account(11);
+        let order_id = Id::new_uuid();
+        state.on_admission(order_id, acct, 100, 10);
+
+        state.disable();
+
+        // Config gone, but counters remain.
+        assert!(state.config().is_none());
+        assert!(state.counters.contains_key(&acct));
+        assert!(state.orders.contains_key(&order_id));
+
+        // After disable, every check is a passthrough again.
+        assert!(
+            state
+                .check_limit_admission(acct, 100, 100, Some(100))
+                .is_ok()
+        );
+    }
+}

--- a/src/orderbook/risk.rs
+++ b/src/orderbook/risk.rs
@@ -149,7 +149,6 @@ pub(super) struct RiskEntry {
 /// "no reference price available" code path. All public operations
 /// are no-ops when `config` is `None`.
 #[derive(Debug, Default)]
-#[allow(dead_code)] // counters/orders/warned_no_reference are wired by book.rs in commits 2-3
 pub struct RiskState {
     pub(super) config: Option<RiskConfig>,
     pub(super) counters: DashMap<Hash32, RiskCounters>,
@@ -157,7 +156,6 @@ pub struct RiskState {
     pub(super) warned_no_reference: AtomicBool,
 }
 
-#[allow(dead_code)] // wired by book.rs / modifications.rs / matching.rs in commits 2-3
 impl RiskState {
     /// Construct an empty state with no configuration installed.
     #[inline]
@@ -395,6 +393,7 @@ impl RiskState {
     /// snapshot's resting orders have been re-installed into the book.
     /// Iteration is in input-vector order, which is deterministic and
     /// does not affect outbound emissions.
+    #[allow(dead_code)] // wired in commit 4 (snapshot persistence)
     pub(super) fn rebuild_from_snapshot(
         &self,
         bids: &[PriceLevelSnapshot],

--- a/src/orderbook/risk.rs
+++ b/src/orderbook/risk.rs
@@ -63,6 +63,27 @@ pub enum ReferencePriceSource {
 /// returns `Ok(())`. The struct is `Default` and `Serialize`/
 /// `Deserialize`, so it round-trips cleanly through the snapshot
 /// package with `#[serde(default)]`.
+///
+/// # Semantics: submitted vs. resting
+///
+/// The `max_open_orders_per_account` and `max_notional_per_account`
+/// limits are evaluated against the **submitted** quantity / notional,
+/// **before** matching. An aggressive limit order that would fully
+/// match against the opposite side and leave nothing resting is still
+/// gated against these limits as if every contract were going to rest.
+///
+/// This is the standard pre-trade gating pattern in tier-one electronic
+/// venues (CME / Nasdaq pre-trade risk hooks behave the same way): the
+/// engine does not speculatively match before deciding whether to
+/// admit. Counter updates **after** matching reflect the actual resting
+/// remainder, so a fully-filled aggressive order does not leave
+/// long-lived counter pressure on the account — only the in-flight
+/// admission check sees the worst case.
+///
+/// If you need a "would-rest" projection instead of a "submitted"
+/// admission gate, run a `peek_match` simulation in your gateway
+/// layer and pass the resulting resting remainder in. Issue a
+/// follow-up if you want this surfaced from the engine itself.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RiskConfig {
     /// Maximum number of resting orders a single account may have on
@@ -154,6 +175,31 @@ pub struct RiskState {
     pub(super) counters: DashMap<Hash32, RiskCounters>,
     pub(super) orders: DashMap<Id, RiskEntry>,
     pub(super) warned_no_reference: AtomicBool,
+}
+
+/// Saturating decrement on an `AtomicU64` via `fetch_update`. Clamps at
+/// zero so a double-decrement under a fill / cancel race floors rather
+/// than wrapping to `u64::MAX` and permanently locking an account out
+/// of admission.
+#[inline]
+fn saturating_sub_u64(counter: &AtomicU64, delta: u64) {
+    let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_sub(delta))
+    });
+}
+
+/// Saturating decrement on an `AtomicCell<u128>` via a compare-exchange
+/// loop. Clamps at zero — same rationale as [`saturating_sub_u64`].
+#[inline]
+fn saturating_sub_u128(cell: &AtomicCell<u128>, delta: u128) {
+    let mut current = cell.load();
+    loop {
+        let new = current.saturating_sub(delta);
+        match cell.compare_exchange(current, new) {
+            Ok(_) => return,
+            Err(actual) => current = actual,
+        }
+    }
 }
 
 impl RiskState {
@@ -337,6 +383,12 @@ impl RiskState {
     /// not tracked (e.g. risk was disabled when the maker was
     /// admitted, or the entry was already evicted by a prior cancel
     /// in the same submit call).
+    ///
+    /// Both decrements clamp at zero via saturating CAS — under a
+    /// double-fill / fill-cancel race the worst case is a counter
+    /// that floors at zero rather than wrapping to `u64::MAX` /
+    /// `u128::MAX` and permanently locking the account out of
+    /// admission.
     pub(super) fn on_fill(&self, maker_id: Id, filled_qty: u64, maker_price: u128) {
         if self.config.is_none() {
             return;
@@ -356,9 +408,9 @@ impl RiskState {
         let notional_delta = (filled_qty as u128).saturating_mul(maker_price);
 
         if let Some(counters_ref) = self.counters.get(&account) {
-            counters_ref.resting_notional.fetch_sub(notional_delta);
+            saturating_sub_u128(&counters_ref.resting_notional, notional_delta);
             if fully_filled {
-                counters_ref.open_count.fetch_sub(1, Ordering::Relaxed);
+                saturating_sub_u64(&counters_ref.open_count, 1);
             }
         }
 
@@ -372,6 +424,9 @@ impl RiskState {
     /// Removes the entry and decrements both per-account counters
     /// using the entry's stored `remaining_qty` and `price`. No-op
     /// when the entry is not present.
+    ///
+    /// Both decrements clamp at zero via saturating CAS — same
+    /// rationale as [`on_fill`].
     pub(super) fn on_cancel(&self, order_id: Id) {
         if self.config.is_none() {
             return;
@@ -381,8 +436,8 @@ impl RiskState {
         };
         let notional_delta = (entry.remaining_qty as u128).saturating_mul(entry.price);
         if let Some(counters_ref) = self.counters.get(&entry.account) {
-            counters_ref.open_count.fetch_sub(1, Ordering::Relaxed);
-            counters_ref.resting_notional.fetch_sub(notional_delta);
+            saturating_sub_u64(&counters_ref.open_count, 1);
+            saturating_sub_u128(&counters_ref.resting_notional, notional_delta);
         }
     }
 
@@ -702,5 +757,44 @@ mod tests {
                 .check_limit_admission(acct, 100, 100, Some(100))
                 .is_ok()
         );
+    }
+
+    #[test]
+    fn test_on_fill_overshoot_clamps_counters_at_zero() {
+        // Regression: a stray double-fill or filled_qty > remaining
+        // must not wrap counters via `fetch_sub`. Both decrements
+        // saturate at zero.
+        let mut state = RiskState::new();
+        state.set_config(RiskConfig::new().with_max_notional_per_account(10_000));
+
+        let acct = account(12);
+        let order_id = Id::new_uuid();
+        state.on_admission(order_id, acct, 100, 5);
+
+        // Decrement by far more than what was admitted.
+        state.on_fill(order_id, 1_000_000, 100);
+
+        let counters = state.counters.get(&acct).expect("counters present");
+        assert_eq!(counters.open_count.load(Ordering::Relaxed), 0);
+        assert_eq!(counters.resting_notional.load(), 0);
+    }
+
+    #[test]
+    fn test_on_cancel_after_fully_filled_is_noop_and_does_not_wrap() {
+        // Regression: cancel after the entry has already been removed
+        // by an on_fill must be a no-op and not under-flow the
+        // counters that the prior fill already drove to zero.
+        let mut state = RiskState::new();
+        state.set_config(RiskConfig::new().with_max_open_orders_per_account(10));
+
+        let acct = account(13);
+        let order_id = Id::new_uuid();
+        state.on_admission(order_id, acct, 100, 5);
+        state.on_fill(order_id, 5, 100); // entry removed, counters at 0
+        state.on_cancel(order_id); // no-op (entry not present)
+
+        let counters = state.counters.get(&acct).expect("counters present");
+        assert_eq!(counters.open_count.load(Ordering::Relaxed), 0);
+        assert_eq!(counters.resting_notional.load(), 0);
     }
 }

--- a/src/orderbook/risk.rs
+++ b/src/orderbook/risk.rs
@@ -393,7 +393,6 @@ impl RiskState {
     /// snapshot's resting orders have been re-installed into the book.
     /// Iteration is in input-vector order, which is deterministic and
     /// does not affect outbound emissions.
-    #[allow(dead_code)] // wired in commit 4 (snapshot persistence)
     pub(super) fn rebuild_from_snapshot(
         &self,
         bids: &[PriceLevelSnapshot],
@@ -443,10 +442,7 @@ mod tests {
         assert_eq!(cfg.max_open_orders_per_account, Some(5));
         assert_eq!(cfg.max_notional_per_account, Some(1_000_000));
         assert_eq!(cfg.price_band_bps, Some(500));
-        assert_eq!(
-            cfg.reference_price,
-            Some(ReferencePriceSource::LastTrade)
-        );
+        assert_eq!(cfg.reference_price, Some(ReferencePriceSource::LastTrade));
     }
 
     #[test]
@@ -507,9 +503,7 @@ mod tests {
     #[test]
     fn test_on_fill_partial_keeps_open_count() {
         let mut state = RiskState::new();
-        state.set_config(
-            RiskConfig::new().with_max_notional_per_account(1_000_000),
-        );
+        state.set_config(RiskConfig::new().with_max_notional_per_account(1_000_000));
 
         let acct = account(3);
         let order_id = Id::new_uuid();
@@ -517,10 +511,7 @@ mod tests {
 
         state.on_fill(order_id, 4, 100);
 
-        let counters = state
-            .counters
-            .get(&acct)
-            .expect("counters entry present");
+        let counters = state.counters.get(&acct).expect("counters entry present");
         assert_eq!(
             counters.open_count.load(Ordering::Relaxed),
             1,
@@ -541,9 +532,7 @@ mod tests {
     #[test]
     fn test_on_fill_full_decrements_open_count() {
         let mut state = RiskState::new();
-        state.set_config(
-            RiskConfig::new().with_max_open_orders_per_account(10),
-        );
+        state.set_config(RiskConfig::new().with_max_open_orders_per_account(10));
 
         let acct = account(4);
         let order_id = Id::new_uuid();
@@ -551,10 +540,7 @@ mod tests {
 
         state.on_fill(order_id, 10, 100);
 
-        let counters = state
-            .counters
-            .get(&acct)
-            .expect("counters entry retained");
+        let counters = state.counters.get(&acct).expect("counters entry retained");
         assert_eq!(counters.open_count.load(Ordering::Relaxed), 0);
         assert_eq!(counters.resting_notional.load(), 0);
         assert!(!state.orders.contains_key(&order_id));
@@ -563,9 +549,7 @@ mod tests {
     #[test]
     fn test_check_limit_admission_max_open_orders_breach_returns_typed_error() {
         let mut state = RiskState::new();
-        state.set_config(
-            RiskConfig::new().with_max_open_orders_per_account(2),
-        );
+        state.set_config(RiskConfig::new().with_max_open_orders_per_account(2));
 
         let acct = account(5);
         state.on_admission(Id::new_uuid(), acct, 100, 1);
@@ -591,9 +575,7 @@ mod tests {
     #[test]
     fn test_check_limit_admission_max_notional_breach_returns_typed_error() {
         let mut state = RiskState::new();
-        state.set_config(
-            RiskConfig::new().with_max_notional_per_account(1_000),
-        );
+        state.set_config(RiskConfig::new().with_max_notional_per_account(1_000));
 
         let acct = account(6);
         // Pre-load 800 of notional.
@@ -695,19 +677,13 @@ mod tests {
 
         let acct = account(10);
         // Reference 100, submitted 100 → 0 bps. All checks pass.
-        assert!(
-            state
-                .check_limit_admission(acct, 100, 5, Some(100))
-                .is_ok()
-        );
+        assert!(state.check_limit_admission(acct, 100, 5, Some(100)).is_ok());
     }
 
     #[test]
     fn test_disable_keeps_counters() {
         let mut state = RiskState::new();
-        state.set_config(
-            RiskConfig::new().with_max_open_orders_per_account(10),
-        );
+        state.set_config(RiskConfig::new().with_max_open_orders_per_account(10));
 
         let acct = account(11);
         let order_id = Id::new_uuid();

--- a/src/orderbook/snapshot.rs
+++ b/src/orderbook/snapshot.rs
@@ -8,6 +8,7 @@ use tracing::trace;
 
 use super::error::OrderBookError;
 use super::fees::FeeSchedule;
+use super::risk::RiskConfig;
 use super::stp::STPMode;
 
 /// A snapshot of the order book state at a specific point in time
@@ -216,6 +217,17 @@ pub struct OrderBookSnapshotPackage {
     /// always came back disengaged.
     #[serde(default)]
     pub kill_switch_engaged: bool,
+
+    /// Risk configuration active at the time of snapshot. `None` means
+    /// no risk gating. Counters and per-order risk state are rebuilt
+    /// post-restore by walking the snapshot's resting orders.
+    ///
+    /// `#[serde(default)]` keeps the format version at `2`: payloads
+    /// written before this field existed deserialize with `None`, which
+    /// matches the previous (implicit) behaviour where a restored book
+    /// always came back without any risk gates engaged.
+    #[serde(default)]
+    pub risk_config: Option<RiskConfig>,
 }
 
 impl OrderBookSnapshotPackage {
@@ -237,6 +249,7 @@ impl OrderBookSnapshotPackage {
             max_order_size: None,
             engine_seq: 0,
             kill_switch_engaged: false,
+            risk_config: None,
         })
     }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -53,6 +53,9 @@ pub use crate::orderbook::order_state::{
     CancelReason, OrderStateListener, OrderStateTracker, OrderStatus,
 };
 
+// Pre-trade risk layer types
+pub use crate::orderbook::risk::{ReferencePriceSource, RiskConfig, RiskState};
+
 // Event serialization types
 #[cfg(feature = "bincode")]
 pub use crate::orderbook::serialization::BincodeEventSerializer;

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -18,6 +18,7 @@ mod operations_coverage_tests_extended;
 mod order_state_tests;
 mod private_coverage_tests;
 mod replay_coverage_tests;
+mod risk_layer_tests;
 mod sequencer_types_tests;
 mod snapshot_restore_tests;
 mod validation_tests;

--- a/tests/unit/risk_layer_tests.rs
+++ b/tests/unit/risk_layer_tests.rs
@@ -208,6 +208,370 @@ mod tests_risk_layer {
     // Market-order bypass
     // ───────────────────────────────────────────────────────────────
 
+    // ───────────────────────────────────────────────────────────────
+    // Per-account counter state (commit 3 — admission/fill/cancel hooks)
+    // ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn submit_above_max_open_orders_returns_risk_max_open() {
+        let mut book = new_book();
+        book.set_risk_config(
+            RiskConfig::new().with_max_open_orders_per_account(2),
+        );
+        let acct = account(11);
+
+        // Two admissions consume the quota.
+        book.add_limit_order_with_user(
+            Id::new_uuid(),
+            100,
+            1,
+            Side::Buy,
+            TimeInForce::Gtc,
+            acct,
+            None,
+        )
+        .expect("first order admitted");
+        book.add_limit_order_with_user(
+            Id::new_uuid(),
+            101,
+            1,
+            Side::Buy,
+            TimeInForce::Gtc,
+            acct,
+            None,
+        )
+        .expect("second order admitted");
+
+        // Third is rejected.
+        let result = book.add_limit_order_with_user(
+            Id::new_uuid(),
+            102,
+            1,
+            Side::Buy,
+            TimeInForce::Gtc,
+            acct,
+            None,
+        );
+        match result {
+            Err(OrderBookError::RiskMaxOpenOrders {
+                account: a,
+                current,
+                limit,
+            }) => {
+                assert_eq!(a, acct);
+                assert_eq!(current, 2);
+                assert_eq!(limit, 2);
+            }
+            other => panic!("expected RiskMaxOpenOrders, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn submit_within_max_open_orders_succeeds() {
+        let mut book = new_book();
+        book.set_risk_config(
+            RiskConfig::new().with_max_open_orders_per_account(3),
+        );
+        let acct = account(12);
+
+        for i in 0..3 {
+            book.add_limit_order_with_user(
+                Id::new_uuid(),
+                100 + i,
+                1,
+                Side::Buy,
+                TimeInForce::Gtc,
+                acct,
+                None,
+            )
+            .unwrap_or_else(|err| panic!("admission {i} failed: {err:?}"));
+        }
+    }
+
+    #[test]
+    fn submit_above_max_notional_returns_risk_max_notional() {
+        let mut book = new_book();
+        // 1_000 notional ceiling per account.
+        book.set_risk_config(
+            RiskConfig::new().with_max_notional_per_account(1_000),
+        );
+        let acct = account(13);
+
+        // 8 * 100 = 800 notional consumed.
+        book.add_limit_order_with_user(
+            Id::new_uuid(),
+            100,
+            8,
+            Side::Buy,
+            TimeInForce::Gtc,
+            acct,
+            None,
+        )
+        .expect("first admission within budget");
+
+        // 3 * 100 = 300 attempted; 800 + 300 > 1_000 → reject.
+        let result = book.add_limit_order_with_user(
+            Id::new_uuid(),
+            100,
+            3,
+            Side::Buy,
+            TimeInForce::Gtc,
+            acct,
+            None,
+        );
+        match result {
+            Err(OrderBookError::RiskMaxNotional {
+                account: a,
+                current,
+                attempted,
+                limit,
+            }) => {
+                assert_eq!(a, acct);
+                assert_eq!(current, 800);
+                assert_eq!(attempted, 300);
+                assert_eq!(limit, 1_000);
+            }
+            other => panic!("expected RiskMaxNotional, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn submit_within_max_notional_succeeds() {
+        let mut book = new_book();
+        book.set_risk_config(
+            RiskConfig::new().with_max_notional_per_account(1_000),
+        );
+        let acct = account(14);
+
+        // 8 * 100 = 800 in budget.
+        book.add_limit_order_with_user(
+            Id::new_uuid(),
+            100,
+            8,
+            Side::Buy,
+            TimeInForce::Gtc,
+            acct,
+            None,
+        )
+        .expect("first within budget");
+
+        // 2 * 100 = 200; 800 + 200 = 1_000, exactly at the limit, so
+        // accepted (`current + attempted > limit` is the gate, strict).
+        book.add_limit_order_with_user(
+            Id::new_uuid(),
+            100,
+            2,
+            Side::Buy,
+            TimeInForce::Gtc,
+            acct,
+            None,
+        )
+        .expect("second hits ceiling exactly and is accepted");
+    }
+
+    #[test]
+    fn cancel_decrements_counters() {
+        let mut book = new_book();
+        book.set_risk_config(
+            RiskConfig::new().with_max_open_orders_per_account(1),
+        );
+        let acct = account(15);
+
+        let order_id = Id::new_uuid();
+        book.add_limit_order_with_user(
+            order_id,
+            100,
+            1,
+            Side::Buy,
+            TimeInForce::Gtc,
+            acct,
+            None,
+        )
+        .expect("first admission");
+
+        // Second is rejected because the quota is full.
+        assert!(
+            matches!(
+                book.add_limit_order_with_user(
+                    Id::new_uuid(),
+                    100,
+                    1,
+                    Side::Buy,
+                    TimeInForce::Gtc,
+                    acct,
+                    None,
+                ),
+                Err(OrderBookError::RiskMaxOpenOrders { .. })
+            ),
+            "second should be rejected"
+        );
+
+        // Cancel and retry; should now succeed.
+        book.cancel_order(order_id)
+            .expect("cancel returns Ok")
+            .expect("cancel returns Some");
+        book.add_limit_order_with_user(
+            Id::new_uuid(),
+            100,
+            1,
+            Side::Buy,
+            TimeInForce::Gtc,
+            acct,
+            None,
+        )
+        .expect("cancel must drop the counter and re-open the slot");
+    }
+
+    #[test]
+    fn partial_fill_decrements_notional_and_keeps_count() {
+        let mut book = new_book();
+        // High open ceiling, tight notional ceiling: we want the
+        // partial fill to free notional headroom for a follow-up.
+        book.set_risk_config(
+            RiskConfig::new()
+                .with_max_open_orders_per_account(10)
+                .with_max_notional_per_account(2_000),
+        );
+        let maker_acct = account(16);
+        let taker_acct = account(17);
+
+        // Maker rests 10 @ 100 (1_000 notional).
+        book.add_limit_order_with_user(
+            Id::new_uuid(),
+            100,
+            10,
+            Side::Buy,
+            TimeInForce::Gtc,
+            maker_acct,
+            None,
+        )
+        .expect("maker admitted");
+
+        // Taker (different account) submits an aggressive sell that
+        // partially fills the maker (qty 4 of 10 at price 100).
+        book.submit_market_order_with_user(Id::new_uuid(), 4, Side::Sell, taker_acct)
+            .expect("aggressive sell fills 4 of 10");
+
+        // Maker now has 600 notional (6 * 100). New maker admission
+        // for 14 * 100 = 1_400 notional must succeed: 600 + 1_400 =
+        // 2_000 (== limit, accepted by strict `>` gate). A larger one
+        // (15 * 100 = 1_500) would be rejected.
+        book.add_limit_order_with_user(
+            Id::new_uuid(),
+            99,
+            14,
+            Side::Buy,
+            TimeInForce::Gtc,
+            maker_acct,
+            None,
+        )
+        .expect("partial fill must free notional headroom");
+
+        let breach = book.add_limit_order_with_user(
+            Id::new_uuid(),
+            98,
+            1,
+            Side::Buy,
+            TimeInForce::Gtc,
+            maker_acct,
+            None,
+        );
+        assert!(
+            matches!(breach, Err(OrderBookError::RiskMaxNotional { .. })),
+            "ceiling already hit; expected RiskMaxNotional, got {breach:?}"
+        );
+    }
+
+    #[test]
+    fn full_fill_decrements_open_count() {
+        let mut book = new_book();
+        book.set_risk_config(
+            RiskConfig::new().with_max_open_orders_per_account(1),
+        );
+        let maker_acct = account(18);
+        let taker_acct = account(19);
+
+        // Maker uses the only slot.
+        book.add_limit_order_with_user(
+            Id::new_uuid(),
+            100,
+            5,
+            Side::Buy,
+            TimeInForce::Gtc,
+            maker_acct,
+            None,
+        )
+        .expect("maker admitted");
+
+        // Aggressive sell fully consumes the maker.
+        book.submit_market_order_with_user(Id::new_uuid(), 5, Side::Sell, taker_acct)
+            .expect("aggressive sell fills the maker fully");
+
+        // Maker's slot must be free again.
+        book.add_limit_order_with_user(
+            Id::new_uuid(),
+            100,
+            1,
+            Side::Buy,
+            TimeInForce::Gtc,
+            maker_acct,
+            None,
+        )
+        .expect("full fill must drop open_count and re-open the slot");
+    }
+
+    #[test]
+    fn disable_risk_clears_gates_keeps_counters() {
+        let mut book = new_book();
+        book.set_risk_config(
+            RiskConfig::new().with_max_open_orders_per_account(1),
+        );
+        let acct = account(20);
+
+        book.add_limit_order_with_user(
+            Id::new_uuid(),
+            100,
+            1,
+            Side::Buy,
+            TimeInForce::Gtc,
+            acct,
+            None,
+        )
+        .expect("first admitted");
+        // Quota full → second rejected.
+        assert!(
+            matches!(
+                book.add_limit_order_with_user(
+                    Id::new_uuid(),
+                    100,
+                    1,
+                    Side::Buy,
+                    TimeInForce::Gtc,
+                    acct,
+                    None,
+                ),
+                Err(OrderBookError::RiskMaxOpenOrders { .. })
+            ),
+            "expected rejection at quota"
+        );
+
+        book.disable_risk();
+
+        // After disable, gate is lifted and admission succeeds even
+        // though the per-account counter still reads 1 underneath.
+        book.add_limit_order_with_user(
+            Id::new_uuid(),
+            100,
+            1,
+            Side::Buy,
+            TimeInForce::Gtc,
+            acct,
+            None,
+        )
+        .expect("disable_risk lifts the gate");
+        assert!(book.risk_config().is_none());
+    }
+
     #[test]
     fn market_orders_bypass_risk_checks() {
         let mut book = new_book();

--- a/tests/unit/risk_layer_tests.rs
+++ b/tests/unit/risk_layer_tests.rs
@@ -11,9 +11,7 @@
 
 #[cfg(test)]
 mod tests_risk_layer {
-    use orderbook_rs::{
-        OrderBook, OrderBookError, ReferencePriceSource, RiskConfig,
-    };
+    use orderbook_rs::{OrderBook, OrderBookError, ReferencePriceSource, RiskConfig};
     use pricelevel::{Hash32, Id, Side, TimeInForce};
 
     fn new_book() -> OrderBook<()> {
@@ -71,15 +69,8 @@ mod tests_risk_layer {
         )
         .expect("seed resting ask");
         // Aggressive buy crosses fully.
-        book.add_limit_order(
-            Id::new_uuid(),
-            price,
-            10,
-            Side::Buy,
-            TimeInForce::Gtc,
-            None,
-        )
-        .expect("aggressive buy fills the ask");
+        book.add_limit_order(Id::new_uuid(), price, 10, Side::Buy, TimeInForce::Gtc, None)
+            .expect("aggressive buy fills the ask");
         assert_eq!(
             book.last_trade_price(),
             Some(price),
@@ -93,8 +84,7 @@ mod tests_risk_layer {
         seed_last_trade_price(&book, 1_000_000);
         // 1000 bps = 10% allowed band.
         book.set_risk_config(
-            RiskConfig::new()
-                .with_price_band_bps(1_000, ReferencePriceSource::LastTrade),
+            RiskConfig::new().with_price_band_bps(1_000, ReferencePriceSource::LastTrade),
         );
 
         // Submit at +30% from reference → rejected.
@@ -127,8 +117,7 @@ mod tests_risk_layer {
         let mut book = new_book();
         seed_last_trade_price(&book, 1_000_000);
         book.set_risk_config(
-            RiskConfig::new()
-                .with_price_band_bps(1_000, ReferencePriceSource::LastTrade),
+            RiskConfig::new().with_price_band_bps(1_000, ReferencePriceSource::LastTrade),
         );
 
         // +5% from reference is well within the 10% band.
@@ -140,7 +129,10 @@ mod tests_risk_layer {
             TimeInForce::Gtc,
             None,
         );
-        assert!(result.is_ok(), "in-band order must be accepted; got {result:?}");
+        assert!(
+            result.is_ok(),
+            "in-band order must be accepted; got {result:?}"
+        );
     }
 
     #[test]
@@ -160,9 +152,7 @@ mod tests_risk_layer {
         .expect("seed bid");
         assert!(book.best_ask().is_none(), "book must be one-sided");
 
-        book.set_risk_config(
-            RiskConfig::new().with_price_band_bps(500, ReferencePriceSource::Mid),
-        );
+        book.set_risk_config(RiskConfig::new().with_price_band_bps(500, ReferencePriceSource::Mid));
 
         // +30% from last_trade (1.3M) → rejected because Mid falls
         // back to last_trade when the book is one-sided.
@@ -184,9 +174,7 @@ mod tests_risk_layer {
     fn band_skipped_with_warn_when_no_reference_available() {
         let mut book = new_book();
         // Empty book + no trades → no reference price exists.
-        book.set_risk_config(
-            RiskConfig::new().with_price_band_bps(100, ReferencePriceSource::Mid),
-        );
+        book.set_risk_config(RiskConfig::new().with_price_band_bps(100, ReferencePriceSource::Mid));
 
         // Far-out price should NOT be rejected because no reference
         // is available; the band check is skipped (warn-once latch).
@@ -215,9 +203,7 @@ mod tests_risk_layer {
     #[test]
     fn submit_above_max_open_orders_returns_risk_max_open() {
         let mut book = new_book();
-        book.set_risk_config(
-            RiskConfig::new().with_max_open_orders_per_account(2),
-        );
+        book.set_risk_config(RiskConfig::new().with_max_open_orders_per_account(2));
         let acct = account(11);
 
         // Two admissions consume the quota.
@@ -269,9 +255,7 @@ mod tests_risk_layer {
     #[test]
     fn submit_within_max_open_orders_succeeds() {
         let mut book = new_book();
-        book.set_risk_config(
-            RiskConfig::new().with_max_open_orders_per_account(3),
-        );
+        book.set_risk_config(RiskConfig::new().with_max_open_orders_per_account(3));
         let acct = account(12);
 
         for i in 0..3 {
@@ -292,9 +276,7 @@ mod tests_risk_layer {
     fn submit_above_max_notional_returns_risk_max_notional() {
         let mut book = new_book();
         // 1_000 notional ceiling per account.
-        book.set_risk_config(
-            RiskConfig::new().with_max_notional_per_account(1_000),
-        );
+        book.set_risk_config(RiskConfig::new().with_max_notional_per_account(1_000));
         let acct = account(13);
 
         // 8 * 100 = 800 notional consumed.
@@ -338,9 +320,7 @@ mod tests_risk_layer {
     #[test]
     fn submit_within_max_notional_succeeds() {
         let mut book = new_book();
-        book.set_risk_config(
-            RiskConfig::new().with_max_notional_per_account(1_000),
-        );
+        book.set_risk_config(RiskConfig::new().with_max_notional_per_account(1_000));
         let acct = account(14);
 
         // 8 * 100 = 800 in budget.
@@ -372,22 +352,12 @@ mod tests_risk_layer {
     #[test]
     fn cancel_decrements_counters() {
         let mut book = new_book();
-        book.set_risk_config(
-            RiskConfig::new().with_max_open_orders_per_account(1),
-        );
+        book.set_risk_config(RiskConfig::new().with_max_open_orders_per_account(1));
         let acct = account(15);
 
         let order_id = Id::new_uuid();
-        book.add_limit_order_with_user(
-            order_id,
-            100,
-            1,
-            Side::Buy,
-            TimeInForce::Gtc,
-            acct,
-            None,
-        )
-        .expect("first admission");
+        book.add_limit_order_with_user(order_id, 100, 1, Side::Buy, TimeInForce::Gtc, acct, None)
+            .expect("first admission");
 
         // Second is rejected because the quota is full.
         assert!(
@@ -485,9 +455,7 @@ mod tests_risk_layer {
     #[test]
     fn full_fill_decrements_open_count() {
         let mut book = new_book();
-        book.set_risk_config(
-            RiskConfig::new().with_max_open_orders_per_account(1),
-        );
+        book.set_risk_config(RiskConfig::new().with_max_open_orders_per_account(1));
         let maker_acct = account(18);
         let taker_acct = account(19);
 
@@ -523,9 +491,7 @@ mod tests_risk_layer {
     #[test]
     fn disable_risk_clears_gates_keeps_counters() {
         let mut book = new_book();
-        book.set_risk_config(
-            RiskConfig::new().with_max_open_orders_per_account(1),
-        );
+        book.set_risk_config(RiskConfig::new().with_max_open_orders_per_account(1));
         let acct = account(20);
 
         book.add_limit_order_with_user(
@@ -617,15 +583,167 @@ mod tests_risk_layer {
         );
 
         // With user_id variant: same story.
-        let result = book.submit_market_order_with_user(
-            Id::new_uuid(),
-            1,
-            Side::Buy,
-            account(42),
-        );
+        let result = book.submit_market_order_with_user(Id::new_uuid(), 1, Side::Buy, account(42));
         assert!(
             result.is_ok(),
             "submit_market_order_with_user must bypass risk; got {result:?}"
         );
+    }
+
+    // ───────────────────────────────────────────────────────────────
+    // Snapshot persistence (commit 4 — RiskConfig + counter rebuild)
+    // ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn risk_config_round_trips_through_snapshot() {
+        // Build the original book, install a fully-configured risk
+        // layer, and rest a few orders across two accounts so the
+        // per-account counters carry meaningful state.
+        let mut original = new_book();
+        let cfg = RiskConfig::new()
+            .with_max_open_orders_per_account(2)
+            .with_max_notional_per_account(1_000)
+            .with_price_band_bps(5_000, ReferencePriceSource::LastTrade);
+        original.set_risk_config(cfg.clone());
+
+        let acct_a = account(31);
+        let acct_b = account(32);
+
+        // Account A: 2 resting orders @ price 100 — saturates the
+        // open-orders quota for that account post-restore.
+        original
+            .add_limit_order_with_user(
+                Id::new_uuid(),
+                100,
+                3,
+                Side::Buy,
+                TimeInForce::Gtc,
+                acct_a,
+                None,
+            )
+            .expect("acct_a first admission");
+        original
+            .add_limit_order_with_user(
+                Id::new_uuid(),
+                100,
+                4,
+                Side::Buy,
+                TimeInForce::Gtc,
+                acct_a,
+                None,
+            )
+            .expect("acct_a second admission");
+
+        // Account B: a single resting order — quota still has room.
+        original
+            .add_limit_order_with_user(
+                Id::new_uuid(),
+                100,
+                2,
+                Side::Buy,
+                TimeInForce::Gtc,
+                acct_b,
+                None,
+            )
+            .expect("acct_b first admission");
+
+        // JSON round-trip via the public snapshot API.
+        let json_payload = original
+            .snapshot_to_json(10)
+            .expect("serialize snapshot package to JSON");
+
+        let mut restored = new_book();
+        restored
+            .restore_from_snapshot_json(&json_payload)
+            .expect("restore from JSON");
+
+        // 1. Config round-trips field-by-field.
+        let restored_cfg = restored.risk_config().expect("config restored");
+        assert_eq!(
+            restored_cfg.max_open_orders_per_account,
+            cfg.max_open_orders_per_account,
+        );
+        assert_eq!(
+            restored_cfg.max_notional_per_account,
+            cfg.max_notional_per_account,
+        );
+        assert_eq!(restored_cfg.price_band_bps, cfg.price_band_bps);
+        assert_eq!(restored_cfg.reference_price, cfg.reference_price);
+
+        // 2. Account A saturated its quota pre-snapshot. A new
+        // submission must be rejected by the rebuilt counters.
+        let breach = restored.add_limit_order_with_user(
+            Id::new_uuid(),
+            100,
+            1,
+            Side::Buy,
+            TimeInForce::Gtc,
+            acct_a,
+            None,
+        );
+        match breach {
+            Err(OrderBookError::RiskMaxOpenOrders {
+                account: a,
+                current,
+                limit,
+            }) => {
+                assert_eq!(a, acct_a);
+                assert_eq!(current, 2);
+                assert_eq!(limit, 2);
+            }
+            other => {
+                panic!("expected RiskMaxOpenOrders for acct_a after restore, got {other:?}");
+            }
+        }
+
+        // 3. Account B still has one slot of headroom.
+        restored
+            .add_limit_order_with_user(
+                Id::new_uuid(),
+                100,
+                1,
+                Side::Buy,
+                TimeInForce::Gtc,
+                acct_b,
+                None,
+            )
+            .expect("acct_b within rebuilt quota must succeed");
+    }
+
+    #[test]
+    fn legacy_v2_snapshot_without_risk_config_field_defaults_to_none() {
+        use orderbook_rs::orderbook::OrderBookSnapshotPackage;
+
+        // Hand-rolled v2 payload that omits the new `risk_config`
+        // field. Deserialization must succeed via `#[serde(default)]`
+        // and yield `risk_config: None`. The checksum corresponds to
+        // the empty snapshot below; we only assert the additive field
+        // default — checksum validation is exercised elsewhere.
+        let legacy_v2 = r#"{
+            "version": 2,
+            "snapshot": {
+                "symbol": "LEGACY",
+                "timestamp": 0,
+                "bids": [],
+                "asks": []
+            },
+            "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
+            "fee_schedule": null,
+            "stp_mode": "None",
+            "tick_size": null,
+            "lot_size": null,
+            "min_order_size": null,
+            "max_order_size": null,
+            "engine_seq": 0,
+            "kill_switch_engaged": false
+        }"#;
+
+        let pkg =
+            OrderBookSnapshotPackage::from_json(legacy_v2).expect("legacy v2 payload deserializes");
+        assert!(
+            pkg.risk_config.is_none(),
+            "missing risk_config must default to None for v2 payloads"
+        );
+        assert_eq!(pkg.version, 2);
     }
 }

--- a/tests/unit/risk_layer_tests.rs
+++ b/tests/unit/risk_layer_tests.rs
@@ -1,0 +1,267 @@
+//! Integration tests for the pre-trade risk layer on `OrderBook<T>`.
+//!
+//! Commit 2 of issue #54 covers the rejection paths that work with
+//! the just-installed config: price-band breach, mid-fallback to
+//! last-trade, no-reference fallthrough, market-order bypass, and
+//! the public `set_risk_config` / `risk_config` / `disable_risk`
+//! round-trip. Tests that depend on per-account counter state being
+//! populated across submits (max_open_orders, max_notional, fill /
+//! cancel deltas) land with commit 3, where `on_admission`,
+//! `on_fill`, and `on_cancel` are wired into the engine.
+
+#[cfg(test)]
+mod tests_risk_layer {
+    use orderbook_rs::{
+        OrderBook, OrderBookError, ReferencePriceSource, RiskConfig,
+    };
+    use pricelevel::{Hash32, Id, Side, TimeInForce};
+
+    fn new_book() -> OrderBook<()> {
+        OrderBook::new("TEST")
+    }
+
+    fn account(byte: u8) -> Hash32 {
+        Hash32::new([byte; 32])
+    }
+
+    // ───────────────────────────────────────────────────────────────
+    // Public API round-trip
+    // ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn risk_config_set_get_disable_round_trip() {
+        let mut book = new_book();
+        assert!(book.risk_config().is_none());
+
+        let cfg = RiskConfig::new()
+            .with_max_open_orders_per_account(7)
+            .with_max_notional_per_account(123_456)
+            .with_price_band_bps(250, ReferencePriceSource::LastTrade);
+        book.set_risk_config(cfg.clone());
+
+        let installed = book.risk_config().expect("config installed");
+        assert_eq!(installed.max_open_orders_per_account, Some(7));
+        assert_eq!(installed.max_notional_per_account, Some(123_456));
+        assert_eq!(installed.price_band_bps, Some(250));
+        assert_eq!(
+            installed.reference_price,
+            Some(ReferencePriceSource::LastTrade)
+        );
+
+        book.disable_risk();
+        assert!(book.risk_config().is_none());
+    }
+
+    // ───────────────────────────────────────────────────────────────
+    // Price-band rejection paths
+    // ───────────────────────────────────────────────────────────────
+
+    /// Seed two crossing orders so a trade prints and `last_trade_price`
+    /// is set. After the helper returns, the book has no resting
+    /// orders.
+    fn seed_last_trade_price(book: &OrderBook<()>, price: u128) {
+        // Resting ask at `price`.
+        book.add_limit_order(
+            Id::new_uuid(),
+            price,
+            10,
+            Side::Sell,
+            TimeInForce::Gtc,
+            None,
+        )
+        .expect("seed resting ask");
+        // Aggressive buy crosses fully.
+        book.add_limit_order(
+            Id::new_uuid(),
+            price,
+            10,
+            Side::Buy,
+            TimeInForce::Gtc,
+            None,
+        )
+        .expect("aggressive buy fills the ask");
+        assert_eq!(
+            book.last_trade_price(),
+            Some(price),
+            "last trade must be set"
+        );
+    }
+
+    #[test]
+    fn limit_far_outside_price_band_returns_risk_price_band() {
+        let mut book = new_book();
+        seed_last_trade_price(&book, 1_000_000);
+        // 1000 bps = 10% allowed band.
+        book.set_risk_config(
+            RiskConfig::new()
+                .with_price_band_bps(1_000, ReferencePriceSource::LastTrade),
+        );
+
+        // Submit at +30% from reference → rejected.
+        let result = book.add_limit_order(
+            Id::new_uuid(),
+            1_300_000,
+            1,
+            Side::Buy,
+            TimeInForce::Gtc,
+            None,
+        );
+        match result {
+            Err(OrderBookError::RiskPriceBand {
+                submitted,
+                reference,
+                deviation_bps,
+                limit_bps,
+            }) => {
+                assert_eq!(submitted, 1_300_000);
+                assert_eq!(reference, 1_000_000);
+                assert_eq!(deviation_bps, 3_000);
+                assert_eq!(limit_bps, 1_000);
+            }
+            other => panic!("expected RiskPriceBand, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn limit_within_price_band_succeeds() {
+        let mut book = new_book();
+        seed_last_trade_price(&book, 1_000_000);
+        book.set_risk_config(
+            RiskConfig::new()
+                .with_price_band_bps(1_000, ReferencePriceSource::LastTrade),
+        );
+
+        // +5% from reference is well within the 10% band.
+        let result = book.add_limit_order(
+            Id::new_uuid(),
+            1_050_000,
+            1,
+            Side::Buy,
+            TimeInForce::Gtc,
+            None,
+        );
+        assert!(result.is_ok(), "in-band order must be accepted; got {result:?}");
+    }
+
+    #[test]
+    fn mid_reference_falls_back_to_last_trade_when_one_sided() {
+        let mut book = new_book();
+        // Seed a last trade and confirm.
+        seed_last_trade_price(&book, 1_000_000);
+        // Add a single bid so the book is one-sided (no asks).
+        book.add_limit_order(
+            Id::new_uuid(),
+            999_000,
+            1,
+            Side::Buy,
+            TimeInForce::Gtc,
+            None,
+        )
+        .expect("seed bid");
+        assert!(book.best_ask().is_none(), "book must be one-sided");
+
+        book.set_risk_config(
+            RiskConfig::new().with_price_band_bps(500, ReferencePriceSource::Mid),
+        );
+
+        // +30% from last_trade (1.3M) → rejected because Mid falls
+        // back to last_trade when the book is one-sided.
+        let result = book.add_limit_order(
+            Id::new_uuid(),
+            1_300_000,
+            1,
+            Side::Sell,
+            TimeInForce::Gtc,
+            None,
+        );
+        assert!(
+            matches!(result, Err(OrderBookError::RiskPriceBand { .. })),
+            "Mid reference should fall back to last_trade and reject; got {result:?}"
+        );
+    }
+
+    #[test]
+    fn band_skipped_with_warn_when_no_reference_available() {
+        let mut book = new_book();
+        // Empty book + no trades → no reference price exists.
+        book.set_risk_config(
+            RiskConfig::new().with_price_band_bps(100, ReferencePriceSource::Mid),
+        );
+
+        // Far-out price should NOT be rejected because no reference
+        // is available; the band check is skipped (warn-once latch).
+        let result = book.add_limit_order(
+            Id::new_uuid(),
+            999_999_999,
+            1,
+            Side::Buy,
+            TimeInForce::Gtc,
+            None,
+        );
+        assert!(
+            result.is_ok(),
+            "no-reference path must skip the band check; got {result:?}"
+        );
+    }
+
+    // ───────────────────────────────────────────────────────────────
+    // Market-order bypass
+    // ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn market_orders_bypass_risk_checks() {
+        let mut book = new_book();
+        // Seed resting liquidity for both market-order calls BEFORE
+        // installing the risk config, so the seeding limits aren't
+        // themselves blocked by the gate we're about to configure.
+        book.add_limit_order(
+            Id::new_uuid(),
+            1_000_000,
+            10,
+            Side::Sell,
+            TimeInForce::Gtc,
+            None,
+        )
+        .expect("seed resting ask 1");
+        book.add_limit_order(
+            Id::new_uuid(),
+            1_000_000,
+            10,
+            Side::Sell,
+            TimeInForce::Gtc,
+            None,
+        )
+        .expect("seed resting ask 2");
+
+        // Configure a band so tight any submitted limit price would
+        // fail, plus zero open-orders / notional ceilings. Market
+        // orders carry no submitted price and no resting contribution
+        // so they must bypass every gate.
+        book.set_risk_config(
+            RiskConfig::new()
+                .with_price_band_bps(1, ReferencePriceSource::LastTrade)
+                .with_max_open_orders_per_account(0)
+                .with_max_notional_per_account(0),
+        );
+
+        // No user_id → submit_market_order; should match against a
+        // resting ask and not be rejected by any risk gate.
+        let result = book.submit_market_order(Id::new_uuid(), 1, Side::Buy);
+        assert!(
+            result.is_ok(),
+            "market orders must bypass risk checks; got {result:?}"
+        );
+
+        // With user_id variant: same story.
+        let result = book.submit_market_order_with_user(
+            Id::new_uuid(),
+            1,
+            Side::Buy,
+            account(42),
+        );
+        assert!(
+            result.is_ok(),
+            "submit_market_order_with_user must bypass risk; got {result:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a **pre-trade risk layer** with three opt-in guard-rails:
  per-account `max_open_orders`, per-account `max_notional`, and a
  global `price_band_bps` against a configurable
  `ReferencePriceSource` (`LastTrade` / `Mid` / `FixedPrice`).
- Three new typed reject variants on the existing
  `#[non_exhaustive]` `OrderBookError` carrying enough context for
  downstream consumers to react without parsing strings.
- New public API on `OrderBook<T>`: `set_risk_config`,
  `risk_config`, `disable_risk`. `RiskConfig` is a builder.
- Check ordering on submit/add becomes:
  **`kill_switch → risk → STP → fees → match`**.
  Market orders bypass the risk layer (no submitted price, no rest);
  kill switch still gates them.
- Per-account counters in `DashMap<Hash32, RiskCounters>` with
  `AtomicU64` + `AtomicCell<u128>`; per-order state in
  `DashMap<Id, RiskEntry>`. Allocation-free on the happy path.
- `OrderBookSnapshotPackage.risk_config: Option<RiskConfig>` —
  operator config persists across snapshot/restore. On restore, the
  per-account counters and per-order map are rebuilt by walking the
  snapshot's resting orders. Snapshot format version stays at `2`;
  the field is additive via `#[serde(default)]`.
- New example `examples/src/bin/risk_limits.rs` walks every guard-rail.

## Out of scope

- `OrderStateEvent` as a first-class outbound stream — deferred. Risk
  rejections currently surface only via the typed `OrderBookError`
  variant returned to the caller. Once #55 lands, the variants will be
  reachable via a typed `RejectReason` code without breaking the
  existing payload.
- Risk config is not journaled; replays via `ReplayEngine::replay_from*`
  start with no risk gating. Operators re-attach config post-replay.

## Commits

```
5764307 docs: document risk layer in CHANGELOG and lib.rs
ee5c813 examples: add risk_limits demo
84b588c feat(snapshot): persist RiskConfig and rebuild counters on restore
e6e0747 feat(orderbook): risk state updates on admission, fill, cancel
77a2b7d feat(orderbook): pre-trade risk checks at submit/add_order entries
08b2dcd feat(orderbook): add RiskConfig, RiskState, and risk reject variants
```

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] `cargo test --all-features` — 582 + 25 + 407 + 44 (4 pre-existing
      ignored) = **1058** tests pass.
- [x] New unit tests in `src/orderbook/risk.rs` (12): builder, no-config
      passthrough, admission/cancel round-trip, partial/full fill,
      max-open / max-notional / price-band reject paths, no-reference
      skip with warn-once latch.
- [x] New integration tests in `tests/unit/risk_layer_tests.rs` (16):
      max_open / max_notional / price_band reject + pass; mid fallback
      to last-trade on one-sided book; band skip + warn-once when no
      reference is available; market-order bypass; admit/cancel
      round-trip; partial-fill keeps count, full-fill drops count;
      `disable_risk` clears gates but keeps counters; snapshot
      round-trip rebuilds counters; legacy v2 payload (no
      `risk_config` field) defaults to `None`.
- [x] `cargo run --bin risk_limits --manifest-path examples/Cargo.toml`
      runs cleanly. Example breaches each gate in sequence and
      observes the typed reject variants:
      ```
      third bid correctly rejected: account=1 current=2 limit=2
      second bid correctly rejected: current=4000 attempted=2000 limit=5000
      off-band bid correctly rejected: submitted=50 reference=100 deviation=5000bps limit=1000bps
      clean order admitted
      ```
- [x] `cargo build --release --all-features` — clean.

## Closes

Closes #54.
