### PR TITLE
fix(matching): record true filled_quantity for fully-consumed makers (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   counter. Previously these three effects were skipped, desynchronizing book-change
   consumers, leaving the maker in a non-terminal state, and leaking per-account
   open-order / notional counters.
+- **Fully-consumed makers record their true filled quantity (#104).** The
+  matching batch-removal path recorded `OrderStatus::Filled { filled_quantity: 0 }`
+  (a placeholder) for every fully-consumed resting maker; it now records the real
+  executed amount (the sum of the maker's trades in the submit), so
+  `OrderStateTracker` / lifecycle consumers and any audit/risk reconciliation that
+  sums filled quantity from terminal events are correct.
 
 ## [0.8.0] — 2026-05-03
 

--- a/src/orderbook/matching.rs
+++ b/src/orderbook/matching.rs
@@ -494,11 +494,18 @@ where
             self.record_depth_metric();
         }
 
-        // Batch remove filled orders from tracking and update state
-        for filled_id in &filled_orders {
-            // Track the resting order as Filled (quantity unknown here;
-            // use 0 as placeholder — the important thing is the terminal state)
-            self.track_state(*filled_id, OrderStatus::Filled { filled_quantity: 0 });
+        // Batch remove filled orders from tracking and update state. Each entry
+        // carries the maker's TRUE filled quantity (captured per-level in
+        // `process_level_match`), so OrderStateTracker / lifecycle consumers and
+        // any audit/risk reconciliation that sums filled quantity from terminal
+        // events see the real executed amount instead of a `0` placeholder (#104).
+        for (filled_id, filled_quantity) in &filled_orders {
+            self.track_state(
+                *filled_id,
+                OrderStatus::Filled {
+                    filled_quantity: *filled_quantity,
+                },
+            );
             self.order_locations.remove(filled_id);
             self.untrack_order_by_id(filled_id);
         }
@@ -668,7 +675,7 @@ where
         &self,
         match_result: &mut MatchResult,
         price_level_match: &MatchResult,
-        filled_orders: &mut Vec<Id>,
+        filled_orders: &mut Vec<(Id, u64)>,
         price: u128,
         price_level: &std::sync::Arc<pricelevel::PriceLevel>,
         side: Side,
@@ -705,10 +712,23 @@ where
             }
         }
 
-        // Collect filled orders for batch removal
+        // Collect fully-consumed makers for batch removal, each with its true
+        // filled quantity. Sum the maker's trades from THIS per-level result,
+        // where `filled_order_ids()` and `trades()` are kept consistent by
+        // pricelevel (an id is recorded only after its trade is added) — so the
+        // recorded `Filled { filled_quantity }` stays correct even if an aggregate
+        // `match_result.add_trade` were dropped (#104). Per-level trade counts are
+        // small; this is the cold path, not the matching hot loop.
         for &filled_order_id in price_level_match.filled_order_ids() {
             match_result.add_filled_order_id(filled_order_id);
-            filled_orders.push(filled_order_id);
+            let filled_quantity: u64 = price_level_match
+                .trades()
+                .as_vec()
+                .iter()
+                .filter(|trade| trade.maker_order_id() == filled_order_id)
+                .map(|trade| trade.quantity().as_u64())
+                .sum();
+            filled_orders.push((filled_order_id, filled_quantity));
         }
 
         // Check if price level is empty and mark for removal

--- a/src/orderbook/pool.rs
+++ b/src/orderbook/pool.rs
@@ -4,7 +4,9 @@ use std::cell::RefCell;
 /// A memory pool for reusing vectors to reduce allocations in hot paths.
 #[derive(Debug)]
 pub struct MatchingPool {
-    filled_orders_pool: RefCell<Vec<Vec<Id>>>,
+    /// Reusable buffers of `(fully_consumed_maker_id, filled_quantity)` collected
+    /// during a match so terminal `Filled` events carry the true fill (#104).
+    filled_orders_pool: RefCell<Vec<Vec<(Id, u64)>>>,
     price_vec_pool: RefCell<Vec<Vec<u128>>>,
 }
 
@@ -17,8 +19,9 @@ impl MatchingPool {
         }
     }
 
