### PR TITLE
fix(matching): cancel the STP self-cross residual instead of resting it (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   also posited is not reachable through the validated admission path — it rejects
   non-lot-multiple orders — but the rounding is kept so the check stays faithful to
   the matching walk.)
+- **STP-cancelled takers no longer rest a self-cross residual (#97).** When a taker
+  partially filled against another user and then would self-cross under
+  `CancelTaker` / `CancelBoth`, the engine returned `Ok` with a resting remainder
+  (GTC) — defeating STP and never recording the terminal `SelfTradePrevention`
+  state. `match_order_inner` now returns a `MatchOutcome` carrying a
+  `taker_stp_cancelled` flag; `add_order` cancels the residual (records
+  `Cancelled { SelfTradePrevention }` with the true filled quantity and returns
+  `SelfTradePrevented`) instead of resting it. The public `match_order` /
+  `match_order_with_user` signatures are unchanged.
 
 ## [0.8.0] — 2026-05-03
 

--- a/src/orderbook/matching.rs
+++ b/src/orderbook/matching.rs
@@ -36,6 +36,29 @@ fn order_matchable_qty(order: &OrderType<()>) -> u64 {
     visible.saturating_add(drawable_hidden)
 }
 
+/// Outcome of an internal match: the [`MatchResult`] plus whether self-trade
+/// prevention cancelled the taker. The flag lets the resting caller (`add_order`)
+/// know it must NOT rest the residual — a partially-filled taker that then
+/// self-crossed under `CancelTaker` / `CancelBoth` is cancelled, not rested (#97).
+#[derive(Debug)]
+pub(crate) struct MatchOutcome {
+    /// The trades, filled-order ids, and remaining quantity of the match.
+    pub(crate) result: MatchResult,
+    /// `true` when STP cancelled the taker, so any residual must not rest.
+    pub(crate) taker_stp_cancelled: bool,
+}
+
+impl MatchOutcome {
+    /// Wrap a `MatchResult` with no STP cancellation (common case / empty book).
+    #[inline]
+    fn resting(result: MatchResult) -> Self {
+        Self {
+            result,
+            taker_stp_cancelled: false,
+        }
+    }
+}
+
 /// Selects how the matching loop measures its budget.
 ///
 /// `BaseQty` is the legacy base-asset quantity path (existing market and
@@ -217,6 +240,21 @@ where
         limit_price: Option<u128>,
         taker_user_id: Hash32,
     ) -> Result<MatchResult, OrderBookError> {
+        self.match_order_with_user_outcome(order_id, side, quantity, limit_price, taker_user_id)
+            .map(|o| o.result)
+    }
+
+    /// Like [`Self::match_order_with_user`] but returns the full [`MatchOutcome`],
+    /// including the STP-cancel signal the resting caller in `add_order` needs to
+    /// avoid resting a self-cross residual (#97).
+    pub(crate) fn match_order_with_user_outcome(
+        &self,
+        order_id: Id,
+        side: Side,
+        quantity: u64,
+        limit_price: Option<u128>,
+        taker_user_id: Hash32,
+    ) -> Result<MatchOutcome, OrderBookError> {
         self.match_order_inner(
             order_id,
             side,
@@ -255,6 +293,7 @@ where
             MatchMode::QuoteAmount { amount },
             taker_user_id,
         )
+        .map(|o| o.result)
     }
 
     /// Unified matching loop driven by [`MatchMode`] / [`StopCondition`].
@@ -278,7 +317,7 @@ where
         side: Side,
         mode: MatchMode,
         taker_user_id: Hash32,
-    ) -> Result<MatchResult, OrderBookError> {
+    ) -> Result<MatchOutcome, OrderBookError> {
         self.cache.invalidate();
         let mut match_result =
             MatchResult::new(order_id, Quantity::new(mode.initial_match_quantity()));
@@ -301,7 +340,9 @@ where
 
         // Early exit if the opposite side is empty
         if match_side.is_empty() {
-            return self.empty_book_result(side, &mode, match_result);
+            return self
+                .empty_book_result(side, &mode, match_result)
+                .map(MatchOutcome::resting);
         }
 
         // Use static memory pool for better performance
@@ -610,7 +651,10 @@ where
             match_result = Self::normalize_notional_match_result(order_id, match_result);
         }
 
-        Ok(match_result)
+        Ok(MatchOutcome {
+            result: match_result,
+            taker_stp_cancelled: stp_taker_cancelled,
+        })
     }
 
     /// Rebuild a `MatchResult` produced by the quote-notional path so its

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -1,6 +1,7 @@
 use crate::orderbook::book::OrderBook;
 use crate::orderbook::book_change_event::PriceLevelChangedEvent;
 use crate::orderbook::error::OrderBookError;
