### PR TITLE
fix(snapshot): preserve scheduled market close across snapshot round-trip (#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   permanently rejected new flow (the exact failure bulk cancel exists to avoid). It
   now calls a new `RiskState::clear()` (also reused by `rebuild_from_snapshot`),
   zeroing the per-account counters and the per-order risk map.
+- **Snapshot packages preserve the scheduled market close (#100).**
+  `create_snapshot_package` did not capture `market_close_timestamp` /
+  `has_market_close`, and `restore_from_snapshot` reset them to `0` / `false`, so a
+  book with a configured market close silently lost it (and its DAY / GTD expiry
+  schedule) after a snapshot round-trip or replay. The two values are now carried on
+  `OrderBookSnapshotPackage` (additive `#[serde(default)]`, format version stays 2)
+  and re-applied on restore, mirroring `kill_switch_engaged`.
 
 ## [0.8.0] — 2026-05-03
 

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -2637,6 +2637,8 @@ where
         package.engine_seq = self.engine_seq();
         package.kill_switch_engaged = self.is_kill_switch_engaged();
         package.risk_config = self.risk_state.config().cloned();
+        package.market_close_timestamp = self.market_close_timestamp.load(Ordering::Relaxed);
+        package.has_market_close = self.has_market_close.load(Ordering::Relaxed);
         Ok(package)
     }
 
@@ -2650,7 +2652,7 @@ where
     /// This restores both the order data and the configuration fields
     /// (`fee_schedule`, `stp_mode`, `tick_size`, `lot_size`,
     /// `min_order_size`, `max_order_size`, `engine_seq`,
-    /// `kill_switch_engaged`) that were captured by
+    /// `kill_switch_engaged`, and the scheduled market close) that were captured by
     /// [`create_snapshot_package`](Self::create_snapshot_package).
     ///
     /// The kill-switch flag is operator-driven and not journaled by
@@ -2672,6 +2674,8 @@ where
         let engine_seq = package.engine_seq;
         let kill_switch_engaged = package.kill_switch_engaged;
         let risk_config = package.risk_config.clone();
+        let market_close_timestamp = package.market_close_timestamp;
+        let has_market_close = package.has_market_close;
 
         // Take ownership of the validated snapshot. We hold it locally
         // so that the per-account risk counters can be rebuilt from
@@ -2715,6 +2719,14 @@ where
         // operational mode it was halted in.
         self.kill_switch
             .store(kill_switch_engaged, Ordering::Relaxed);
+
+        // Restore the scheduled market close so DAY / GTD expiry resumes against the
+        // same session boundary the book was snapshotted with. `restore_from_snapshot`
+        // reset these to `0` / `false`, so re-apply them afterwards (#100).
+        self.market_close_timestamp
+            .store(market_close_timestamp, Ordering::Relaxed);
+        self.has_market_close
+            .store(has_market_close, Ordering::Relaxed);
 
         Ok(())
     }

--- a/src/orderbook/snapshot.rs
+++ b/src/orderbook/snapshot.rs
@@ -228,6 +228,23 @@ pub struct OrderBookSnapshotPackage {
     /// always came back without any risk gates engaged.
     #[serde(default)]
     pub risk_config: Option<RiskConfig>,
+
+    /// Scheduled market-close timestamp (milliseconds since epoch) active at the
+    /// time of snapshot — drives DAY / GTD expiry. `0` together with
+    /// `has_market_close = false` means no close is configured. Restored by
+    /// [`OrderBook::restore_from_snapshot_package`](super::book::OrderBook::restore_from_snapshot_package)
+    /// so a recovered book keeps its session schedule (#100).
+    ///
+    /// `#[serde(default)]` keeps the format version at `2`: payloads written before
+    /// these fields existed deserialize with `0` / `false`, matching the previous
+    /// behaviour where a restored book always came back with no market close.
+    #[serde(default)]
+    pub market_close_timestamp: u64,
+
+    /// Whether a market close was configured at the time of snapshot. See
+    /// [`Self::market_close_timestamp`].
+    #[serde(default)]
+    pub has_market_close: bool,
 }
 
 impl OrderBookSnapshotPackage {
@@ -250,6 +267,8 @@ impl OrderBookSnapshotPackage {
             engine_seq: 0,
             kill_switch_engaged: false,
             risk_config: None,
+            market_close_timestamp: 0,
+            has_market_close: false,
         })
     }
 

--- a/src/orderbook/tests/snapshot.rs
+++ b/src/orderbook/tests/snapshot.rs
@@ -818,4 +818,39 @@ mod test_snapshot_engine_seq {
             "omitted engine_seq must default to 0 via #[serde(default)]"
         );
     }
+
+    /// #100: a configured market close must survive a snapshot package round-trip
+    /// (including the JSON serde path). Previously `create_snapshot_package` did not
+    /// capture it and `restore_from_snapshot` reset it to `0` / `false`.
+    #[test]
+    fn test_market_close_survives_snapshot_package_round_trip_issue_100() {
+        use crate::orderbook::OrderBookSnapshotPackage;
+        use crate::orderbook::book::OrderBook;
+        use std::sync::atomic::Ordering;
+
+        let book: OrderBook<()> = OrderBook::new("TEST");
+        book.set_market_close_timestamp(1_700_000_000_000);
+
+        let json = book
+            .create_snapshot_package(10)
+            .expect("snapshot package")
+            .to_json()
+            .expect("to_json");
+        let package = OrderBookSnapshotPackage::from_json(&json).expect("from_json");
+
+        let mut restored: OrderBook<()> = OrderBook::new("TEST");
+        restored
+            .restore_from_snapshot_package(package)
+            .expect("restore");
+
+        assert!(
+            restored.has_market_close.load(Ordering::Relaxed),
+            "has_market_close must survive the round trip"
+        );
+        assert_eq!(
+            restored.market_close_timestamp.load(Ordering::Relaxed),
+            1_700_000_000_000,
+            "market_close_timestamp must survive the round trip"
+        );
+    }
 }


### PR DESCRIPTION
## Overview

`market_close_timestamp` / `has_market_close` are genuine book configuration (set via `set_market_close_timestamp`, drive DAY / GTD expiry, captured by the book's own `Serialize`), but `create_snapshot_package` did **not** copy them, `OrderBookSnapshotPackage` had no field for them, and `restore_from_snapshot` actively reset both to `0` / `false`. A book with a configured market close silently lost it after a snapshot round-trip or replay.

## Fix

Adds `market_close_timestamp: u64` + `has_market_close: bool` to `OrderBookSnapshotPackage` (additive `#[serde(default)]` — **format version stays 2**), captures them in `create_snapshot_package`, and re-applies them in `restore_from_snapshot_package` after `restore_from_snapshot` (which resets them). This mirrors the existing `kill_switch_engaged` / `risk_config` precedent exactly.

## Test

`test_market_close_survives_snapshot_package_round_trip_issue_100` — a configured market close survives `create_snapshot_package` → `to_json` → `from_json` → `restore_from_snapshot_package`. Backward-compatible: the pre-existing legacy-v2 deserialization tests (payloads omitting the new fields → `0` / `false`) still pass.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, `cargo test --all-features` (678 pass), `cargo build --release` — all clean. No `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump (additive fields).

Closes #100