### PR TITLE
fix(matching): fire full cancel side-effects on STP maker cancels (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CancelBoth `maker_order_id` follow price-time priority and are reproducible for a
   given book state. Non-determinism there previously broke replay (`snapshots_match`
   could diverge) for `CancelTaker` / `CancelBoth`.
+- **STP maker cancels now fire the full cancel side-effects (#95).** Under
+  `CancelMaker` / `CancelBoth`, each STP-cancelled resting maker is routed through
+  `cancel_order_with_reason`, so it emits a `PriceLevelChangedEvent`, transitions to
+  `OrderStatus::Cancelled { SelfTradePrevention }`, and releases its per-account risk
+  counter. Previously these three effects were skipped, desynchronizing book-change
+  consumers, leaving the maker in a non-terminal state, and leaking per-account
+  open-order / notional counters.
 
 ## [0.8.0] — 2026-05-03
 

--- a/src/orderbook/matching.rs
+++ b/src/orderbook/matching.rs
@@ -10,7 +10,7 @@ use crate::orderbook::pool::MatchingPool;
 use crate::orderbook::stp::{STPAction, check_stp_at_level};
 use crate::{OrderBook, OrderBookError};
 use either::Either;
-use pricelevel::{Hash32, Id, MatchResult, OrderUpdate, Quantity, Side, TakerKind, TimeInForce};
+use pricelevel::{Hash32, Id, MatchResult, Quantity, Side, TakerKind, TimeInForce};
 use std::sync::atomic::Ordering;
 
 /// Selects how the matching loop measures its budget.
@@ -383,19 +383,19 @@ where
 
                     STPAction::CancelMaker { maker_order_ids } => {
                         // Cancel same-user resting orders, then match normally.
-                        // Look up each maker's user_id from the snapshot rather
-                        // than assuming it equals taker_user_id.
+                        // Each cancel runs on the level we already hold — it emits the
+                        // level-change event, records OrderStatus::Cancelled
+                        // { SelfTradePrevention }, and releases the per-account risk slot
+                        // in lockstep, but does NOT remove the level from the map (no
+                        // order_locations re-resolution either), so level removal stays
+                        // with the post-walk empty_price_levels drain (#95).
                         for maker_id in &maker_order_ids {
-                            let maker_user_id = orders
-                                .iter()
-                                .find(|o| o.id() == *maker_id)
-                                .map(|o| o.user_id())
-                                .unwrap_or(taker_user_id);
-                            let _ = price_level.update_order(OrderUpdate::Cancel {
-                                order_id: *maker_id,
-                            });
-                            self.order_locations.remove(maker_id);
-                            self.untrack_user_order(maker_user_id, maker_id);
+                            self.cancel_resting_maker_on_level(
+                                price_level,
+                                side.opposite(),
+                                *maker_id,
+                                CancelReason::SelfTradePrevention,
+                            );
                         }
                         // If the level is now empty, mark for removal and continue
                         if price_level.order_count() == 0 {
@@ -436,18 +436,15 @@ where
                                 stop.consume(executed, price);
                             }
                         }
-                        // Cancel the maker order — look up its user_id from the
-                        // snapshot rather than assuming it equals taker_user_id.
-                        let maker_user_id = orders
-                            .iter()
-                            .find(|o| o.id() == maker_order_id)
-                            .map(|o| o.user_id())
-                            .unwrap_or(taker_user_id);
-                        let _ = price_level.update_order(OrderUpdate::Cancel {
-                            order_id: maker_order_id,
-                        });
-                        self.order_locations.remove(&maker_order_id);
-                        self.untrack_user_order(maker_user_id, &maker_order_id);
+                        // Cancel the maker on the held level for the same lockstep
+                        // event + state + risk effects as CancelMaker (#95); level
+                        // removal stays with the empty_price_levels drain below.
+                        self.cancel_resting_maker_on_level(
+                            price_level,
+                            side.opposite(),
+                            maker_order_id,
+                            CancelReason::SelfTradePrevention,
+                        );
                         if price_level.order_count() == 0 {
                             empty_price_levels.push(price);
                         }

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -593,6 +593,72 @@ where
         }
     }
 