+use crate::orderbook::matching::MatchOutcome;
 use crate::orderbook::order_state::{CancelReason, OrderStatus};
 use crate::orderbook::reject_reason::RejectReason;
 use crate::orderbook::trade::TradeResult;
@@ -862,8 +863,12 @@ where
         }
 
         self.cache.invalidate();
-        // Attempt to match the order immediately (with STP user_id propagation)
-        let match_result = self.match_order_with_user(
+        // Attempt to match the order immediately (with STP user_id propagation).
+        // The outcome also carries whether STP cancelled the taker (#97).
+        let MatchOutcome {
+            result: match_result,
+            taker_stp_cancelled,
+        } = self.match_order_with_user_outcome(
             order.id(),
             order.side(),
             order.total_quantity(), // Use total quantity for matching
@@ -885,9 +890,30 @@ where
             }
         }
 
-        // Track the incoming order's state based on matching result
+        // True (non-self) executed quantity. `remaining_quantity` only decrements on
+        // real trades, so STP-prevented self-fills never count toward it.
         let original_qty = order.total_quantity();
         let filled_qty = original_qty.saturating_sub(match_result.remaining_quantity().as_u64());
+
+        // If STP cancelled the taker, the residual must NOT rest — even though some
+        // non-self fills already occurred at earlier levels. Record the terminal
+        // SelfTradePrevention state with the true filled quantity and surface the STP
+        // error (#97). The zero-fills case already returned this error from the match.
+        if taker_stp_cancelled {
+            self.track_state(
+                order.id(),
+                OrderStatus::Cancelled {
+                    filled_quantity: filled_qty,
+                    reason: CancelReason::SelfTradePrevention,
+                },
+            );
+            crate::orderbook::metrics::record_reject(RejectReason::SelfTradePrevention);
+            return Err(OrderBookError::SelfTradePrevented {
+                mode: self.stp_mode,
+                taker_order_id: order.id(),
+                user_id: order.user_id(),
+            });
+        }
 
         // If the order was not fully filled, add the remainder to the book
         if match_result.remaining_quantity().as_u64() > 0 {

--- a/src/orderbook/tests/stp.rs
+++ b/src/orderbook/tests/stp.rs
@@ -308,6 +308,101 @@ mod tests {
         );
     }
 
+    /// #97: a taker that partially fills against another user and then would
+    /// self-cross under CancelTaker must have its residual CANCELLED, not rested.
+    /// Previously the partial-fill path returned Ok with a resting remainder,
+    /// defeating STP and never recording the SelfTradePrevention terminal state.
+    #[test]
+    fn test_cancel_taker_partial_self_cross_does_not_rest_residual() {
+        use crate::orderbook::order_state::{CancelReason, OrderStateTracker, OrderStatus};
+
+        let mut book: OrderBook<()> = OrderBook::new("TEST");
+        book.set_stp_mode(STPMode::CancelTaker);
+        book.set_order_state_tracker(OrderStateTracker::new());
+
+        let taker_user = user(7);
+        let other = user(1);
+
+        // Non-self liquidity at the better price; the taker's own order behind it.
+        let other_maker = add_sell_order_with_user(&book, 100, 5, other);
+        let self_maker = add_sell_order_with_user(&book, 200, 10, taker_user);
+
+        // GTC buy 20 at limit 200: fills 5 vs `other` at 100, then hits its own
+        // order at 200 -> CancelTaker cancels the taker. The 15-unit residual must
+        // NOT rest, and the taker records Cancelled { SelfTradePrevention }.
+        let taker_id = Id::new();
+        let taker = OrderType::Standard {
+            id: taker_id,
+            price: Price::new(200),
+            quantity: Quantity::new(20),
+            side: Side::Buy,
+            user_id: taker_user,
+            time_in_force: TimeInForce::Gtc,
+            timestamp: TimestampMs::new(crate::utils::current_time_millis()),
+            extra_fields: (),
+        };
+        let result = book.add_order(taker);
+
+        assert!(
+            matches!(result, Err(OrderBookError::SelfTradePrevented { .. })),
+            "partial self-cross under CancelTaker must surface the STP error, got {result:?}"
+        );
+        assert!(
+            book.get_order(taker_id).is_none(),
+            "STP-cancelled taker must not rest its residual"
+        );
+        assert!(book.bids.is_empty(), "no residual bid level should exist");
+
+        match book.order_status(taker_id) {
+            Some(OrderStatus::Cancelled {
+                filled_quantity,
+                reason,
+            }) => {
+                assert_eq!(reason, CancelReason::SelfTradePrevention);
+                assert_eq!(
+                    filled_quantity, 5,
+                    "filled quantity must reflect the 5-unit non-self fill"
+                );
+            }
+            other => panic!("expected Cancelled {{ SelfTradePrevention, 5 }}, got {other:?}"),
+        }
+
+        // The non-self maker was consumed; the self maker survives (CancelTaker).
+        assert!(book.get_order(other_maker).is_none());
+        assert!(book.get_order(self_maker).is_some());
+    }
+
+    /// #97 (notional path contract): `match_market_order_by_amount_with_user` is a
+    /// MATCH-ONLY API — a notional taker that partially fills then self-crosses
+    /// under CancelTaker returns `Ok(partial)` (the unspent notional is simply not
+    /// consumed), mirroring the base-qty market-order contract. It never rests a
+    /// residual and never emits a self-trade; the residual-cancel of #97 only
+    /// applies to the lifecycle-managing `add_order` path.
+    #[test]
+    fn test_notional_market_partial_self_cross_returns_partial() {
+        let mut book: OrderBook<()> = OrderBook::new("TEST");
+        book.set_stp_mode(STPMode::CancelTaker);
+
+        let taker_user = user(7);
+        let other = user(1);
+
+        let other_maker = add_sell_order_with_user(&book, 100, 5, other);
+        let self_maker = add_sell_order_with_user(&book, 200, 10, taker_user);
+
+        // Notional buy of 1000 quote: 5 @ 100 (500 spent) vs `other`, then the
+        // self-cross at 200 cancels the taker. Match-only -> Ok with the 5-unit fill.
+        let taker_id = Id::new();
+        let result =
+            book.match_market_order_by_amount_with_user(taker_id, 1000, Side::Buy, taker_user);
+
+        let mr = result.expect("notional partial self-cross returns Ok(partial)");
+        assert_eq!(mr.executed_quantity().unwrap(), Quantity::new(5));
+        assert!(book.get_order(taker_id).is_none(), "no residual rests");
+        assert!(book.bids.is_empty());
+        assert!(book.get_order(other_maker).is_none());
+        assert!(book.get_order(self_maker).is_some());
+    }
+
     // -----------------------------------------------------------------------
     // STPMode::None — backward compatibility
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Overview

