### PR TITLE
fix(matching): make the STP per-level scan deterministic via snapshot_orders (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropped the stale `ISSUE_IV.md` implied-volatility design draft from the repo
   root (the implied-volatility solver now lives in `src/orderbook/implied_volatility/`).
 
+### Fixed
+
+- **STP per-level scan is now deterministic (#94).** The self-trade-prevention
+  pre-scan reads `PriceLevel::snapshot_orders()` (timestamp-ordered) instead of
+  `iter_orders()` (DashMap, non-stable order), so `safe_quantity` and the
+  CancelBoth `maker_order_id` follow price-time priority and are reproducible for a
+  given book state. Non-determinism there previously broke replay (`snapshots_match`
+  could diverge) for `CancelTaker` / `CancelBoth`.
+
 ## [0.8.0] — 2026-05-03
 
 ### Added — Quote-notional market orders (#85)

--- a/src/orderbook/matching.rs
+++ b/src/orderbook/matching.rs
@@ -331,7 +331,17 @@ where
             // When STP is active, check for self-trade conflicts before matching.
             // This is done per-price-level to handle partial fills correctly.
             if stp_active {
-                let orders: Vec<_> = price_level.iter_orders().collect();
+                // `check_stp_at_level` needs the resting orders in the order the sweep
+                // will consume them. `iter_orders()` is DashMap-backed (non-stable) and
+                // makes `safe_quantity` / the CancelBoth `maker_order_id` non-deterministic,
+                // which breaks replay (#94) — so use the deterministic `snapshot_orders()`.
+                //
+                // PRECONDITION: `snapshot_orders()` is `(timestamp, sequence)`-ordered,
+                // whereas `match_order` consumes by pure insertion sequence; these coincide
+                // only when timestamps are monotonic with insertion (the normal case). Under
+                // non-monotonic timestamps the scan can diverge from the sweep — tracked in
+                // #132 (needs an insertion-sequence accessor upstream, PriceLevel#102).
+                let orders = price_level.snapshot_orders();
                 let action = check_stp_at_level(&orders, taker_user_id, self.stp_mode);
 
                 match action {

--- a/src/orderbook/tests/stp.rs
+++ b/src/orderbook/tests/stp.rs
@@ -58,6 +58,129 @@ mod tests {
         id
     }
 
+    /// Helper: add a resting sell order with an explicit user_id and timestamp,
+    /// used to pin price-time priority in the determinism tests below.
+    fn add_sell_order_with_ts(
+        book: &OrderBook<()>,
+        price: u128,
+        quantity: u64,
+        user_id: Hash32,
+        timestamp: u64,
+    ) -> Id {
+        let order = OrderType::Standard {
+            id: Id::new(),
+            price: Price::new(price),
+            quantity: Quantity::new(quantity),
+            side: Side::Sell,
+            user_id,
+            timestamp: TimestampMs::new(timestamp),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        };
+        let id = order.id();
+        let result = book.add_order(order);
+        assert!(result.is_ok(), "failed to add sell order: {result:?}");
+        id
+    }
+
+    // -----------------------------------------------------------------------
+    // STP determinism (#94) — the per-level scan must follow price-time
+    // priority (timestamp order), not the DashMap iteration order. With the
+    // pre-scan reading `snapshot_orders()` (timestamp-sorted) instead of
+    // `iter_orders()` (DashMap, non-stable), `safe_quantity` and the
+    // CancelBoth maker selection are reproducible for a given book state.
+    // -----------------------------------------------------------------------
+
+    /// CancelTaker accumulates `safe_quantity` over the orders that precede the
+    /// first same-user maker *in timestamp order*, so the taker fills exactly the
+    /// older non-self liquidity before the self-trade is prevented.
+    #[test]
+    fn test_cancel_taker_scan_follows_time_priority_at_one_level() {
+        let mut book: OrderBook<()> = OrderBook::new("TEST");
+        book.set_stp_mode(STPMode::CancelTaker);
+
+        let taker_user = user(9);
+        let other = user(1);
+
+        // All at price 100, added in timestamp order. The taker's own resting
+        // order sits third by time, so only m1 + m2 are safe to fill.
+        let m1 = add_sell_order_with_ts(&book, 100, 3, other, 10);
+        let m2 = add_sell_order_with_ts(&book, 100, 4, other, 20);
+        let m_self = add_sell_order_with_ts(&book, 100, 5, taker_user, 30);
+        let m3 = add_sell_order_with_ts(&book, 100, 6, other, 40);
+
+        let taker_id = Id::new();
+        let result = book.match_market_order_with_user(taker_id, 50, Side::Buy, taker_user);
+
+        assert!(result.is_ok(), "expected partial fill, got {result:?}");
+        let mr = result.unwrap();
+        assert_eq!(mr.executed_quantity().unwrap(), Quantity::new(7));
+
+        let trades = mr.trades().as_vec();
+        assert_eq!(
+            trades.len(),
+            2,
+            "should fill exactly the two older non-self orders"
+        );
+        assert_eq!(trades[0].maker_order_id(), m1);
+        assert_eq!(trades[0].quantity(), Quantity::new(3));
+        assert_eq!(trades[1].maker_order_id(), m2);
+        assert_eq!(trades[1].quantity(), Quantity::new(4));
+
+        // The self order (and the later other-user order) are untouched.
+        assert!(
+            book.get_order(m_self).is_some(),
+            "self maker must survive STP"
+        );
+        assert!(
+            book.get_order(m3).is_some(),
+            "later order must not be reached"
+        );
+        assert!(book.get_order(m1).is_none());
+        assert!(book.get_order(m2).is_none());
+    }
+
+    /// CancelBoth cancels the *earliest* same-user maker by timestamp (not an
+    /// arbitrary one chosen by DashMap order) and fills the older non-self liquidity.
+    #[test]
+    fn test_cancel_both_cancels_earliest_self_maker_by_time() {
+        let mut book: OrderBook<()> = OrderBook::new("TEST");
+        book.set_stp_mode(STPMode::CancelBoth);
+
+        let taker_user = user(9);
+        let other = user(1);
+
+        // Price 100, timestamp order: other -> self1 -> self2.
+        let o1 = add_sell_order_with_ts(&book, 100, 8, other, 10);
+        let self1 = add_sell_order_with_ts(&book, 100, 5, taker_user, 20);
+        let self2 = add_sell_order_with_ts(&book, 100, 6, taker_user, 30);
+
+        let taker_id = Id::new();
+        let result = book.match_market_order_with_user(taker_id, 50, Side::Buy, taker_user);
+
+        assert!(result.is_ok(), "expected partial fill, got {result:?}");
+        let mr = result.unwrap();
+
+        let trades = mr.trades().as_vec();
+        assert_eq!(trades.len(), 1);
+        assert_eq!(trades[0].maker_order_id(), o1);
+        assert_eq!(trades[0].quantity(), Quantity::new(8));
+
+        // The earliest same-user maker is cancelled; the later one survives.
+        assert!(
+            book.get_order(self1).is_none(),
+            "earliest self maker should be cancelled"
+        );
+        assert!(
+            book.get_order(self2).is_some(),
+            "later self maker should remain"
+        );
+        assert!(
+            book.get_order(o1).is_none(),
+            "older non-self order fully consumed"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // STPMode::None — backward compatibility
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Overview

The STP per-level pre-scan in `match_order_inner` read `price_level.iter_orders().collect()`, which is `DashMap`-backed and has **non-stable** iteration order. `check_stp_at_level` assumes FIFO time priority, so `safe_quantity` (CancelTaker/CancelBoth) and the cancelled `maker_order_id` (CancelBoth) varied run-to-run for identical book state — non-deterministic, which breaks replay (`snapshots_match` can diverge). This swaps the scan to the deterministic, timestamp-ordered `price_level.snapshot_orders()`.

## Changes

- `src/orderbook/matching.rs`: STP pre-scan uses `snapshot_orders()` instead of `iter_orders().collect()`.
- `src/orderbook/tests/stp.rs`: two determinism tests — CancelTaker `safe_quantity` accumulation (3+4=7 before the self maker) and CancelBoth earliest-same-user-maker cancellation at a single price level.
- `CHANGELOG.md`: `### Fixed` note under `[0.9.0]`.

## Known limitation (documented + tracked)

Two independent reviews (determinism-auditor, microstructure-critic) flagged that `snapshot_orders()` is `(timestamp, sequence)`-ordered, while pricelevel's `match_order` consumes by **pure insertion sequence**. These coincide **only when timestamps are monotonic with insertion** (the normal case). Under non-monotonic timestamps (client-supplied out-of-order `TimestampMs`, clock jitter, modify re-stamp) at a contended STP level, the scan can diverge from the sweep.

This PR fixes the **determinism** (the literal #94 bug) and is correct in the normal case — strictly better than the prior DashMap-ordered scan, where the same divergence existed *and* was non-deterministic. The fully consumption-faithful fix needs an **insertion-sequence accessor** that pricelevel 0.8 doesn't expose:

- Upstream request: **PriceLevel#102** (add `snapshot_by_insertion_seq()` or equivalent).
- Downstream follow-up: **#132** (switch the scan once the upstream primitive lands; add an out-of-order-timestamp test).

The precondition is documented inline at the `snapshot_orders()` call site.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test --all-features` — all pass (49 STP tests incl. the 2 new)
- `cargo build --release --all-features` — clean

Closes #94
