### PR TITLE
fix(sequencer): use checked_add for the replay protocol sequence counter (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Replay protocol sequence counter uses `checked_add` (#126).** `replay_into`
+  advanced `expected_seq` (and the applied-event tally) with `saturating_add`,
+  which violates the no-saturating-on-protocol-counters rule and would silently
+  stop advancing at the `u64` ceiling — masking a real gap instead of surfacing
+  it. Both now use `checked_add` and return the new `ReplayError::SequenceOverflow`
+  on overflow. Unreachable at any realistic journal length; the value is rule
+  compliance and correct failure semantics at the boundary.
 - **`snapshots_match` compares full per-level structure (#102).** The replay
   equality oracle now compares each level's `hidden_quantity` and `order_count`
   in addition to `price` and `visible_quantity`. Previously two books that

--- a/src/orderbook/sequencer/replay.rs
+++ b/src/orderbook/sequencer/replay.rs
@@ -40,6 +40,17 @@ pub enum ReplayError {
         found: u64,
     },
 
+    /// The protocol sequence counter overflowed `u64` while advancing.
+    ///
+    /// Unreachable at any realistic journal length, but advancing the counter
+    /// with a checked add (rather than a saturating one) keeps gap detection
+    /// correct at the boundary instead of silently stalling `expected_seq`.
+    #[error("replay sequence counter overflowed u64 at sequence {at}")]
+    SequenceOverflow {
+        /// The sequence number that could not be advanced past.
+        at: u64,
+    },
+
     /// An OrderBook operation failed during replay.
     #[error("order book error during replay at sequence {sequence_num}: {source}")]
     OrderBookError {
@@ -260,11 +271,19 @@ where
             // sequence" contract on the public entry points.
             let applied = !matches!(event.result, SequencerResult::Rejected { .. });
             Self::apply_event(book, event)?;
-            expected_seq = expected_seq.saturating_add(1);
+            // Protocol counter: a saturating add would silently stop advancing
+            // `expected_seq` at the u64 ceiling and mask a real gap, so use a
+            // checked add and surface a typed overflow error instead (per the
+            // no-saturating-on-protocol-counters rule).
+            expected_seq = expected_seq
+                .checked_add(1)
+                .ok_or(ReplayError::SequenceOverflow { at: expected_seq })?;
 
             if applied {
                 last_applied_seq = event.sequence_num;
-                count = count.saturating_add(1);
+                count = count
+                    .checked_add(1)
+                    .ok_or(ReplayError::SequenceOverflow { at: count })?;
                 progress(count, last_applied_seq);
             }
         }
@@ -505,6 +524,26 @@ mod tests {
             !snapshots_match(&base, &diff_count),
             "an order-count divergence must not be reported equal"
         );
+    }
+
+    /// #126: the protocol sequence counter advances with `checked_add`, so at
+    /// the `u64` boundary it surfaces a typed `SequenceOverflow` instead of
+    /// silently stalling `expected_seq` (which would mask a real gap).
+    #[test]
+    fn test_replay_sequence_counter_overflow_is_a_typed_error() {
+        let journal: InMemoryJournal<()> = InMemoryJournal::new();
+        // A single event at the very top of the sequence space.
+        let ev = make_add_event(u64::MAX, Id::new_uuid(), 100, 10, Side::Buy);
+        assert!(journal.append(&ev).is_ok());
+
+        // Replaying from u64::MAX applies the event, then advancing the
+        // expected-sequence counter past u64::MAX must overflow with a typed
+        // error rather than saturating.
+        match ReplayEngine::<()>::replay_from(&journal, u64::MAX, "TEST") {
+            Err(ReplayError::SequenceOverflow { at }) => assert_eq!(at, u64::MAX),
+            Err(other) => panic!("expected SequenceOverflow {{ at: u64::MAX }}, got {other:?}"),
+            Ok(_) => panic!("advancing past u64::MAX must error"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`replay_into` advanced the protocol sequence counter `expected_seq` (and the
applied-event tally `count`) with `saturating_add`. `rules/global_rules.md` bans
`saturating_*` / `wrapping_*` on counters tied to protocol state — sequencer ids
and journal sequence numbers included. At the `u64` ceiling a saturating add
would silently stop advancing `expected_seq`, masking a real sequence gap rather
than surfacing it: the wrong failure mode for a correctness oracle.

## Change

- `expected_seq` and `count` now advance with `checked_add(1)` and return a new
  typed `ReplayError::SequenceOverflow { at }` on overflow.
- Added the `SequenceOverflow` variant (with `///` docs) to `ReplayError`.
- Added `test_replay_sequence_counter_overflow_is_a_typed_error`: replays a
  single event at `u64::MAX` and asserts the typed overflow error fires instead
  of saturating.

Unreachable at any realistic journal length — the value is rule compliance and
correct gap-detection semantics at the boundary.

## Tests

- `cargo test --all-features` — 680 + 25 pass, 0 failed (new overflow test
  included; existing replay/gap-detection tests unchanged and green).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.
- `cargo build --release` — clean, zero warnings.

Closes #126