+    /// Apply the side-effects of cancelling a single resting `order_id` that is
+    /// known to live on the already-held `price_level` (resting on `side`),
+    /// **without** removing the level from the bid/ask map.
+    ///
+    /// This mirrors the per-order effects of [`Self::cancel_order_with_reason`]
+    /// — level-change event, `Cancelled { reason }` state transition, per-account
+    /// risk release, `user_orders` / `order_locations` untrack, and special-order
+    /// deregistration — but it deliberately does **not** touch the bid/ask
+    /// `SkipMap`. The caller owns level removal (the matching loop drains
+    /// `empty_price_levels` after the walk), so this is safe to invoke mid-walk:
+    /// it never removes a level the iterator still references and never
+    /// re-resolves `order_locations`, so a sequence of cancels on the same held
+    /// level cannot skip a later order. Used by the STP `CancelMaker` /
+    /// `CancelBoth` arms (#95). No-op if `order_id` is not resting on the level.
+    pub(super) fn cancel_resting_maker_on_level(
+        &self,
+        price_level: &PriceLevel,
+        side: Side,
+        order_id: Id,
+        reason: CancelReason,
+    ) {
+        let Ok(Some(cancelled)) = price_level.update_order(OrderUpdate::Cancel { order_id }) else {
+            return;
+        };
+        self.cache.invalidate();
+
+        // 1. Notify the level change (same shape as cancel_order_with_reason).
+        if let Some(ref listener) = self.price_level_changed_listener {
+            let engine_seq = self.next_engine_seq();
+            listener(PriceLevelChangedEvent {
+                side,
+                price: price_level.price(),
+                quantity: price_level.visible_quantity(),
+                engine_seq,
+            });
+        }
+
+        // 2. Record the terminal cancellation, preserving any prior fill.
+        let prev_filled = self
+            .order_state_tracker
+            .as_ref()
+            .and_then(|t| t.get(order_id))
+            .map(|s| s.filled_quantity())
+            .unwrap_or(0);
+        self.track_state(
+            order_id,
+            OrderStatus::Cancelled {
+                filled_quantity: prev_filled,
+                reason,
+            },
+        );
+
+        // 3. Drop the per-account risk contribution, then untrack the order.
+        self.order_locations.remove(&order_id);
+        self.risk_state.on_cancel(order_id);
+        self.untrack_user_order(cancelled.user_id(), &order_id);
+
+        #[cfg(feature = "special_orders")]
+        {
+            self.special_order_tracker
+                .unregister_pegged_order(&order_id);
+            self.special_order_tracker
+                .unregister_trailing_stop(&order_id);
+        }
+    }
+
     /// Add a new order to the book, automatically matching it if it's aggressive.
     ///
     /// # Errors

