### PR TITLE
fix(mass_cancel): reset per-account risk counters in cancel_all_orders (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   maker match what `match_order` actually consumes even under non-monotonic
   timestamps — closing the consumption-fidelity gap that #94 left open (and which the
   #94 determinism fix only addressed for monotonic timestamps).
+- **`cancel_all_orders` resets per-account risk counters (#99).** The bulk cancel
+  drained the book but never touched `risk_state`, so after a mass unwind every
+  account's `open_orders` / `notional` counters stayed at pre-cancel values and
+  permanently rejected new flow (the exact failure bulk cancel exists to avoid). It
+  now calls a new `RiskState::clear()` (also reused by `rebuild_from_snapshot`),
+  zeroing the per-account counters and the per-order risk map.
 
 ## [0.8.0] — 2026-05-03
 

--- a/src/orderbook/mass_cancel.rs
+++ b/src/orderbook/mass_cancel.rs
@@ -191,6 +191,12 @@ where
         #[cfg(feature = "special_orders")]
         self.special_order_tracker.clear();
 
+        // 6. Reset the pre-trade risk state. cancel_all empties the whole book, so
+        // the per-order on_cancel accounting collapses to a single clear — otherwise
+        // every account's open_orders / notional counters would stay at pre-cancel
+        // values and permanently reject new flow (#99). No-op without a RiskConfig.
+        self.risk_state.clear();
+
         self.cache.invalidate();
         // Refresh the depth gauges; both sides are now empty.
         self.record_depth_metric();

--- a/src/orderbook/risk.rs
+++ b/src/orderbook/risk.rs
@@ -441,6 +441,18 @@ impl RiskState {
         }
     }
 
+    /// Drop all per-order risk entries and per-account counters in one shot.
+    ///
+    /// Used by [`OrderBook::cancel_all_orders`](super::book::OrderBook::cancel_all_orders),
+    /// which empties the entire book in bulk — the per-order [`Self::on_cancel`]
+    /// accounting collapses to a single clear, and leaving the maps populated would
+    /// strand phantom open-order / notional counters that reject new flow (#99).
+    /// No-op semantics when no `RiskConfig` is installed (the maps are already empty).
+    pub(super) fn clear(&self) {
+        self.orders.clear();
+        self.counters.clear();
+    }
+
     /// Rebuild the per-order map and per-account counters by walking
     /// the supplied bid and ask snapshots.
     ///
@@ -453,8 +465,7 @@ impl RiskState {
         bids: &[PriceLevelSnapshot],
         asks: &[PriceLevelSnapshot],
     ) {
-        self.orders.clear();
-        self.counters.clear();
+        self.clear();
         for level in bids.iter().chain(asks.iter()) {
             let price = level.price().as_u128();
             for order in level.orders() {

--- a/tests/unit/risk_layer_tests.rs
+++ b/tests/unit/risk_layer_tests.rs
@@ -746,4 +746,64 @@ mod tests_risk_layer {
         );
         assert_eq!(pkg.version, 2);
     }
+
+    /// #99: `cancel_all_orders` must reset the per-account risk counters; otherwise
+    /// an account stays pinned at its open-order limit and new flow is permanently
+    /// rejected after a bulk unwind (the exact failure bulk cancel exists to avoid).
+    #[test]
+    fn cancel_all_orders_resets_open_order_counter() {
+        let mut book = new_book();
+        book.set_risk_config(RiskConfig::new().with_max_open_orders_per_account(2));
+        let acct = account(11);
+
+        book.add_limit_order_with_user(
+            Id::new_uuid(),
+            100,
+            1,
+            Side::Buy,
+            TimeInForce::Gtc,
+            acct,
+            None,
+        )
+        .expect("first admitted (1/2)");
+        book.add_limit_order_with_user(
+            Id::new_uuid(),
+            101,
+            1,
+            Side::Buy,
+            TimeInForce::Gtc,
+            acct,
+            None,
+        )
+        .expect("second admitted (2/2)");
+        // At the limit, a third is rejected.
+        assert!(matches!(
+            book.add_limit_order_with_user(
+                Id::new_uuid(),
+                102,
+                1,
+                Side::Buy,
+                TimeInForce::Gtc,
+                acct,
+                None
+            ),
+            Err(OrderBookError::RiskMaxOpenOrders { .. })
+        ));
+
+        // Bulk cancel must reset the per-account counters.
+        let res = book.cancel_all_orders();
+        assert_eq!(res.cancelled_count(), 2);
+
+        // A fresh order from the same account is now admitted (counter was reset).
+        book.add_limit_order_with_user(
+            Id::new_uuid(),
+            103,
+            1,
+            Side::Buy,
+            TimeInForce::Gtc,
+            acct,
+            None,
+        )
+        .expect("re-admitted after cancel_all_orders");
+    }
 }


### PR DESCRIPTION
## Overview

`cancel_all_orders` cleared `order_locations` / `user_orders`, drained the bid/ask SkipMaps, and cleared the special-order tracker, but **never touched `risk_state`** — unlike the single-order path and the other three mass-cancel variants. After a bulk unwind on a book with a `RiskConfig`, every account's `RiskCounters` (open_orders, notional) stayed at pre-cancel values and the per-order risk map kept stale entries, so subsequent admission checks saw phantom open orders and **permanently rejected legitimate new flow** until the book was recreated — the exact failure risk-managed bulk cancel exists to prevent (unwind then re-quote).

## Fix

Adds `RiskState::clear()` (also reused by `rebuild_from_snapshot`, deduping its inline clear) and calls it in `cancel_all_orders`. Since the whole book is emptied, the per-order `on_cancel` accounting collapses to a single clear.

## Test

`cancel_all_orders_resets_open_order_counter` — `max_open_orders_per_account(2)`, fill to the limit (third rejected with `RiskMaxOpenOrders`), `cancel_all_orders`, then a fresh order from the same account is admitted (would fail without the reset).

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, `cargo test --all-features` (677 pass), `cargo build --release` — all clean.

Closes #99