### PR TITLE
fix(matching): make FOK feasibility STP- and depth-faithful (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   executed amount (the sum of the maker's trades in the submit), so
   `OrderStateTracker` / lifecycle consumers and any audit/risk reconciliation that
   sums filled quantity from terminal events are correct.
+- **Fill-or-kill feasibility is self-trade-prevention aware (#96).** FOK admission
+  checked feasibility with `peek_match`, which sums raw level depth: under
+  `STPMode::CancelMaker` it counted same-user resting quantity (which the real
+  match *cancels*, not fills), so a FOK could pass the check, cancel the maker,
+  fill nothing, and still return `InsufficientLiquidity` — with the book already
+  mutated. A new faithful `fok_fillable_quantity` mirrors the real walk —
+  `lot_size`-rounded budget, per-level STP via `check_stp_at_level`, and per-order
+  *drawable* depth (a non-auto-replenish reserve's hidden tranche is dropped
+  unfilled by the sweep, so it is excluded) — so a FOK that cannot be fully filled
+  is killed *before* any trade or cancel. (The `lot_size` divergence the report
+  also posited is not reachable through the validated admission path — it rejects
+  non-lot-multiple orders — but the rounding is kept so the check stays faithful to
+  the matching walk.)
 
 ## [0.8.0] — 2026-05-03
 

--- a/src/orderbook/matching.rs
+++ b/src/orderbook/matching.rs
@@ -10,8 +10,31 @@ use crate::orderbook::pool::MatchingPool;
 use crate::orderbook::stp::{STPAction, check_stp_at_level};
 use crate::{OrderBook, OrderBookError};
 use either::Either;
-use pricelevel::{Hash32, Id, MatchResult, Quantity, Side, TakerKind, TimeInForce};
+use pricelevel::{Hash32, Id, MatchResult, OrderType, Quantity, Side, TakerKind, TimeInForce};
 use std::sync::atomic::Ordering;
+
+/// Matchable depth of a single resting order: its visible quantity plus any
+/// hidden quantity the sweep can actually draw. An iceberg always replenishes
+/// its hidden tranche; a reserve only when `auto_replenish` is set — a
+/// non-auto-replenish reserve drops its hidden unfilled, so that hidden is NOT
+/// reachable depth. Used by FOK feasibility (#96) so undrawable hidden is never
+/// counted as fillable.
+#[inline]
+fn order_matchable_qty(order: &OrderType<()>) -> u64 {
+    let visible = order.visible_quantity().as_u64();
+    let drawable_hidden = match order {
+        OrderType::IcebergOrder {
+            hidden_quantity, ..
+        } => hidden_quantity.as_u64(),
+        OrderType::ReserveOrder {
+            hidden_quantity,
+            auto_replenish,
+            ..
+        } if *auto_replenish => hidden_quantity.as_u64(),
+        _ => 0,
+    };
+    visible.saturating_add(drawable_hidden)
+}
 
 /// Selects how the matching loop measures its budget.
 ///
@@ -787,6 +810,112 @@ where
         }
 
         matched_quantity
+    }
+
+    /// Faithful fill-or-kill feasibility: the quantity an immediate match of
+    /// `quantity` would *actually* fill, mirroring the real walk in
+    /// [`Self::match_order_inner`] — `lot_size` budget rounding, self-trade
+    /// prevention, and per-order *drawable* depth (a non-auto-replenish reserve's
+    /// hidden tranche is dropped unfilled by the sweep, so it is not counted).
+    ///
+    /// [`Self::peek_match`] only sums raw level depth, so it over-reports when STP
+    /// would cancel makers / the taker, or when a non-replenish reserve's hidden is
+    /// present. Routing FOK admission through this keeps fill-or-kill
+    /// all-or-nothing: an order that cannot be fully filled is killed *before* any
+    /// trade is emitted (#96).
+    pub(crate) fn fok_fillable_quantity(
+        &self,
+        side: Side,
+        quantity: u64,
+        price_limit: Option<u128>,
+        taker_user_id: Hash32,
+    ) -> u64 {
+        let price_levels = match side {
+            Side::Buy => &self.asks,
+            Side::Sell => &self.bids,
+        };
+        if quantity == 0 || price_levels.is_empty() {
+            return 0;
+        }
+
+        let lot = self.lot_size.unwrap_or(1);
+        let stp_active = self.stp_mode.is_enabled() && taker_user_id != Hash32::zero();
+
+        let price_iter = match side {
+            Side::Buy => Either::Left(price_levels.iter()),
+            Side::Sell => Either::Right(price_levels.iter().rev()),
+        };
+
+        let mut matched = 0u64;
+        for entry in price_iter {
+            if matched >= quantity {
+                break;
+            }
+
+            let price = *entry.key();
+            if let Some(limit) = price_limit {
+                match side {
+                    Side::Buy if price > limit => break,
+                    Side::Sell if price < limit => break,
+                    _ => {}
+                }
+            }
+
+            // Lot-round the remaining budget exactly like `StopCondition::level_qty_cap`:
+            // a budget below one full lot is dust and stops the walk.
+            let needed = quantity - matched;
+            let cap = if lot <= 1 {
+                needed
+            } else {
+                needed - (needed % lot)
+            };
+            if cap == 0 {
+                break;
+            }
+
+            let price_level = entry.value();
+
+            // Reachable depth at this level — the quantity the real sweep could
+            // actually fill — using per-order *matchable* depth (visible + drawable
+            // hidden), not the level's raw total, so a non-auto-replenish reserve's
+            // undrawable hidden tranche is not counted (#96).
+            let (reachable, stop_after) = if stp_active {
+                let orders = price_level.snapshot_orders();
+                match check_stp_at_level(&orders, taker_user_id, self.stp_mode) {
+                    STPAction::NoConflict => {
+                        (orders.iter().map(|o| order_matchable_qty(o)).sum(), false)
+                    }
+                    // Same-user makers are cancelled, not filled: only non-self
+                    // resting depth is reachable; the walk continues.
+                    STPAction::CancelMaker { .. } => {
+                        let non_self: u64 = orders
+                            .iter()
+                            .filter(|o| o.user_id() != taker_user_id)
+                            .map(|o| order_matchable_qty(o))
+                            .sum();
+                        (non_self, false)
+                    }
+                    // The taker is cancelled at the first same-user order: it can
+                    // fill at most `safe_quantity` (visible-only, matching the real
+                    // sweep's cap) here, then stops.
+                    STPAction::CancelTaker { safe_quantity }
+                    | STPAction::CancelBoth { safe_quantity, .. } => (safe_quantity, true),
+                }
+            } else {
+                let reachable = price_level
+                    .iter_orders()
+                    .map(|o| order_matchable_qty(&o))
+                    .sum();
+                (reachable, false)
+            };
+
+            matched = matched.saturating_add(cap.min(reachable));
+            if stop_after {
+                break;
+            }
+        }
+
+        matched
     }
 
     /// Batch operation for multiple order matches (additional optimization)

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -833,12 +833,16 @@ where
             });
         }
 