--- a/src/orderbook/tests/stp.rs
+++ b/src/orderbook/tests/stp.rs
@@ -182,6 +182,92 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // STP maker-cancel side effects (#95) — a CancelMaker / CancelBoth cancel
+    // must emit a level-change event, record OrderStatus::Cancelled
+    // { SelfTradePrevention }, and release the per-account risk slot, in
+    // lockstep with cancel_order_with_reason.
+    // -----------------------------------------------------------------------
+
+    /// CancelMaker: the cancelled maker reaches `Cancelled { SelfTradePrevention }`
+    /// and a `PriceLevelChangedEvent` is emitted for its level.
+    #[test]
+    fn test_stp_cancel_maker_emits_event_and_records_state() {
+        use crate::orderbook::book_change_event::PriceLevelChangedEvent;
+        use crate::orderbook::order_state::{CancelReason, OrderStateTracker, OrderStatus};
+        use std::sync::{Arc, Mutex};
+
+        let mut book: OrderBook<()> = OrderBook::new("TEST");
+        book.set_stp_mode(STPMode::CancelMaker);
+        book.set_order_state_tracker(OrderStateTracker::new());
+
+        let u = user(7);
+        let maker = add_sell_order_with_user(&book, 100, 10, u);
+
+        // Install the listener only after the maker rests, so the captured events
+        // come from the STP cancel path, not the admission.
+        let events: Arc<Mutex<Vec<PriceLevelChangedEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&events);
+        book.set_price_level_listener(Arc::new(move |e: PriceLevelChangedEvent| {
+            sink.lock().expect("event sink").push(e);
+        }));
+
+        // Same user crosses -> CancelMaker cancels the resting maker.
+        let taker = Id::new();
+        let _ = book.match_market_order_with_user(taker, 10, Side::Buy, u);
+
+        match book.order_status(maker) {
+            Some(OrderStatus::Cancelled { reason, .. }) => {
+                assert_eq!(reason, CancelReason::SelfTradePrevention);
+            }
+            other => panic!("expected Cancelled {{ SelfTradePrevention }}, got {other:?}"),
+        }
+
+        let captured = events.lock().expect("event sink");
+        assert!(
+            captured
+                .iter()
+                .any(|e| e.price == 100 && e.side == Side::Sell),
+            "expected a Sell-side PriceLevelChangedEvent at price 100 for the cancelled maker's level"
+        );
+    }
+
+    /// CancelBoth: cancelling the maker releases its per-account risk slot (no
+    /// counter leak) and records `Cancelled { SelfTradePrevention }`.
+    #[test]
+    fn test_stp_cancel_both_frees_risk_slot_and_records_state() {
+        use crate::orderbook::order_state::{CancelReason, OrderStateTracker, OrderStatus};
+        use crate::orderbook::risk::RiskConfig;
+
+        let mut book: OrderBook<()> = OrderBook::new("TEST");
+        book.set_stp_mode(STPMode::CancelBoth);
+        book.set_risk_config(RiskConfig::new().with_max_open_orders_per_account(1));
+        book.set_order_state_tracker(OrderStateTracker::new());
+
+        let u = user(7);
+        // Consumes the single per-account open-order slot.
+        let maker = Id::new();
+        book.add_limit_order_with_user(maker, 100, 10, Side::Sell, TimeInForce::Gtc, u, None)
+            .expect("maker admitted (1/1)");
+
+        // Same user crosses -> CancelBoth cancels the maker (and the taker).
+        let taker = Id::new();
+        let _ = book.match_market_order_with_user(taker, 5, Side::Buy, u);
+
+        match book.order_status(maker) {
+            Some(OrderStatus::Cancelled { reason, .. }) => {
+                assert_eq!(reason, CancelReason::SelfTradePrevention);
+            }
+            other => panic!("expected Cancelled {{ SelfTradePrevention }}, got {other:?}"),
+        }
+
+        // The risk slot must have been released: a new order from the same account
+        // is admitted. If on_cancel were skipped, the counter would still read 1/1
+        // and this would fail with RiskMaxOpenOrders.
+        book.add_limit_order_with_user(Id::new(), 101, 1, Side::Sell, TimeInForce::Gtc, u, None)
+            .expect("STP cancel must free the per-account risk slot");
+    }
+
+    // -----------------------------------------------------------------------
     // STPMode::None — backward compatibility
     // -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Overview

Under `STPMode::CancelMaker` / `CancelBoth`, each STP-cancelled resting maker was removed via `update_order(Cancel)` + `order_locations.remove` + `untrack_user_order` but **skipped three side-effects** that the canonical cancel path performs in lockstep:

1. no `PriceLevelChangedEvent` — book-change consumers (NATS / journal) saw level depth shrink silently;
2. no `OrderStatus::Cancelled { SelfTradePrevention }` — the maker was stuck non-terminal in the order-state tracker forever;
3. no `risk_state.on_cancel` — the per-account `open_orders` / `notional` counters leaked, which can permanently reject new flow.

## Fix

Adds `cancel_resting_maker_on_level` (`modifications.rs`), invoked by both STP arms. It applies the event + `Cancelled { SelfTradePrevention }` (preserving any prior fill) + risk release + untrack **on the already-held `price_level`**, and deliberately:

- does **not** remove the level from the bid/ask `SkipMap` — level removal stays with the loop's post-walk `empty_price_levels` drain, so no structural mutation happens under the price iterator;
- does **not** re-resolve `order_locations` — so a sequence of cancels on the same held level cannot skip a later maker.

## Tests

- `test_stp_cancel_maker_emits_event_and_records_state` — CancelMaker records `Cancelled { SelfTradePrevention }` and emits a Sell-side `PriceLevelChangedEvent` at the maker's price.
- `test_stp_cancel_both_frees_risk_slot_and_records_state` — with `max_open_orders_per_account(1)`, the maker consumes the slot; CancelBoth releases it (a fresh same-account order is admitted, which would fail with `RiskMaxOpenOrders` if `on_cancel` had been skipped) and records the terminal state.

## Review

- **determinism-auditor:** replay-safe / commit-safe — no SkipMap mutation under the iterator, no reentrancy-skip, engine_seq minted in deterministic snapshot order.
- **microstructure-critic:** STP semantics preserved; strict correctness improvement over the prior manual path.

(Pre-existing, out of scope: the `snapshot_orders` vs insertion-order scan caveat is tracked in #132 / PriceLevel#102.)

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test --all-features` — 670 pass (incl. the 2 new)
- `cargo build --release --all-features` — clean

Closes #95
