### PR TITLE
fix(matching): STP scan follows insertion-sequence (sweep) order via pricelevel 0.8.1 (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Cancelled { SelfTradePrevention }` with the true filled quantity and returns
   `SelfTradePrevented`) instead of resting it. The public `match_order` /
   `match_order_with_user` signatures are unchanged.
+- **STP scan follows insertion-sequence (sweep) order (#132).** Bumped `pricelevel`
+  0.8.0 → 0.8.1 for `PriceLevel::snapshot_by_insertion_seq()`. The STP pre-scan and
+  the FOK feasibility scan now read it instead of `snapshot_orders()`
+  (`(timestamp, sequence)`-ordered), so `safe_quantity` and the cancelled / selected
+  maker match what `match_order` actually consumes even under non-monotonic
+  timestamps — closing the consumption-fidelity gap that #94 left open (and which the
+  #94 determinism fix only addressed for monotonic timestamps).
 
 ## [0.8.0] — 2026-05-03
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ members = [
 
 [workspace.dependencies]
 orderbook-rs = { path = "." }
-pricelevel = "0.8"
+pricelevel = "0.8.1"
 tracing = "0.1"
 uuid = { version = "1.23", features = ["v4", "v5", "serde"] }
 dashmap = "6.2"

--- a/src/orderbook/matching.rs
+++ b/src/orderbook/matching.rs
@@ -395,17 +395,15 @@ where
             // When STP is active, check for self-trade conflicts before matching.
             // This is done per-price-level to handle partial fills correctly.
             if stp_active {
-                // `check_stp_at_level` needs the resting orders in the order the sweep
-                // will consume them. `iter_orders()` is DashMap-backed (non-stable) and
-                // makes `safe_quantity` / the CancelBoth `maker_order_id` non-deterministic,
-                // which breaks replay (#94) — so use the deterministic `snapshot_orders()`.
-                //
-                // PRECONDITION: `snapshot_orders()` is `(timestamp, sequence)`-ordered,
-                // whereas `match_order` consumes by pure insertion sequence; these coincide
-                // only when timestamps are monotonic with insertion (the normal case). Under
-                // non-monotonic timestamps the scan can diverge from the sweep — tracked in
-                // #132 (needs an insertion-sequence accessor upstream, PriceLevel#102).
-                let orders = price_level.snapshot_orders();
+                // `check_stp_at_level` must see the resting orders in the exact order
+                // the sweep consumes them — pure insertion sequence — so `safe_quantity`
+                // and the CancelBoth `maker_order_id` correspond to what `match_order`
+                // will actually fill/cancel. `snapshot_by_insertion_seq()` (pricelevel
+                // 0.8.1) gives that order; it is deterministic (fixing the #94 DashMap
+                // non-determinism) AND faithful to the sweep even under non-monotonic
+                // timestamps, unlike `snapshot_orders()` which is `(timestamp, seq)`-ordered
+                // (the residual gap closed by #132 / PriceLevel#102).
+                let orders = price_level.snapshot_by_insertion_seq();
                 let action = check_stp_at_level(&orders, taker_user_id, self.stp_mode);
 
                 match action {
@@ -924,7 +922,10 @@ where
             // hidden), not the level's raw total, so a non-auto-replenish reserve's
             // undrawable hidden tranche is not counted (#96).
             let (reachable, stop_after) = if stp_active {
-                let orders = price_level.snapshot_orders();
+                // Insertion-sequence order = the sweep's consumption order, so the
+                // feasibility STP decision matches the real match even under
+                // non-monotonic timestamps (#132).
+                let orders = price_level.snapshot_by_insertion_seq();
                 match check_stp_at_level(&orders, taker_user_id, self.stp_mode) {
                     STPAction::NoConflict => {
                         (orders.iter().map(|o| order_matchable_qty(o)).sum(), false)

--- a/src/orderbook/tests/stp.rs
+++ b/src/orderbook/tests/stp.rs
@@ -84,16 +84,19 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // STP determinism (#94) — the per-level scan must follow price-time
-    // priority (timestamp order), not the DashMap iteration order. With the
-    // pre-scan reading `snapshot_orders()` (timestamp-sorted) instead of
-    // `iter_orders()` (DashMap, non-stable), `safe_quantity` and the
-    // CancelBoth maker selection are reproducible for a given book state.
+    // STP determinism (#94) + consumption fidelity (#132) — the per-level scan
+    // must follow the sweep's consumption order (insertion sequence), not the
+    // DashMap iteration order. The pre-scan reads `snapshot_by_insertion_seq()`
+    // (pricelevel 0.8.1), so `safe_quantity` and the CancelBoth maker selection
+    // are deterministic AND match what `match_order` actually consumes — even
+    // under non-monotonic timestamps. (#94 first made it deterministic via the
+    // timestamp-sorted `snapshot_orders()`; #132 made it sweep-faithful.)
     // -----------------------------------------------------------------------
 
     /// CancelTaker accumulates `safe_quantity` over the orders that precede the
-    /// first same-user maker *in timestamp order*, so the taker fills exactly the
-    /// older non-self liquidity before the self-trade is prevented.
+    /// first same-user maker *in insertion (sweep) order* — here the orders are
+    /// added in timestamp order so the two coincide — so the taker fills exactly
+    /// the older non-self liquidity before the self-trade is prevented.
     #[test]
     fn test_cancel_taker_scan_follows_time_priority_at_one_level() {
         let mut book: OrderBook<()> = OrderBook::new("TEST");
@@ -140,8 +143,9 @@ mod tests {
         assert!(book.get_order(m2).is_none());
     }
 
-    /// CancelBoth cancels the *earliest* same-user maker by timestamp (not an
-    /// arbitrary one chosen by DashMap order) and fills the older non-self liquidity.
+    /// CancelBoth cancels the *earliest* same-user maker in insertion (sweep) order
+    /// — here equal to timestamp order — not an arbitrary one chosen by DashMap
+    /// order, and fills the older non-self liquidity.
     #[test]
     fn test_cancel_both_cancels_earliest_self_maker_by_time() {
         let mut book: OrderBook<()> = OrderBook::new("TEST");
@@ -178,6 +182,48 @@ mod tests {
         assert!(
             book.get_order(o1).is_none(),
             "older non-self order fully consumed"
+        );
+    }
+
+    /// #132: the STP scan follows the sweep's INSERTION-sequence consumption order
+    /// (via `snapshot_by_insertion_seq`, pricelevel 0.8.1), not timestamp order, so
+    /// it stays correct even when timestamps are non-monotonic with insertion
+    /// (client-supplied / modify-restamped). Here the same-user order is inserted
+    /// SECOND but carries an EARLIER timestamp; the sweep consumes the other-user
+    /// order first, so CancelTaker must fill it before the self-cross — which only
+    /// insertion-order scanning gets right (a timestamp scan would cancel with 0 fills).
+    #[test]
+    fn test_cancel_taker_scan_follows_insertion_not_timestamp_order() {
+        let mut book: OrderBook<()> = OrderBook::new("TEST");
+        book.set_stp_mode(STPMode::CancelTaker);
+
+        let taker_user = user(9);
+        let other = user(1);
+
+        // Same price 100. Insertion order (what the sweep consumes): other, then
+        // self — but timestamps are non-monotonic with insertion (self is older).
+        let m_other = add_sell_order_with_ts(&book, 100, 4, other, 30);
+        let m_self = add_sell_order_with_ts(&book, 100, 5, taker_user, 10);
+
+        let result = book.match_market_order_with_user(Id::new(), 20, Side::Buy, taker_user);
+
+        assert!(
+            result.is_ok(),
+            "expected a 4-unit partial fill, got {result:?}"
+        );
+        let mr = result.unwrap();
+        let trades = mr.trades().as_vec();
+        assert_eq!(trades.len(), 1);
+        assert_eq!(trades[0].maker_order_id(), m_other);
+        assert_eq!(trades[0].quantity(), Quantity::new(4));
+
+        assert!(
+            book.get_order(m_self).is_some(),
+            "self order survives CancelTaker"
+        );
+        assert!(
+            book.get_order(m_other).is_none(),
+            "other-user order is consumed first by insertion order"
         );
     }
 


### PR DESCRIPTION
## Overview

Follow-up to #94, now unblocked by **pricelevel 0.8.1**. The STP pre-scan (and the FOK feasibility scan) read `price_level.snapshot_orders()`, which is `(timestamp, sequence)`-ordered. That equals the sweep's **pure insertion-sequence** consumption order (`match_order` → `OrderQueue::match_front`) only when timestamps are monotonic with insertion. Under non-monotonic timestamps (client-supplied or modify-restamped), the scan's `safe_quantity` / cancelled-maker selection diverged from what the real match fills/cancels. #94 made the scan deterministic but not sweep-faithful.

## Fix

Bumps `pricelevel` 0.8.0 → 0.8.1 for `PriceLevel::snapshot_by_insertion_seq()` — the accessor requested in PriceLevel#102, documented as materializing resting orders "in the exact order `match_order` consumes them: ascending insertion sequence." Both STP scan sites switch to it:

- the STP pre-scan in `match_order_inner` (CancelTaker / CancelBoth / CancelMaker), and
- the per-level STP branch of `fok_fillable_quantity`.

So the pre-scan and the real sweep now walk the same order in **all** cases.

## Test

`test_cancel_taker_scan_follows_insertion_not_timestamp_order` — a same-user order inserted SECOND but carrying an EARLIER timestamp must still be consumed AFTER the other-user order (insertion order). CancelTaker fills the other-user order first (`safe_quantity = 4`) instead of cancelling with zero fills. With the old `snapshot_orders()` (timestamp order) this returned `Err(SelfTradePrevented)` with no fills; the test asserts the correct `Ok(partial)` outcome.

## Review

- **determinism-auditor:** replay-safe, commit-safe — `snapshot_by_insertion_seq()` is `SkipMap`-backed (deterministic ascending insertion sequence; DashMap used only for point lookups, no unordered iteration leaks). It exactly matches `match_front`'s consumption order, closing the #94/#132 fidelity gap. No new hazards from the swap or the 0.8.1 bump.

## Note

pricelevel 0.8.1 added `snapshot_by_insertion_seq` but kept `matchable_quantity` private, so the FOK depth-delegation follow-up **#136 remains blocked**.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, `cargo test --all-features` (677 pass), `cargo build --release` — all clean. `cargo tree -p pricelevel` → 0.8.1.

Closes #132