-        // For FOK orders, first check if the entire quantity can be matched without altering the book.
+        // For FOK orders, first check if the entire quantity can be matched
+        // without altering the book. Use the faithful feasibility check (lot_size
+        // + STP aware), not the raw-depth `peek_match`, so fill-or-kill stays
+        // all-or-nothing and never emits a partial fill it then reports as killed (#96).
         if order.is_fill_or_kill() {
-            let potential_match = self.peek_match(
+            let potential_match = self.fok_fillable_quantity(
                 order.side(),
                 order.total_quantity(),
                 Some(order.price().as_u128()),
+                order.user_id(),
             );
             if potential_match < order.total_quantity() {
                 self.track_state(

--- a/src/orderbook/tests/matching.rs
+++ b/src/orderbook/tests/matching.rs
@@ -101,6 +101,91 @@ mod tests {
         }
     }
 
+    /// #96: the FOK feasibility check is now `lot_size`-aware. Admission already
+    /// rejects non-lot-multiple orders, so a lot-rounding *divergence* from raw
+    /// depth is not reachable through the public API — but the lot branch in the
+    /// faithful feasibility check must still admit a legitimately fillable,
+    /// lot-aligned FOK (it must not spuriously kill it).
+    #[test]
+    fn test_fok_with_lot_size_fills_when_depth_suffices_issue_96() {
+        let book: OrderBook<()> = OrderBook::with_lot_size("TEST", 5);
+        add_limit_order(&book, Side::Sell, 100, 5);
+        add_limit_order(&book, Side::Sell, 101, 5);
+
+        // FOK buy 10 (lot-aligned) at limit 101 — full reachable depth is 10.
+        let fok = OrderType::Standard {
+            id: Id::new(),
+            price: Price::new(101),
+            quantity: Quantity::new(10),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            time_in_force: TimeInForce::Fok,
+            timestamp: TimestampMs::new(0),
+            extra_fields: (),
+        };
+        let result = book.add_order(fok);
+        assert!(
+            result.is_ok(),
+            "lot-aligned FOK with sufficient depth must fill, got {result:?}"
+        );
+        assert!(book.has_traded.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(book.asks.is_empty(), "both ask levels should be consumed");
+    }
+
+    /// #96: FOK feasibility must count only *drawable* depth. A non-auto-replenish
+    /// reserve's hidden tranche is dropped unfilled by the sweep, so it is not
+    /// reachable — a FOK that would need it must be killed before any partial fill.
+    #[test]
+    fn test_fok_excludes_non_replenish_reserve_hidden_issue_96() {
+        use std::num::NonZeroU64;
+
+        let book: OrderBook<()> = OrderBook::new("TEST");
+        let reserve_id = Id::new();
+        book.add_order(OrderType::ReserveOrder {
+            id: reserve_id,
+            price: Price::new(100),
+            visible_quantity: Quantity::new(5),
+            hidden_quantity: Quantity::new(5),
+            side: Side::Sell,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(0),
+            time_in_force: TimeInForce::Gtc,
+            replenish_threshold: Quantity::new(0),
+            replenish_amount: Some(NonZeroU64::new(5).expect("nonzero")),
+            auto_replenish: false,
+            extra_fields: (),
+        })
+        .expect("reserve admitted");
+
+        // FOK buy 10 at price 100. Raw level total is 10 (5 visible + 5 hidden),
+        // but only the 5 visible is drawable, so the FOK must be killed with no
+        // trade and the reserve untouched. The old raw-depth check let it proceed,
+        // fill 5, drop the hidden, and error with the book already mutated.
+        let fok = OrderType::Standard {
+            id: Id::new(),
+            price: Price::new(100),
+            quantity: Quantity::new(10),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            time_in_force: TimeInForce::Fok,
+            timestamp: TimestampMs::new(0),
+            extra_fields: (),
+        };
+        let result = book.add_order(fok);
+        assert!(
+            matches!(result, Err(OrderBookError::InsufficientLiquidity { .. })),
+            "FOK must be killed: a non-replenish reserve's hidden is not drawable, got {result:?}"
+        );
+        assert!(
+            !book.has_traded.load(std::sync::atomic::Ordering::SeqCst),
+            "FOK kill must emit no trades"
+        );
+        assert!(
+            book.get_order(reserve_id).is_some(),
+            "the reserve must be untouched by a killed FOK"
+        );
+    }
+
     #[test]
     fn test_market_buy_full_match() {
         let book = setup_book();

--- a/src/orderbook/tests/stp.rs
+++ b/src/orderbook/tests/stp.rs
@@ -267,6 +267,47 @@ mod tests {
             .expect("STP cancel must free the per-account risk slot");
     }
 
+    /// FOK feasibility must be STP-aware (#96): under CancelMaker, a same-user
+    /// resting order is NOT fillable (it gets cancelled), so a FOK that could only
+    /// be "filled" by crossing its own order must be killed up front — before any
+    /// maker is cancelled or any trade is emitted. The raw `peek_match` counted the
+    /// self quantity and let the FOK proceed, cancelling the maker and filling 0.
+    #[test]
+    fn test_fok_under_stp_cancel_maker_kills_without_touching_makers() {
+        let mut book: OrderBook<()> = OrderBook::new("TEST");
+        book.set_stp_mode(STPMode::CancelMaker);
+
+        let u = user(7);
+        // The only resting liquidity at price 100 belongs to the taker's own user.
+        let maker = add_sell_order_with_user(&book, 100, 10, u);
+
+        let fok = OrderType::Standard {
+            id: Id::new(),
+            price: Price::new(100),
+            quantity: Quantity::new(10),
+            side: Side::Buy,
+            user_id: u,
+            time_in_force: TimeInForce::Fok,
+            timestamp: TimestampMs::new(crate::utils::current_time_millis()),
+            extra_fields: (),
+        };
+        let result = book.add_order(fok);
+
+        assert!(
+            matches!(result, Err(OrderBookError::InsufficientLiquidity { .. })),
+            "FOK must be killed when only self-liquidity exists, got {result:?}"
+        );
+        // Killed before matching: the maker is untouched and nothing traded.
+        assert!(
+            book.get_order(maker).is_some(),
+            "FOK kill must not cancel the resting maker"
+        );
+        assert!(
+            !book.has_traded.load(std::sync::atomic::Ordering::SeqCst),
+            "FOK kill must emit no trades"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // STPMode::None — backward compatibility
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Overview

FOK admission validated feasibility with `peek_match`, which sums raw level depth with no STP awareness and no drawable-depth check. Under `STPMode::CancelMaker`, a same-user resting order counted toward the fillable total — so a FOK could pass the check, then the real match cancels those makers (no trade), fills less than requested, and returns `InsufficientLiquidity` **with the book already mutated**. Fill-or-kill must never emit a trade (or cancel) unless the order can be completely filled.

## Fix

Adds `OrderBook::fok_fillable_quantity`, a faithful dry-run of `match_order_inner`, and routes FOK admission through it. Per level it:

- **lot-rounds the budget** exactly like `StopCondition::level_qty_cap` (`needed - needed % lot`, stop on a sub-lot remainder);
- **resolves STP** via `check_stp_at_level(snapshot_orders())`: NoConflict → full level depth; CancelMaker → non-self depth only (same-user makers are cancelled, not filled); CancelTaker/CancelBoth → `safe_quantity` then stop (the taker is cancelled at the first self order);
- counts **per-order drawable depth** via `order_matchable_qty` = `visible + drawable_hidden`, where hidden is drawable for icebergs and auto-replenish reserves only — a **non-auto-replenish reserve's hidden is dropped unfilled** by the sweep, so it must not be counted.

An order that cannot be fully filled is now killed at admission, before any trade or cancel.

## Scope notes (honest)

- The **`lot_size` divergence** the report also posited is **not reachable** through the validated admission path: it rejects non-lot-multiple orders, so every resting and incoming quantity is a lot multiple and raw/lot-rounded depth always agree. The lot-rounding is kept so `fok_fillable_quantity` stays faithful to the matching walk.
- `order_matchable_qty` is a hand-rolled twin of pricelevel's **private** `matchable_quantity`; **#136** tracks delegating to it once pricelevel exposes it (`pub`), referencing PriceLevel#102.

## Tests

- `test_fok_under_stp_cancel_maker_kills_without_touching_makers` (stp) — FOK whose only liquidity is its own order is killed; the maker is untouched and nothing trades.
- `test_fok_excludes_non_replenish_reserve_hidden_issue_96` (matching) — a non-auto-replenish reserve's hidden is not drawable; a FOK that would need it is killed, reserve untouched.
- `test_fok_with_lot_size_fills_when_depth_suffices_issue_96` (matching) — a legitimately fillable lot-aligned FOK is not spuriously killed.

## Review

- **microstructure-critic:** ready for release — faithful for every `OrderType` variant, agrees with the upstream (private) `matchable_quantity`; the only residual is a conservative under-report under exotic STP layouts that *strengthens* the all-or-nothing guarantee.
- **determinism-auditor:** replay-safe, commit-safe — read-only feasibility, integer-only, no new non-determinism.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, `cargo test --all-features` (674 pass), `cargo build --release` — all clean.

Closes #96
