### PR TITLE
Closed RejectReason enum on rejection events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > below group changes by feature; everything ships in the same
 > 0.7.0 publish.
 
+### Added — closed `RejectReason` enum (#55)
+
+- **New `RejectReason`** closed `#[non_exhaustive] #[repr(u16)]` enum
+  with stable explicit discriminants (1..13 + `Other(u16)`). It is the
+  canonical wire-side reject taxonomy — consumers can route on the
+  numeric code without parsing strings, and the discriminants are
+  documented as stable across `0.7.x` patch upgrades.
+- **`OrderStatus::Rejected.reason: String`** → `RejectReason`
+  (breaking change to a public enum's variant shape; allowed under the
+  `0.6.x → 0.7.x` minor delta in `0.x` semver).
+- **Crate-root + prelude re-export** of `RejectReason`.
+- **`impl From<&OrderBookError> for RejectReason`** — operational
+  ergonomics. Maps every `OrderBookError` variant to its wire-side
+  reject code (or `Other(0)` for internal-state errors with no public
+  reject mapping). Exhaustive match — adding an `OrderBookError`
+  variant in the future is caught at compile time inside the crate.
+- **Risk-gate rejection now records the tracker.** When an
+  `OrderStateTracker` is configured and `add_order` is rejected by the
+  risk layer, the engine records
+  `OrderStatus::Rejected { reason: RejectReason::Risk* }` against the
+  rejected order id before propagating the typed error. Mirrors the
+  kill-switch tracker pattern.
+- **Kill-switch reject now uses the typed code.** The previous string
+  `"kill switch active"` is replaced by
+  `RejectReason::KillSwitchActive`.
+- **Validation / post-only / missing-user-id rejects also typed.** The
+  internal sites in `modifications.rs` that already transitioned the
+  tracker to `OrderStatus::Rejected` now emit `RejectReason::InvalidPrice`,
+  `RejectReason::PostOnlyWouldCross`, and `RejectReason::MissingUserId`
+  respectively (incidental migration — these paths previously stored a
+  free-form string).
+- New integration tests `tests/unit/reject_reason_tests.rs` cover the
+  kill-switch and three risk-gate tracker emissions and a Display
+  smoke test.
+
+### Notes — `RejectReason`
+
+- Discriminants are stable wire codes. Do not reorder or reuse a
+  retired discriminant within the `0.7.x` series.
+- `Other(u16)` is the forward-compat escape hatch for application-side
+  extensions. Values `>= 1000` are reserved for caller use; the
+  library will never emit a value in that range.
+- The reverse direction `From<RejectReason> for OrderBookError` is
+  **not** provided. The enum is the stable public contract; the error
+  is the internal impl detail.
+- Snapshot format unchanged. `OrderStateTracker` history is not
+  persisted in `OrderBookSnapshotPackage`; format version stays at `2`.
+- Out of scope (deferred to a follow-up issue): wiring tracker
+  `Rejected` emission for STP cancel-taker and `InsufficientLiquidity`
+  IOC/FOK paths, both of which currently return errors without
+  transitioning the tracker.
+
 ### Added — pre-trade risk layer (#54)
 
 - **Pre-trade risk layer** on `OrderBook<T>`. New `RiskConfig` with

--- a/README.md
+++ b/README.md
@@ -48,6 +48,27 @@ This order book engine is built with the following design principles:
 
 ### What's New in Version 0.7.0
 
+#### v0.7.0 — Closed `RejectReason` enum
+
+- **New [`RejectReason`]** — closed
+  `#[non_exhaustive] #[repr(u16)]` enum with stable explicit
+  discriminants (1..13 + `Other(u16)`). The canonical wire-side
+  reject taxonomy; consumers can route on the numeric code without
+  parsing strings.
+- **`OrderStatus::Rejected.reason: String`** is now
+  `RejectReason` — typed, machine-routable, and stable across
+  `0.7.x`. Breaking change on a public variant shape; allowed under
+  the `0.6.x → 0.7.x` minor delta in `0.x` semver.
+- **`impl From<&OrderBookError> for RejectReason`** — operational
+  ergonomics. Exhaustive match — a future `OrderBookError` variant
+  addition is caught at compile time.
+- **Tracker emission on every reject path that already transitioned
+  the tracker.** Kill switch, risk gates, and the three internal
+  sites in `modifications.rs` (validation / post-only / missing
+  user id) now record typed reasons. STP cancel-taker and IOC/FOK
+  `InsufficientLiquidity` paths still return typed errors without
+  transitioning the tracker — deferred to a follow-up.
+
 #### v0.7.0 — Pre-trade risk layer
 
 - **New [`RiskConfig`]** with three opt-in guard-rails:
@@ -94,7 +115,7 @@ This order book engine is built with the following design principles:
   `#[serde(default)]`.
 - When an `OrderStateTracker` is configured, kill-switched
   rejections are recorded as
-  `OrderStatus::Rejected { reason: "kill switch active" }`.
+  `OrderStatus::Rejected { reason: RejectReason::KillSwitchActive }`.
 - Example: `examples/src/bin/kill_switch_drain.rs`.
 
 #### v0.7.0 — Global `engine_seq` across outbound streams

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,6 +379,7 @@ pub use orderbook::market_impact::{MarketImpact, OrderSimulation};
 pub use orderbook::order_state::{
     CancelReason, OrderStateListener, OrderStateTracker, OrderStatus,
 };