-    /// Retrieves a vector for filled orders from the pool.
-    pub fn get_filled_orders_vec(&self) -> Vec<Id> {
+    /// Retrieves a vector for filled orders (with their filled quantities) from
+    /// the pool.
+    pub fn get_filled_orders_vec(&self) -> Vec<(Id, u64)> {
         self.filled_orders_pool
             .borrow_mut()
             .pop()
@@ -26,7 +29,7 @@ impl MatchingPool {
     }
 
     /// Returns a filled orders vector to the pool for reuse.
-    pub fn return_filled_orders_vec(&self, mut vec: Vec<Id>) {
+    pub fn return_filled_orders_vec(&self, mut vec: Vec<(Id, u64)>) {
         vec.clear();
         self.filled_orders_pool.borrow_mut().push(vec);
     }

--- a/src/orderbook/tests/matching.rs
+++ b/src/orderbook/tests/matching.rs
@@ -76,6 +76,31 @@ mod tests {
         assert_eq!(t3[1].quantity(), Quantity::new(3));
     }
 
+    /// Regression for #104: a fully-consumed resting maker records its TRUE
+    /// filled quantity in the order-state tracker, not the old `0` placeholder.
+    #[test]
+    fn test_fully_consumed_maker_records_true_filled_quantity_issue_104() {
+        use crate::orderbook::order_state::{OrderStateTracker, OrderStatus};
+
+        let mut book = setup_book();
+        book.set_order_state_tracker(OrderStateTracker::new());
+
+        let maker = add_limit_order(&book, Side::Sell, 100, 10);
+        let taker = Id::new();
+        let result = book.match_order(taker, Side::Buy, 10, None).unwrap();
+        assert!(result.is_complete());
+
+        match book.order_status(maker) {
+            Some(OrderStatus::Filled { filled_quantity }) => {
+                assert_eq!(
+                    filled_quantity, 10,
+                    "fully-consumed maker must record its true 10-unit fill, not 0"
+                );
+            }
+            other => panic!("expected Filled {{ filled_quantity: 10 }}, got {other:?}"),
+        }
+    }
+
     #[test]
     fn test_market_buy_full_match() {
         let book = setup_book();


### PR DESCRIPTION
## Overview

The post-match batch-removal loop in `match_order_inner` recorded `OrderStatus::Filled { filled_quantity: 0 }` — an explicit placeholder — for every fully-consumed resting maker, because the true filled quantity was not threaded through this path. The taker path already records its true fill; only the maker path was wrong.

`OrderStateTracker` / `OrderStateListener` consumers and `get_order_history` therefore saw `Filled { filled_quantity: 0 }` for every maker, so any audit/risk reconciliation that sums filled quantity from terminal lifecycle events was misled. (The terminal *status* was already correct; only the quantity was a placeholder.)

## Fix

`process_level_match` now captures each fully-consumed maker's true filled quantity — the sum of its trades in **the per-level `MatchResult`** — and threads it through `filled_orders` (now `Vec<(Id, u64)>`) to the batch loop, which records `Filled { filled_quantity }`.

Deriving the quantity from the per-level `price_level_match` (not the aggregate `match_result`) is deliberate: pricelevel guarantees `filled_order_ids()` and `trades()` are consistent (a maker id is recorded only after its trade is added), so the value is correct even if an aggregate `add_trade` were dropped, and it avoids an `O(filled × total_trades)` scan over the whole submit.

## Tests

`test_fully_consumed_maker_records_true_filled_quantity_issue_104` — a maker fully consumed by a taker records `Filled { filled_quantity: 10 }`, not `0`.

## Review

determinism-auditor: **replay-safe, commit-safe** — the per-level result keeps `filled_order_ids`/`trades` in guaranteed correspondence; the quantity is a deterministic integer fold; the pool type change (`Vec<(Id, u64)>`) introduces no new hazard.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test --all-features` — 671 pass (incl. the new test)
- `cargo build --release --all-features` — clean

Closes #104