When a taker partially filled against another user and then would self-cross under `STPMode::CancelTaker` / `CancelBoth`, `match_order_inner` returned `Ok` with `remaining > 0`, and `add_order` **rested the GTC remainder** (or mislabelled IOC as `InsufficientLiquidity`) — defeating self-trade prevention and never recording the terminal `SelfTradePrevention` state. (The zero-fill case was already handled.)

## Fix

`match_order_inner` now returns `MatchOutcome { result: MatchResult, taker_stp_cancelled: bool }`. The **public `match_order` / `match_order_with_user` / `match_order_by_amount_with_user` signatures are unchanged** — they map to `.result`. `add_order` calls the new `match_order_with_user_outcome`, and when `taker_stp_cancelled`:

1. emits the real partial-fill trades to the listener (the non-self fills genuinely happened),
2. records `Cancelled { SelfTradePrevention }` with the true filled quantity,
3. records the reject metric, and returns `SelfTradePrevented`,

**without resting the residual**. This covers GTC (would have rested), IOC (would have mislabelled), and FOK (already pre-killed at feasibility by #96).

## Scope note (notional path)

`match_market_order_by_amount_with_user` is a **match-only** API: a notional taker that partially fills then self-crosses returns `Ok(partial)` (the unspent notional is simply not consumed), mirroring the base-qty market-order contract `match_market_order_with_user`. It never rests a residual and never emits a self-trade. The residual-cancel applies only to the lifecycle-managing `add_order` path. Documented + tested.

## Tests

- `test_cancel_taker_partial_self_cross_does_not_rest_residual` — GTC buy fills 5 vs another user, self-crosses at a worse level under CancelTaker → residual not rested (`bids` empty), taker terminal `Cancelled { SelfTradePrevention, filled_quantity: 5 }`, self-maker survives.
- `test_notional_market_partial_self_cross_returns_partial` — documents the notional match-only contract.

## Review

- **microstructure-critic:** core base-qty fix correct — `taker_stp_cancelled` set correctly for CancelTaker/CancelBoth on every fill path; GTC/IOC/FOK residual correctly not rested; `filled_qty` is the true non-self quantity; trade-then-cancel ordering consistent with the zero-fill path; no regression to non-STP / CancelMaker / public `match_order`. (Notional gap → documented + tested.)
- **determinism-auditor:** replay-safe, commit-safe — no new non-determinism; the taker is not inserted in either a live run or a replay of the same op sequence, so `snapshots_match` holds.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, `cargo test --all-features` (676 pass), `cargo build --release` — all clean.

Closes #97