+pub use orderbook::reject_reason::RejectReason;
 pub use orderbook::risk::{ReferencePriceSource, RiskConfig, RiskState};
 pub use orderbook::sequencer::{
     InMemoryJournal, Journal, JournalEntry, JournalError, JournalReadIter, ReplayEngine,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,27 @@
 //!
 //! ## What's New in Version 0.7.0
 //!
+//! ### v0.7.0 — Closed `RejectReason` enum
+//!
+//! - **New [`RejectReason`]** — closed
+//!   `#[non_exhaustive] #[repr(u16)]` enum with stable explicit
+//!   discriminants (1..13 + `Other(u16)`). The canonical wire-side
+//!   reject taxonomy; consumers can route on the numeric code without
+//!   parsing strings.
+//! - **`OrderStatus::Rejected.reason: String`** is now
+//!   `RejectReason` — typed, machine-routable, and stable across
+//!   `0.7.x`. Breaking change on a public variant shape; allowed under
+//!   the `0.6.x → 0.7.x` minor delta in `0.x` semver.
+//! - **`impl From<&OrderBookError> for RejectReason`** — operational
+//!   ergonomics. Exhaustive match — a future `OrderBookError` variant
+//!   addition is caught at compile time.
+//! - **Tracker emission on every reject path that already transitioned
+//!   the tracker.** Kill switch, risk gates, and the three internal
+//!   sites in `modifications.rs` (validation / post-only / missing
+//!   user id) now record typed reasons. STP cancel-taker and IOC/FOK
+//!   `InsufficientLiquidity` paths still return typed errors without
+//!   transitioning the tracker — deferred to a follow-up.
+//!
 //! ### v0.7.0 — Pre-trade risk layer
 //!
 //! - **New [`RiskConfig`]** with three opt-in guard-rails:
@@ -80,7 +101,7 @@
 //!   `#[serde(default)]`.
 //! - When an `OrderStateTracker` is configured, kill-switched
 //!   rejections are recorded as
-//!   `OrderStatus::Rejected { reason: "kill switch active" }`.
+//!   `OrderStatus::Rejected { reason: RejectReason::KillSwitchActive }`.
 //! - Example: `examples/src/bin/kill_switch_drain.rs`.
 //!
 //! ### v0.7.0 — Global `engine_seq` across outbound streams

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -546,7 +546,7 @@ where
             self.track_state(
                 order_id,
                 super::order_state::OrderStatus::Rejected {
-                    reason: "kill switch active".to_string(),
+                    reason: super::reject_reason::RejectReason::KillSwitchActive,
                 },
             );
             return Err(OrderBookError::KillSwitchActive);

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -41,6 +41,9 @@ pub mod mass_cancel;
 /// Order state machine for explicit lifecycle tracking.
 pub mod order_state;
 
+/// Closed-taxonomy reject reasons surfaced on `OrderStatus::Rejected`.
+pub mod reject_reason;
+
 /// Pre-trade risk layer: per-account counters, configurable limits.
 pub mod risk;
 
@@ -78,6 +81,7 @@ pub use nats::NatsTradePublisher;
 #[cfg(feature = "nats")]
 pub use nats_book_change::{BookChangeBatch, BookChangeEntry, NatsBookChangePublisher};
 pub use order_state::{CancelReason, OrderStateListener, OrderStateTracker, OrderStatus};
+pub use reject_reason::RejectReason;
 #[cfg(feature = "special_orders")]
 pub use repricing::{RepricingOperations, RepricingResult, SpecialOrderTracker};
 pub use risk::{ReferencePriceSource, RiskConfig, RiskState};

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -595,11 +595,17 @@ where
         // Pre-trade risk gate: per-account open-orders / notional /
         // price band. No-op when no `RiskConfig` is installed.
         // Documented order: kill_switch → risk → STP → fees → match.
-        self.check_risk_limit_admission(
+        // On the cold reject path, record an `OrderStatus::Rejected`
+        // transition with the closed `RejectReason` taxonomy before
+        // propagating the typed error.
+        if let Err(err) = self.check_risk_limit_admission(
             order.user_id(),
             order.price().as_u128(),
             order.total_quantity(),
-        )?;
+        ) {
+            self.reject_with_risk(order.id(), &err);
+            return Err(err);
+        }
         self.cache.invalidate();
 
         trace!(

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -2,6 +2,7 @@ use crate::orderbook::book::OrderBook;
 use crate::orderbook::book_change_event::PriceLevelChangedEvent;
 use crate::orderbook::error::OrderBookError;
 use crate::orderbook::order_state::{CancelReason, OrderStatus};
+use crate::orderbook::reject_reason::RejectReason;
 use crate::orderbook::trade::TradeResult;
 use pricelevel::{Id, OrderType, OrderUpdate, PriceLevel, Quantity, Side};
 use std::sync::Arc;
@@ -616,7 +617,7 @@ where
             self.track_state(
                 order.id(),
                 OrderStatus::Rejected {
-                    reason: "missing user_id with STP enabled".to_string(),
+                    reason: RejectReason::MissingUserId,
                 },
             );
             return Err(OrderBookError::MissingUserId {
@@ -632,11 +633,7 @@ where
             self.track_state(
                 order.id(),
                 OrderStatus::Rejected {
-                    reason: format!(
-                        "price {} not a multiple of tick size {}",
-                        order.price().as_u128(),
-                        tick
-                    ),
+                    reason: RejectReason::InvalidPrice,
                 },
             );
             return Err(OrderBookError::InvalidTickSize {
@@ -711,7 +708,7 @@ where
             self.track_state(
                 order.id(),
                 OrderStatus::Rejected {
-                    reason: "post-only order would cross market".to_string(),
+                    reason: RejectReason::PostOnlyWouldCross,
                 },
             );
             return Err(OrderBookError::PriceCrossing {

--- a/src/orderbook/order_state.rs
+++ b/src/orderbook/order_state.rs
@@ -23,6 +23,7 @@
 //! ```
 
 use super::clock::{Clock, MonotonicClock};
+use super::reject_reason::RejectReason;
 use dashmap::DashMap;
 use pricelevel::Id;
 use serde::{Deserialize, Serialize};
@@ -106,8 +107,8 @@ pub enum OrderStatus {
 
     /// Order rejected during validation (never entered the book).
     Rejected {
-        /// Human-readable rejection reason.
-        reason: String,
+        /// Closed wire-side reject code. See [`RejectReason`].
+        reason: RejectReason,
     },
 }
 
@@ -562,7 +563,7 @@ mod tests {
         );
         assert!(
             OrderStatus::Rejected {
-                reason: "test".to_string()
+                reason: RejectReason::Other(0)
             }
             .is_terminal()
         );
@@ -621,7 +622,7 @@ mod tests {
         );
         assert_eq!(
             OrderStatus::Rejected {
-                reason: "bad".to_string()
+                reason: RejectReason::InvalidPrice
             }
             .filled_quantity(),
             0
@@ -656,10 +657,10 @@ mod tests {
         );
         assert_eq!(
             OrderStatus::Rejected {
-                reason: "bad tick".to_string()
+                reason: RejectReason::InvalidPrice
             }
             .to_string(),
-            "Rejected(bad tick)"
+            "Rejected(invalid price)"
         );
     }
 
@@ -737,7 +738,7 @@ mod tests {
         tracker.transition(
             id,
             OrderStatus::Rejected {
-                reason: "invalid tick size".to_string(),
+                reason: RejectReason::InvalidPrice,
             },
         );
 
@@ -894,7 +895,7 @@ mod tests {
                 reason: CancelReason::SelfTradePrevention,
             },
             OrderStatus::Rejected {
-                reason: "test".to_string(),
+                reason: RejectReason::InvalidPrice,
             },
         ];
 

--- a/src/orderbook/private.rs
+++ b/src/orderbook/private.rs
@@ -149,14 +149,15 @@ where
     /// entered"). No-op when no tracker is configured.
     #[inline]
     pub(super) fn reject_with_risk(&self, order_id: pricelevel::Id, err: &OrderBookError) {
-        if self.order_state_tracker.is_some() {
-            self.track_state(
-                order_id,
-                super::order_state::OrderStatus::Rejected {
-                    reason: super::reject_reason::RejectReason::from(err),
-                },
-            );
-        }
+        // `track_state` is itself a no-op when no tracker is configured,
+        // so the outer `is_some` check is redundant. Drop it to keep the
+        // helper minimal and avoid future divergence.
+        self.track_state(
+            order_id,
+            super::order_state::OrderStatus::Rejected {
+                reason: super::reject_reason::RejectReason::from(err),
+            },
+        );
     }
 
     /// Convert `OrderType<T>` to OrderType<()> for compatibility with current PriceLevel API

--- a/src/orderbook/private.rs
+++ b/src/orderbook/private.rs
@@ -138,6 +138,27 @@ where
         }
     }
 
+    /// Record an `OrderStatus::Rejected` transition for a failed risk
+    /// admission, mapping the typed [`OrderBookError`] to its closed
+    /// [`super::reject_reason::RejectReason`] code.
+    ///
+    /// Used by new-flow entry points where the risk gate (`Risk*`
+    /// variants) returned `Err` before the order could enter the book —
+    /// emitting `Rejected` here keeps the lifecycle accurate (the
+    /// `Rejected` semantic is "rejected during validation, never
+    /// entered"). No-op when no tracker is configured.
+    #[inline]
+    pub(super) fn reject_with_risk(&self, order_id: pricelevel::Id, err: &OrderBookError) {
+        if self.order_state_tracker.is_some() {
+            self.track_state(
+                order_id,
+                super::order_state::OrderStatus::Rejected {
+                    reason: super::reject_reason::RejectReason::from(err),
+                },
+            );
+        }
+    }
+
     /// Convert `OrderType<T>` to OrderType<()> for compatibility with current PriceLevel API
     pub fn convert_to_unit_type(&self, order: &OrderType<T>) -> OrderType<()> {
         match order {

--- a/src/orderbook/reject_reason.rs
+++ b/src/orderbook/reject_reason.rs
@@ -20,7 +20,7 @@
 //! [`RejectReason`] is the stable public contract.
 
 use crate::orderbook::error::OrderBookError;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Closed taxonomy of reasons an order may be rejected at admission.
 ///
@@ -54,7 +54,7 @@ use serde::{Deserialize, Serialize};
 /// | `DuplicateOrderId`       | 12  |
 /// | `InsufficientLiquidity`  | 13  |
 /// | `Other(code)`            | code|
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 #[repr(u16)]
 pub enum RejectReason {
@@ -118,6 +118,58 @@ impl RejectReason {
             Self::InsufficientLiquidity => 13,
             Self::Other(code) => code,
         }
+    }
+
+    /// Reconstruct a [`RejectReason`] from its wire code. Known
+    /// discriminants map to their named variant; any other value is
+    /// preserved via [`Self::Other`] so older deserializers can carry
+    /// forward unknown codes minted by newer producers.
+    #[inline]
+    #[must_use]
+    pub fn from_u16(code: u16) -> Self {
+        match code {
+            1 => Self::KillSwitchActive,
+            2 => Self::RiskMaxOpenOrders,
+            3 => Self::RiskMaxNotional,
+            4 => Self::RiskPriceBand,
+            5 => Self::PostOnlyWouldCross,
+            6 => Self::SelfTradePrevention,
+            7 => Self::InvalidPrice,
+            8 => Self::InvalidQuantity,
+            9 => Self::InvalidPriceLevel,
+            10 => Self::OrderSizeOutOfRange,
+            11 => Self::MissingUserId,
+            12 => Self::DuplicateOrderId,
+            13 => Self::InsufficientLiquidity,
+            other => Self::Other(other),
+        }
+    }
+}
+
+/// Serialize as the stable `u16` wire code via [`RejectReason::as_u16`].
+///
+/// JSON / Bincode / any serde format encodes the numeric reject code,
+/// not the variant name or an internal serde index. This is what the
+/// wire-stability rustdoc on the type promises and what consumers can
+/// rely on across `0.7.x` patch upgrades.
+impl Serialize for RejectReason {
+    #[inline]
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u16(self.as_u16())
+    }
+}
+
+/// Deserialize from the stable `u16` wire code via
+/// [`RejectReason::from_u16`].
+///
+/// Unknown codes map to [`RejectReason::Other`] so an older deserializer
+/// can still parse a payload minted by a newer producer that has
+/// introduced a new reject variant.
+impl<'de> Deserialize<'de> for RejectReason {
+    #[inline]
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let code = u16::deserialize(deserializer)?;
+        Ok(Self::from_u16(code))
     }
 }
 
@@ -406,6 +458,39 @@ mod tests {
         let json = serde_json::to_string(&other).expect("serialize Other(42)");
         let decoded: RejectReason = serde_json::from_str(&json).expect("deserialize Other(42)");
         assert_eq!(decoded, other);
+    }
+
+    #[test]
+    fn test_serde_json_emits_stable_u16_wire_code() {
+        // Wire format must be the documented u16 code, not a variant
+        // name or a serde-derived index. This is the contract consumers
+        // rely on across `0.7.x` patch upgrades.
+        for reason in named_variants() {
+            let json = serde_json::to_string(&reason).expect("serialize named variant");
+            assert_eq!(
+                json,
+                reason.as_u16().to_string(),
+                "JSON wire code drift for {reason:?}"
+            );
+        }
+        let other = RejectReason::Other(7777);
+        let json = serde_json::to_string(&other).expect("serialize Other");
+        assert_eq!(json, "7777");
+    }
+
+    #[test]
+    fn test_serde_json_unknown_code_decodes_to_other() {
+        // Forward-compat: an older deserializer reading a payload
+        // minted by a newer producer with a code outside the documented
+        // table preserves it via `RejectReason::Other(code)` instead of
+        // failing to deserialize.
+        let decoded: RejectReason = serde_json::from_str("999").expect("deserialize unknown code");
+        assert_eq!(decoded, RejectReason::Other(999));
+
+        // Reserved-application range round-trips too.
+        let decoded: RejectReason =
+            serde_json::from_str("1234").expect("deserialize reserved-range code");
+        assert_eq!(decoded, RejectReason::Other(1234));
     }
 
     #[cfg(feature = "bincode")]

--- a/src/orderbook/reject_reason.rs
+++ b/src/orderbook/reject_reason.rs
@@ -1,0 +1,426 @@
+//! Closed taxonomy of order-rejection reasons exposed on the wire.
+//!
+//! [`RejectReason`] is the canonical wire-side reject code surfaced on
+//! `OrderStatus::Rejected`. Each named variant carries a stable
+//! `#[repr(u16)]` discriminant — consumers that publish or parse the
+//! value over the wire can rely on those numbers staying stable across
+//! `0.7.x` and `0.7.x → 0.7.y` patch upgrades.
+//!
+//! Forward compatibility is preserved by:
+//!
+//! - `#[non_exhaustive]` so adding a new variant is non-breaking on
+//!   downstream `match` blocks (consumers must keep a wildcard arm).
+//! - [`RejectReason::Other`] as an escape hatch for application-side
+//!   extensions. Values `>= 1000` are reserved for caller use; the
+//!   library itself will never emit a value in that range.
+//!
+//! The [`From<&OrderBookError>`](RejectReason#impl-From<%26OrderBookError>-for-RejectReason)
+//! impl provides operational ergonomics for callers that already hold a
+//! typed [`OrderBookError`]: the typed error is the impl detail, the
+//! [`RejectReason`] is the stable public contract.
+
+use crate::orderbook::error::OrderBookError;
+use serde::{Deserialize, Serialize};
+
+/// Closed taxonomy of reasons an order may be rejected at admission.
+///
+/// `RejectReason` is the stable wire-side reject code. Each variant has
+/// an explicit `#[repr(u16)]` discriminant — consumers that publish or
+/// parse the value over the wire can rely on those numbers staying
+/// stable across `0.7.x` and `0.7.x → 0.7.y` patch upgrades. Forward
+/// compatibility is preserved by:
+///
+/// - `#[non_exhaustive]` so adding a variant is non-breaking on
+///   downstream `match` blocks.
+/// - [`Self::Other`] as an escape hatch for application-side extensions.
+///   Values `>= 1000` are reserved for caller use; the library will
+///   never emit a value in that range.
+///
+/// # Discriminant table
+///
+/// | Variant                  | u16 |
+/// |--------------------------|-----|
+/// | `KillSwitchActive`       | 1   |
+/// | `RiskMaxOpenOrders`      | 2   |
+/// | `RiskMaxNotional`        | 3   |
+/// | `RiskPriceBand`          | 4   |
+/// | `PostOnlyWouldCross`     | 5   |
+/// | `SelfTradePrevention`    | 6   |
+/// | `InvalidPrice`           | 7   |
+/// | `InvalidQuantity`        | 8   |
+/// | `InvalidPriceLevel`      | 9   |
+/// | `OrderSizeOutOfRange`    | 10  |
+/// | `MissingUserId`          | 11  |
+/// | `DuplicateOrderId`       | 12  |
+/// | `InsufficientLiquidity`  | 13  |
+/// | `Other(code)`            | code|
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+#[repr(u16)]
+pub enum RejectReason {
+    /// New flow rejected because the operational kill switch is engaged.
+    KillSwitchActive = 1,
+    /// Per-account open-order limit would be breached by this admission.
+    RiskMaxOpenOrders = 2,
+    /// Per-account notional limit would be breached by this admission.
+    RiskMaxNotional = 3,
+    /// Submitted price exceeds the configured price band against the
+    /// reference price.
+    RiskPriceBand = 4,
+    /// Post-only order would cross the resting opposite side at the
+    /// time of admission.
+    PostOnlyWouldCross = 5,
+    /// Self-trade prevention rejected the incoming order.
+    SelfTradePrevention = 6,
+    /// Submitted price violates the configured tick-size validation.
+    InvalidPrice = 7,
+    /// Submitted quantity violates the configured lot-size validation.
+    InvalidQuantity = 8,
+    /// The targeted price level is invalid for the requested operation.
+    InvalidPriceLevel = 9,
+    /// Submitted quantity is outside the configured min/max range.
+    OrderSizeOutOfRange = 10,
+    /// `user_id` is missing or zero while STP is enabled.
+    MissingUserId = 11,
+    /// An order with the same id is already present in the book.
+    DuplicateOrderId = 12,
+    /// The order could not be filled with the available resting depth
+    /// (IOC / FOK semantics).
+    InsufficientLiquidity = 13,
+    /// Caller-supplied / unmapped code. The library never emits this
+    /// variant; it exists so applications can ferry their own reject
+    /// codes through the same channel without forking the enum.
+    Other(u16),
+}
+
+impl RejectReason {
+    /// Numeric wire code. Stable across `0.7.x`.
+    ///
+    /// For named variants this returns the explicit `#[repr(u16)]`
+    /// discriminant; for [`Self::Other`] this returns the wrapped
+    /// caller-supplied code verbatim.
+    #[inline]
+    #[must_use]
+    pub fn as_u16(self) -> u16 {
+        match self {
+            Self::KillSwitchActive => 1,
+            Self::RiskMaxOpenOrders => 2,
+            Self::RiskMaxNotional => 3,
+            Self::RiskPriceBand => 4,
+            Self::PostOnlyWouldCross => 5,
+            Self::SelfTradePrevention => 6,
+            Self::InvalidPrice => 7,
+            Self::InvalidQuantity => 8,
+            Self::InvalidPriceLevel => 9,
+            Self::OrderSizeOutOfRange => 10,
+            Self::MissingUserId => 11,
+            Self::DuplicateOrderId => 12,
+            Self::InsufficientLiquidity => 13,
+            Self::Other(code) => code,
+        }
+    }
+}
+
+impl std::fmt::Display for RejectReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::KillSwitchActive => write!(f, "kill switch active"),
+            Self::RiskMaxOpenOrders => write!(f, "risk: max open orders"),
+            Self::RiskMaxNotional => write!(f, "risk: max notional"),
+            Self::RiskPriceBand => write!(f, "risk: price band"),
+            Self::PostOnlyWouldCross => write!(f, "post-only would cross"),
+            Self::SelfTradePrevention => write!(f, "self-trade prevention"),
+            Self::InvalidPrice => write!(f, "invalid price"),
+            Self::InvalidQuantity => write!(f, "invalid quantity"),
+            Self::InvalidPriceLevel => write!(f, "invalid price level"),
+            Self::OrderSizeOutOfRange => write!(f, "order size out of range"),
+            Self::MissingUserId => write!(f, "missing user id"),
+            Self::DuplicateOrderId => write!(f, "duplicate order id"),
+            Self::InsufficientLiquidity => write!(f, "insufficient liquidity"),
+            Self::Other(code) => write!(f, "other({code})"),
+        }
+    }
+}
+
+/// Map a typed [`OrderBookError`] to its wire-side reject code.
+///
+/// Errors that do not represent a public reject (e.g.
+/// `SerializationError`, `ChecksumMismatch`, `NatsPublishError`,
+/// internal-state errors) map to [`RejectReason::Other(0)`] — they are
+/// not expected to surface on outbound reject events.
+///
+/// The match below is intentionally exhaustive (no `_ =>` catch-all);
+/// any new variant added to [`OrderBookError`] must extend this mapping
+/// at compile time. This is enforced because the `impl` lives inside
+/// the crate, where exhaustive matches over a `#[non_exhaustive]` enum
+/// are still permitted.
+impl From<&OrderBookError> for RejectReason {
+    #[inline]
+    fn from(err: &OrderBookError) -> Self {
+        match err {
+            OrderBookError::KillSwitchActive => Self::KillSwitchActive,
+            OrderBookError::RiskMaxOpenOrders { .. } => Self::RiskMaxOpenOrders,
+            OrderBookError::RiskMaxNotional { .. } => Self::RiskMaxNotional,
+            OrderBookError::RiskPriceBand { .. } => Self::RiskPriceBand,
+            OrderBookError::SelfTradePrevented { .. } => Self::SelfTradePrevention,
+            OrderBookError::InvalidPriceLevel(_) => Self::InvalidPriceLevel,
+            OrderBookError::PriceCrossing { .. } => Self::PostOnlyWouldCross,
+            OrderBookError::InsufficientLiquidity { .. } => Self::InsufficientLiquidity,
+            OrderBookError::InvalidTickSize { .. } => Self::InvalidPrice,
+            OrderBookError::InvalidLotSize { .. } => Self::InvalidQuantity,
+            OrderBookError::OrderSizeOutOfRange { .. } => Self::OrderSizeOutOfRange,
+            OrderBookError::MissingUserId { .. } => Self::MissingUserId,
+            OrderBookError::PriceLevelError(_) => Self::Other(0),
+            OrderBookError::OrderNotFound(_) => Self::Other(0),
+            OrderBookError::InvalidOperation { .. } => Self::Other(0),
+            OrderBookError::SerializationError { .. } => Self::Other(0),
+            OrderBookError::DeserializationError { .. } => Self::Other(0),
+            OrderBookError::ChecksumMismatch { .. } => Self::Other(0),
+            #[cfg(feature = "nats")]
+            OrderBookError::NatsPublishError { .. } => Self::Other(0),
+            #[cfg(feature = "nats")]
+            OrderBookError::NatsSerializationError { .. } => Self::Other(0),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pricelevel::{Hash32, Id, PriceLevelError, Side};
+
+    /// Every named variant — used to drive exhaustive table-style tests.
+    /// The `Other` variant is added explicitly where needed.
+    fn named_variants() -> [RejectReason; 13] {
+        [
+            RejectReason::KillSwitchActive,
+            RejectReason::RiskMaxOpenOrders,
+            RejectReason::RiskMaxNotional,
+            RejectReason::RiskPriceBand,
+            RejectReason::PostOnlyWouldCross,
+            RejectReason::SelfTradePrevention,
+            RejectReason::InvalidPrice,
+            RejectReason::InvalidQuantity,
+            RejectReason::InvalidPriceLevel,
+            RejectReason::OrderSizeOutOfRange,
+            RejectReason::MissingUserId,
+            RejectReason::DuplicateOrderId,
+            RejectReason::InsufficientLiquidity,
+        ]
+    }
+
+    #[test]
+    fn test_discriminants_are_stable() {
+        assert_eq!(RejectReason::KillSwitchActive.as_u16(), 1);
+        assert_eq!(RejectReason::RiskMaxOpenOrders.as_u16(), 2);
+        assert_eq!(RejectReason::RiskMaxNotional.as_u16(), 3);
+        assert_eq!(RejectReason::RiskPriceBand.as_u16(), 4);
+        assert_eq!(RejectReason::PostOnlyWouldCross.as_u16(), 5);
+        assert_eq!(RejectReason::SelfTradePrevention.as_u16(), 6);
+        assert_eq!(RejectReason::InvalidPrice.as_u16(), 7);
+        assert_eq!(RejectReason::InvalidQuantity.as_u16(), 8);
+        assert_eq!(RejectReason::InvalidPriceLevel.as_u16(), 9);
+        assert_eq!(RejectReason::OrderSizeOutOfRange.as_u16(), 10);
+        assert_eq!(RejectReason::MissingUserId.as_u16(), 11);
+        assert_eq!(RejectReason::DuplicateOrderId.as_u16(), 12);
+        assert_eq!(RejectReason::InsufficientLiquidity.as_u16(), 13);
+    }
+
+    #[test]
+    fn test_other_passthrough() {
+        assert_eq!(RejectReason::Other(0).as_u16(), 0);
+        assert_eq!(RejectReason::Other(7777).as_u16(), 7777);
+        assert_eq!(RejectReason::Other(u16::MAX).as_u16(), u16::MAX);
+    }
+
+    #[test]
+    fn test_display_reads_human_text() {
+        // Smoke check that every variant produces a non-empty,
+        // human-readable line.
+        for reason in named_variants() {
+            let text = reason.to_string();
+            assert!(!text.is_empty(), "Display for {reason:?} produced empty");
+        }
+        assert_eq!(
+            RejectReason::KillSwitchActive.to_string(),
+            "kill switch active"
+        );
+        assert_eq!(RejectReason::Other(42).to_string(), "other(42)");
+    }
+
+    #[test]
+    fn test_from_order_book_error_kill_switch_maps_to_kill_switch_active() {
+        let err = OrderBookError::KillSwitchActive;
+        assert_eq!(RejectReason::from(&err), RejectReason::KillSwitchActive);
+    }
+
+    #[test]
+    fn test_from_order_book_error_risk_max_open_maps_to_risk_max_open_orders() {
+        let err = OrderBookError::RiskMaxOpenOrders {
+            account: Hash32::from([1u8; 32]),
+            current: 5,
+            limit: 5,
+        };
+        assert_eq!(RejectReason::from(&err), RejectReason::RiskMaxOpenOrders);
+    }
+
+    #[test]
+    fn test_from_order_book_error_risk_max_notional() {
+        let err = OrderBookError::RiskMaxNotional {
+            account: Hash32::from([1u8; 32]),
+            current: 100,
+            attempted: 50,
+            limit: 100,
+        };
+        assert_eq!(RejectReason::from(&err), RejectReason::RiskMaxNotional);
+    }
+
+    #[test]
+    fn test_from_order_book_error_risk_price_band() {
+        let err = OrderBookError::RiskPriceBand {
+            submitted: 1_000_000,
+            reference: 500_000,
+            deviation_bps: 10_000,
+            limit_bps: 100,
+        };
+        assert_eq!(RejectReason::from(&err), RejectReason::RiskPriceBand);
+    }
+
+    #[test]
+    fn test_from_order_book_error_invalid_price_level_maps_to_invalid_price_level() {
+        let err = OrderBookError::InvalidPriceLevel(42);
+        assert_eq!(RejectReason::from(&err), RejectReason::InvalidPriceLevel);
+    }
+
+    #[test]
+    fn test_from_order_book_error_order_size_out_of_range() {
+        let err = OrderBookError::OrderSizeOutOfRange {
+            quantity: 0,
+            min: Some(1),
+            max: Some(100),
+        };
+        assert_eq!(RejectReason::from(&err), RejectReason::OrderSizeOutOfRange);
+    }
+
+    #[test]
+    fn test_from_order_book_error_missing_user_id() {
+        let err = OrderBookError::MissingUserId {
+            order_id: Id::new_uuid(),
+        };
+        assert_eq!(RejectReason::from(&err), RejectReason::MissingUserId);
+    }
+
+    #[test]
+    fn test_from_order_book_error_self_trade_prevented_maps_to_self_trade_prevention() {
+        let err = OrderBookError::SelfTradePrevented {
+            mode: crate::orderbook::stp::STPMode::CancelTaker,
+            taker_order_id: Id::new_uuid(),
+            user_id: Hash32::from([1u8; 32]),
+        };
+        assert_eq!(RejectReason::from(&err), RejectReason::SelfTradePrevention);
+    }
+
+    #[test]
+    fn test_from_order_book_error_price_crossing_maps_to_post_only_would_cross() {
+        let err = OrderBookError::PriceCrossing {
+            price: 100,
+            side: Side::Buy,
+            opposite_price: 99,
+        };
+        assert_eq!(RejectReason::from(&err), RejectReason::PostOnlyWouldCross);
+    }
+
+    #[test]
+    fn test_from_order_book_error_invalid_tick_size_maps_to_invalid_price() {
+        let err = OrderBookError::InvalidTickSize {
+            price: 150,
+            tick_size: 100,
+        };
+        assert_eq!(RejectReason::from(&err), RejectReason::InvalidPrice);
+    }
+
+    #[test]
+    fn test_from_order_book_error_invalid_lot_size_maps_to_invalid_quantity() {
+        let err = OrderBookError::InvalidLotSize {
+            quantity: 75,
+            lot_size: 10,
+        };
+        assert_eq!(RejectReason::from(&err), RejectReason::InvalidQuantity);
+    }
+
+    #[test]
+    fn test_from_order_book_error_insufficient_liquidity() {
+        let err = OrderBookError::InsufficientLiquidity {
+            side: Side::Buy,
+            requested: 100,
+            available: 50,
+        };
+        assert_eq!(RejectReason::from(&err), RejectReason::InsufficientLiquidity);
+    }
+
+    #[test]
+    fn test_from_order_book_error_serialization_error_maps_to_other_zero() {
+        let err = OrderBookError::SerializationError {
+            message: "oops".to_string(),
+        };
+        assert_eq!(RejectReason::from(&err), RejectReason::Other(0));
+    }
+
+    #[test]
+    fn test_from_order_book_error_internal_state_errors_map_to_other_zero() {
+        let cases = [
+            OrderBookError::OrderNotFound("x".to_string()),
+            OrderBookError::InvalidOperation {
+                message: "nope".to_string(),
+            },
+            OrderBookError::DeserializationError {
+                message: "bad".to_string(),
+            },
+            OrderBookError::ChecksumMismatch {
+                expected: "a".to_string(),
+                actual: "b".to_string(),
+            },
+            OrderBookError::PriceLevelError(PriceLevelError::InvalidFormat),
+        ];
+        for err in cases {
+            assert_eq!(
+                RejectReason::from(&err),
+                RejectReason::Other(0),
+                "{err:?} should map to Other(0)"
+            );
+        }
+    }
+
+    #[test]
+    fn test_serde_json_roundtrip_each_variant() {
+        for reason in named_variants() {
+            let json = serde_json::to_string(&reason).expect("serialize named variant");
+            let decoded: RejectReason =
+                serde_json::from_str(&json).expect("deserialize named variant");
+            assert_eq!(decoded, reason);
+        }
+        let other = RejectReason::Other(42);
+        let json = serde_json::to_string(&other).expect("serialize Other(42)");
+        let decoded: RejectReason = serde_json::from_str(&json).expect("deserialize Other(42)");
+        assert_eq!(decoded, other);
+    }
+
+    #[cfg(feature = "bincode")]
+    #[test]
+    fn test_serde_bincode_roundtrip_each_variant() {
+        let cfg = bincode::config::standard();
+        for reason in named_variants() {
+            let bytes = bincode::serde::encode_to_vec(reason, cfg).expect("encode named variant");
+            let (decoded, n) = bincode::serde::decode_from_slice::<RejectReason, _>(&bytes, cfg)
+                .expect("decode named variant");
+            assert_eq!(decoded, reason);
+            assert_eq!(n, bytes.len(), "bincode should consume entire payload");
+        }
+        let other = RejectReason::Other(42);
+        let bytes = bincode::serde::encode_to_vec(other, cfg).expect("encode Other(42)");
+        let (decoded, n) = bincode::serde::decode_from_slice::<RejectReason, _>(&bytes, cfg)
+            .expect("decode Other(42)");
+        assert_eq!(decoded, other);
+        assert_eq!(n, bytes.len());
+    }
+}

--- a/src/orderbook/reject_reason.rs
+++ b/src/orderbook/reject_reason.rs
@@ -355,7 +355,10 @@ mod tests {
             requested: 100,
             available: 50,
         };
-        assert_eq!(RejectReason::from(&err), RejectReason::InsufficientLiquidity);
+        assert_eq!(
+            RejectReason::from(&err),
+            RejectReason::InsufficientLiquidity
+        );
     }
 
     #[test]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -53,6 +53,9 @@ pub use crate::orderbook::order_state::{
     CancelReason, OrderStateListener, OrderStateTracker, OrderStatus,
 };
 
+// Rejection taxonomy
+pub use crate::orderbook::reject_reason::RejectReason;
+
 // Pre-trade risk layer types
 pub use crate::orderbook::risk::{ReferencePriceSource, RiskConfig, RiskState};
 

--- a/tests/unit/kill_switch_tests.rs
+++ b/tests/unit/kill_switch_tests.rs
@@ -7,7 +7,7 @@
 #[cfg(test)]
 mod tests_kill_switch {
     use orderbook_rs::orderbook::order_state::{OrderStateTracker, OrderStatus};
-    use orderbook_rs::{OrderBook, OrderBookError};
+    use orderbook_rs::{OrderBook, OrderBookError, RejectReason};
     use pricelevel::{Hash32, Id, OrderUpdate, Price, Quantity, Side, TimeInForce};
 
     fn new_book() -> OrderBook<()> {
@@ -275,7 +275,7 @@ mod tests_kill_switch {
         let status = book.order_status(order_id);
         match status {
             Some(OrderStatus::Rejected { reason }) => {
-                assert_eq!(reason, "kill switch active");
+                assert_eq!(reason, RejectReason::KillSwitchActive);
             }
             other => panic!("expected Rejected with kill switch reason, got {other:?}"),
         }

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -17,6 +17,7 @@ mod operations_coverage_tests;
 mod operations_coverage_tests_extended;
 mod order_state_tests;
 mod private_coverage_tests;
+mod reject_reason_tests;
 mod replay_coverage_tests;
 mod risk_layer_tests;
 mod sequencer_types_tests;

--- a/tests/unit/reject_reason_tests.rs
+++ b/tests/unit/reject_reason_tests.rs
@@ -1,0 +1,213 @@
+//! Integration tests for the closed `RejectReason` taxonomy.
+//!
+//! Issue #55 — `OrderStatus::Rejected.reason: RejectReason`. Confirms
+//! that every reject path that already transitions the tracker emits
+//! the typed enum, and that the new risk-gate hook records the
+//! correct variant before propagating the typed error.
+
+#[cfg(test)]
+mod tests_reject_reason {
+    use orderbook_rs::orderbook::order_state::{OrderStateTracker, OrderStatus};
+    use orderbook_rs::{OrderBook, OrderBookError, ReferencePriceSource, RejectReason, RiskConfig};
+    use pricelevel::{Hash32, Id, Side, TimeInForce};
+
+    fn book_with_tracker() -> OrderBook<()> {
+        let mut book = OrderBook::<()>::new("TEST");
+        book.set_order_state_tracker(OrderStateTracker::new());
+        book
+    }
+
+    fn account(byte: u8) -> Hash32 {
+        Hash32::new([byte; 32])
+    }
+
+    /// Seed two crossing orders so a trade prints and `last_trade_price`
+    /// is set. After the helper returns, the book has no resting orders.
+    fn seed_last_trade_price(book: &OrderBook<()>, price: u128) {
+        book.add_limit_order(
+            Id::new_uuid(),
+            price,
+            10,
+            Side::Sell,
+            TimeInForce::Gtc,
+            None,
+        )
+        .expect("seed resting ask");
+        book.add_limit_order(Id::new_uuid(), price, 10, Side::Buy, TimeInForce::Gtc, None)
+            .expect("aggressive buy fills the ask");
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // Kill switch
+    // ───────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn kill_switch_reject_records_kill_switch_active_in_tracker() {
+        let book = book_with_tracker();
+        book.engage_kill_switch();
+
+        let order_id = Id::new_uuid();
+        let result = book.add_limit_order(order_id, 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        assert!(matches!(result, Err(OrderBookError::KillSwitchActive)));
+
+        let status = book.order_status(order_id);
+        assert_eq!(
+            status,
+            Some(OrderStatus::Rejected {
+                reason: RejectReason::KillSwitchActive,
+            }),
+            "expected Rejected{{KillSwitchActive}}, got {status:?}"
+        );
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // Risk gates
+    // ───────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn risk_max_open_reject_records_risk_max_open_orders_in_tracker() {
+        let mut book = book_with_tracker();
+        book.set_risk_config(RiskConfig::new().with_max_open_orders_per_account(1));
+        let acct = account(11);
+
+        // Fill the only open-order slot.
+        book.add_limit_order_with_user(
+            Id::new_uuid(),
+            100,
+            1,
+            Side::Buy,
+            TimeInForce::Gtc,
+            acct,
+            None,
+        )
+        .expect("first admission");
+
+        // Second attempt is rejected on the open-orders gate.
+        let rejected_id = Id::new_uuid();
+        let result = book.add_limit_order_with_user(
+            rejected_id,
+            100,
+            1,
+            Side::Buy,
+            TimeInForce::Gtc,
+            acct,
+            None,
+        );
+        assert!(
+            matches!(result, Err(OrderBookError::RiskMaxOpenOrders { .. })),
+            "expected RiskMaxOpenOrders, got {result:?}"
+        );
+
+        let status = book.order_status(rejected_id);
+        assert_eq!(
+            status,
+            Some(OrderStatus::Rejected {
+                reason: RejectReason::RiskMaxOpenOrders,
+            }),
+            "expected Rejected{{RiskMaxOpenOrders}}, got {status:?}"
+        );
+    }
+
+    #[test]
+    fn risk_max_notional_reject_records_risk_max_notional_in_tracker() {
+        let mut book = book_with_tracker();
+        // 1_000 notional ceiling per account.
+        book.set_risk_config(RiskConfig::new().with_max_notional_per_account(1_000));
+        let acct = account(13);
+
+        // 8 * 100 = 800 notional consumed by the first admission.
+        book.add_limit_order_with_user(
+            Id::new_uuid(),
+            100,
+            8,
+            Side::Buy,
+            TimeInForce::Gtc,
+            acct,
+            None,
+        )
+        .expect("first admission within budget");
+
+        // 3 * 100 = 300 attempted; 800 + 300 > 1_000 → reject.
+        let rejected_id = Id::new_uuid();
+        let result = book.add_limit_order_with_user(
+            rejected_id,
+            100,
+            3,
+            Side::Buy,
+            TimeInForce::Gtc,
+            acct,
+            None,
+        );
+        assert!(
+            matches!(result, Err(OrderBookError::RiskMaxNotional { .. })),
+            "expected RiskMaxNotional, got {result:?}"
+        );
+
+        let status = book.order_status(rejected_id);
+        assert_eq!(
+            status,
+            Some(OrderStatus::Rejected {
+                reason: RejectReason::RiskMaxNotional,
+            }),
+            "expected Rejected{{RiskMaxNotional}}, got {status:?}"
+        );
+    }
+
+    #[test]
+    fn risk_price_band_reject_records_risk_price_band_in_tracker() {
+        let mut book = book_with_tracker();
+        seed_last_trade_price(&book, 1_000_000);
+        // 1000 bps = 10% allowed band.
+        book.set_risk_config(
+            RiskConfig::new().with_price_band_bps(1_000, ReferencePriceSource::LastTrade),
+        );
+
+        // +30% from reference → rejected.
+        let rejected_id = Id::new_uuid();
+        let result =
+            book.add_limit_order(rejected_id, 1_300_000, 1, Side::Buy, TimeInForce::Gtc, None);
+        assert!(
+            matches!(result, Err(OrderBookError::RiskPriceBand { .. })),
+            "expected RiskPriceBand, got {result:?}"
+        );
+
+        let status = book.order_status(rejected_id);
+        assert_eq!(
+            status,
+            Some(OrderStatus::Rejected {
+                reason: RejectReason::RiskPriceBand,
+            }),
+            "expected Rejected{{RiskPriceBand}}, got {status:?}"
+        );
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // Display sanity
+    // ───────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn display_format_round_trips_through_to_string() {
+        // Sanity for log lines / wire-text rendering. One assertion per
+        // variant covered by production emission paths after issue #55.
+        assert_eq!(
+            RejectReason::KillSwitchActive.to_string(),
+            "kill switch active"
+        );
+        assert_eq!(
+            RejectReason::RiskMaxOpenOrders.to_string(),
+            "risk: max open orders"
+        );
+        assert_eq!(
+            RejectReason::RiskMaxNotional.to_string(),
+            "risk: max notional"
+        );
+        assert_eq!(RejectReason::RiskPriceBand.to_string(), "risk: price band");
+        assert_eq!(
+            RejectReason::PostOnlyWouldCross.to_string(),
+            "post-only would cross"
+        );
+        assert_eq!(RejectReason::InvalidPrice.to_string(), "invalid price");
+        assert_eq!(RejectReason::MissingUserId.to_string(), "missing user id");
+        assert_eq!(RejectReason::Other(42).to_string(), "other(42)");
+    }
+}


### PR DESCRIPTION
## Summary

- New **`RejectReason`** closed `#[non_exhaustive] #[repr(u16)]` enum
  with stable explicit discriminants (1..13 + `Other(u16)`). The
  canonical wire-side reject taxonomy — consumers can route on the
  numeric code without parsing strings. Discriminants are documented
  as stable across `0.7.x` patch upgrades.
- **`OrderStatus::Rejected.reason: String`** is now `RejectReason`.
  Breaking change on a public variant shape; allowed under the
  `0.6.x → 0.7.x` minor delta in `0.x` semver.
- **`impl From<&OrderBookError> for RejectReason`** — operational
  ergonomics. Exhaustive match — adding an `OrderBookError` variant
  in the future is caught at compile time inside the crate.
- **Tracker emission on every reject path that already transitioned
  the tracker.** Kill switch, risk gates, and the three internal
  sites in `modifications.rs` (validation / post-only / missing
  user id) now record typed reasons.

## Out of scope

- STP cancel-taker and IOC/FOK `InsufficientLiquidity` paths still
  return typed errors without transitioning the tracker. Deferred to
  a follow-up issue. The enum already contains the corresponding
  variants (`SelfTradePrevention`, `InsufficientLiquidity`) so the
  follow-up wiring is non-breaking.
- Reverse direction `From<RejectReason> for OrderBookError` is **not**
  provided. The enum is the stable public contract; the error is the
  internal impl detail.

## Discriminant table

| Variant                  | u16 |
|--------------------------|-----|
| `KillSwitchActive`       | 1   |
| `RiskMaxOpenOrders`      | 2   |
| `RiskMaxNotional`        | 3   |
| `RiskPriceBand`          | 4   |
| `PostOnlyWouldCross`     | 5   |
| `SelfTradePrevention`    | 6   |
| `InvalidPrice`           | 7   |
| `InvalidQuantity`        | 8   |
| `InvalidPriceLevel`      | 9   |
| `OrderSizeOutOfRange`    | 10  |
| `MissingUserId`          | 11  |
| `DuplicateOrderId`       | 12  |
| `InsufficientLiquidity`  | 13  |
| `Other(code)`            | code|

## Commits

```
e52e6ad docs: document RejectReason in CHANGELOG and lib.rs
96eb62b feat(orderbook): record Rejected on risk-gate breach via tracker
13bf802 refactor(orderbook): replace OrderStatus::Rejected.reason String with RejectReason
028c0fb feat(orderbook): add RejectReason closed enum + From<&OrderBookError>
```

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] `cargo test --all-features` — 603 + 25 + 412 + 44 (4
      pre-existing ignored) = **1084** tests pass.
- [x] New unit tests in `src/orderbook/reject_reason.rs`:
      `test_discriminants_are_stable` (exact 1..13 mapping per
      docstring), `test_other_passthrough`, `test_display_reads_human_text`,
      one `test_from_order_book_error_*` per relevant variant, and
      JSON / Bincode round-trip per variant.
- [x] New integration tests in `tests/unit/reject_reason_tests.rs`:
      kill-switch, risk-max-open, risk-max-notional, risk-price-band
      tracker emissions plus a Display smoke test.
- [x] Updated `tests/unit/kill_switch_tests.rs::tracker_records_rejected_on_kill_switch`
      to assert `RejectReason::KillSwitchActive` instead of the old
      string.
- [x] `cargo build --release --all-features` — clean.

## Closes

Closes #55.
