### PR TITLE
perf(nats): batch and throttle trade publishing off the matching hot path (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **NATS trade publishing is batched/throttled off the matching hot path (#108).**
+  `NatsTradePublisher::into_listener`'s callback used to serialize the payload,
+  build two subjects with `format!`, convert to `Bytes`, and `runtime.spawn` a
+  fresh Tokio task **per trade** on the matching thread — per-operation heap
+  allocation and task-spawn pressure that floods the runtime under a burst. The
+  callback now only clones the `TradeResult` into a bounded channel and returns;
+  a single background task drains, batches (configurable window / size), and
+  optionally throttles before serializing and publishing — mirroring
+  `NatsBookChangePublisher`. The `{prefix}.all` subject is precomputed once at
+  construction. New builders (`with_batch_window_ms`, `with_max_batch_size`,
+  `with_channel_capacity`, `with_min_publish_interval_ms`) and metrics
+  (`events_received`, `batches_published`, `dropped_events`) match the
+  book-change publisher; the per-trade wire format, subjects, and pluggable
+  serializer are unchanged. `nats`-gated.
 - **Replay protocol sequence counter uses `checked_add` (#126).** `replay_into`
   advanced `expected_seq` (and the applied-event tally) with `saturating_add`,
   which violates the no-saturating-on-protocol-counters rule and would silently

--- a/src/orderbook/nats.rs
+++ b/src/orderbook/nats.rs
@@ -7,10 +7,15 @@
 //! - `{prefix}.{symbol}` — per-symbol stream
 //! - `{prefix}.all` — aggregate stream
 //!
-//! The publisher is non-blocking on the hot path: serialization and sequence
-//! numbering happen synchronously, while the actual NATS publish is spawned
-//! onto a Tokio runtime. Transient failures are retried with exponential
-//! backoff.
+//! The listener callback is non-blocking on the matching hot path: it clones
+//! the [`TradeResult`] into a bounded channel and returns immediately — no
+//! serialization, no `format!`, and no per-trade task spawn happen on the
+//! engine thread. A single background Tokio task drains the channel, batches
+//! and (optionally) throttles, and performs the serialization, subject
+//! construction, and JetStream publish with exponential-backoff retry. This
+//! mirrors the sibling [`NatsBookChangePublisher`](crate::orderbook::nats_book_change::NatsBookChangePublisher)
+//! so neither outbound path floods the runtime with tiny per-event tasks under
+//! a burst.
 //!
 //! # Feature Gate
 //!
@@ -25,7 +30,24 @@ use crate::orderbook::serialization::{EventSerializer, JsonEventSerializer};
 use crate::orderbook::trade::{TradeListener, TradeResult};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::sync::mpsc;
 use tracing::{error, trace, warn};
+
+/// Default batch window in milliseconds. Trades are drained from the channel
+/// for at most this duration before the accumulated batch is published.
+const DEFAULT_BATCH_WINDOW_MS: u64 = 1;
+
+/// Default maximum number of trades drained per batch. When this limit is
+/// reached the batch is flushed immediately, regardless of the time window.
+const DEFAULT_MAX_BATCH_SIZE: usize = 100;
+
+/// Default bounded-channel capacity. When the channel is full, new trades are
+/// dropped and `dropped_events` is incremented.
+const DEFAULT_CHANNEL_CAPACITY: usize = 10_000;
+
+/// Default minimum interval in milliseconds between consecutive flushes. Set to
+/// 0 to disable throttling.
+const DEFAULT_MIN_PUBLISH_INTERVAL_MS: u64 = 0;
 
 /// Default maximum number of retry attempts for transient NATS publish failures.
 const DEFAULT_MAX_RETRIES: u32 = 3;
@@ -39,12 +61,27 @@ const BASE_RETRY_DELAY_MS: u64 = 10;
 /// [`into_listener`](NatsTradePublisher::into_listener) method that returns a
 /// [`TradeListener`] suitable for use with [`OrderBook::trade_listener`].
 ///
+/// # Batching and throttling
+///
+/// The listener callback pushes each trade into a bounded channel and returns
+/// immediately. A single background task drains the channel, accumulating
+/// trades until either the
+/// [`batch_window_ms`](NatsTradePublisher::with_batch_window_ms) elapses or
+/// [`max_batch_size`](NatsTradePublisher::with_max_batch_size) trades have been
+/// collected, then publishes them. An optional
+/// [`min_publish_interval_ms`](NatsTradePublisher::with_min_publish_interval_ms)
+/// throttles consecutive flushes on a high-activity book.
+///
 /// # Metrics
 ///
 /// The publisher tracks the following counters via atomic operations:
 ///
-/// - **publish_count** — number of successfully published messages
-/// - **error_count** — number of permanently failed publish attempts
+/// - **publish_count** — number of successfully published trades (a trade
+///   counts once when both its symbol and aggregate publishes succeed)
+/// - **error_count** — number of permanently failed publish/serialize attempts
+/// - **events_received** — total trades received from the listener callback
+/// - **batches_published** — total drain/flush cycles performed
+/// - **dropped_events** — trades dropped because the channel was full
 /// - **sequence** — monotonically increasing sequence number; each publish
 ///   (symbol-specific and aggregate) receives its own unique value
 ///
@@ -73,22 +110,50 @@ pub struct NatsTradePublisher {
     /// `{prefix}.all`.
     subject_prefix: String,
 
-    /// Handle to the Tokio runtime used for spawning async publish tasks.
+    /// The `{prefix}.all` aggregate subject, precomputed once at construction
+    /// so the publish path never rebuilds it.
+    all_subject: String,
+
+    /// Handle to the Tokio runtime used for spawning the background batch task.
     runtime: tokio::runtime::Handle,
 
-    /// Monotonically increasing sequence number embedded in each published
-    /// message as a NATS header.
-    sequence: AtomicU64,
+    /// Batch window duration in milliseconds.
+    batch_window_ms: u64,
 
-    /// Count of successfully published messages (across both subjects).
-    publish_count: AtomicU64,
+    /// Maximum number of trades per batch before an early flush.
+    max_batch_size: usize,
 
-    /// Count of permanently failed publish attempts (after all retries
-    /// exhausted).
-    error_count: AtomicU64,
+    /// Bounded channel capacity for the trade buffer.
+    channel_capacity: usize,
+
+    /// Minimum interval in milliseconds between consecutive flushes.
+    min_publish_interval_ms: u64,
 
     /// Maximum number of retry attempts for transient failures.
     max_retries: u32,
+
+    /// Monotonically increasing sequence number embedded in each published
+    /// message as a NATS header. Written exclusively by the single background
+    /// `publish_task`; the `Relaxed` ordering on its `fetch_add` is correct
+    /// only because no other writer exists (the `into_listener(self)` consuming
+    /// signature spawns exactly one task per publisher).
+    sequence: AtomicU64,
+
+    /// Count of successfully published trades (one per trade when both subjects
+    /// succeed).
+    publish_count: AtomicU64,
+
+    /// Count of permanently failed publish/serialize attempts.
+    error_count: AtomicU64,
+
+    /// Total trades received from the listener callback.
+    events_received: AtomicU64,
+
+    /// Total drain/flush cycles performed.
+    batches_published: AtomicU64,
+
+    /// Trades dropped because the bounded channel was full.
+    dropped_events: AtomicU64,
 
     /// Pluggable event serializer. Defaults to [`JsonEventSerializer`] for
     /// backward compatibility. Can be overridden via
@@ -103,23 +168,86 @@ impl NatsTradePublisher {
     ///
     /// * `jetstream` — JetStream context obtained from an `async_nats` client
     /// * `subject_prefix` — prefix for NATS subjects (e.g. `"trades"`)
-    /// * `runtime` — handle to the Tokio runtime for spawning publish tasks
+    /// * `runtime` — handle to the Tokio runtime for spawning the batch task
     #[inline]
     pub fn new(
         jetstream: async_nats::jetstream::Context,
         subject_prefix: String,
         runtime: tokio::runtime::Handle,
     ) -> Self {
+        let all_subject = format!("{subject_prefix}.all");
         Self {
             jetstream,
             subject_prefix,
+            all_subject,
             runtime,
+            batch_window_ms: DEFAULT_BATCH_WINDOW_MS,
+            max_batch_size: DEFAULT_MAX_BATCH_SIZE,
+            channel_capacity: DEFAULT_CHANNEL_CAPACITY,
+            min_publish_interval_ms: DEFAULT_MIN_PUBLISH_INTERVAL_MS,
+            max_retries: DEFAULT_MAX_RETRIES,
             sequence: AtomicU64::new(0),
             publish_count: AtomicU64::new(0),
             error_count: AtomicU64::new(0),
-            max_retries: DEFAULT_MAX_RETRIES,
+            events_received: AtomicU64::new(0),
+            batches_published: AtomicU64::new(0),
+            dropped_events: AtomicU64::new(0),
             serializer: Arc::new(JsonEventSerializer),
         }
+    }
+
+    /// Set the batch window duration in milliseconds.
+    ///
+    /// Trades are accumulated for at most this duration before being flushed.
+    /// Defaults to [`DEFAULT_BATCH_WINDOW_MS`] (1 ms).
+    #[must_use = "builders do nothing unless consumed"]
+    #[inline]
+    pub fn with_batch_window_ms(mut self, batch_window_ms: u64) -> Self {
+        self.batch_window_ms = batch_window_ms;
+        self
+    }
+
+    /// Set the maximum number of trades per batch.
+    ///
+    /// When the batch reaches this size it is flushed immediately, regardless
+    /// of the time window. Defaults to [`DEFAULT_MAX_BATCH_SIZE`] (100).
+    #[must_use = "builders do nothing unless consumed"]
+    #[inline]
+    pub fn with_max_batch_size(mut self, max_batch_size: usize) -> Self {
+        self.max_batch_size = max_batch_size;
+        self
+    }
+
+    /// Set the bounded channel capacity.
+    ///
+    /// When the channel is full, new trades are dropped and `dropped_events`
+    /// is incremented. Defaults to [`DEFAULT_CHANNEL_CAPACITY`] (10,000).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `channel_capacity` is zero (Tokio mpsc requires a positive
+    /// capacity).
+    #[must_use = "builders do nothing unless consumed"]
+    #[inline]
+    pub fn with_channel_capacity(mut self, channel_capacity: usize) -> Self {
+        assert!(
+            channel_capacity > 0,
+            "channel_capacity must be greater than zero"
+        );
+        self.channel_capacity = channel_capacity;
+        self
+    }
+
+    /// Set the minimum interval in milliseconds between consecutive flushes.
+    ///
+    /// When set to a value greater than 0, the background task waits at least
+    /// this long between consecutive flushes. Defaults to
+    /// [`DEFAULT_MIN_PUBLISH_INTERVAL_MS`] (0, disabled).
+    #[must_use = "builders do nothing unless consumed"]
+    #[inline]
+    pub fn with_min_publish_interval_ms(mut self, min_publish_interval_ms: u64) -> Self {
+        self.min_publish_interval_ms = min_publish_interval_ms;
+        self
     }
 
     /// Set the maximum number of retry attempts for transient NATS failures.
@@ -148,7 +276,7 @@ impl NatsTradePublisher {
         self
     }
 
-    /// Returns the number of successfully published messages.
+    /// Returns the number of successfully published trades.
     #[must_use]
     #[inline]
     pub fn publish_count(&self) -> u64 {
@@ -160,6 +288,27 @@ impl NatsTradePublisher {
     #[inline]
     pub fn error_count(&self) -> u64 {
         self.error_count.load(Ordering::Relaxed)
+    }
+
+    /// Returns the total number of trades received from the listener callback.
+    #[must_use]
+    #[inline]
+    pub fn events_received(&self) -> u64 {
+        self.events_received.load(Ordering::Relaxed)
+    }
+
+    /// Returns the total number of drain/flush cycles performed.
+    #[must_use]
+    #[inline]
+    pub fn batches_published(&self) -> u64 {
+        self.batches_published.load(Ordering::Relaxed)
+    }
+
+    /// Returns the number of trades dropped because the channel was full.
+    #[must_use]
+    #[inline]
+    pub fn dropped_events(&self) -> u64 {
+        self.dropped_events.load(Ordering::Relaxed)
     }
 
     /// Returns the current sequence number (next value to be assigned).
@@ -178,51 +327,160 @@ impl NatsTradePublisher {
 
     /// Convert this publisher into a [`TradeListener`] callback.
     ///
-    /// The returned listener serializes each [`TradeResult`] using the
-    /// configured [`EventSerializer`], assigns a unique sequence number
-    /// per publish, and spawns an async task that publishes to both
-    /// `{prefix}.{symbol}` and `{prefix}.all` subjects on the configured
-    /// JetStream context.
+    /// This method consumes `self`, wraps it in an `Arc`, spawns a single
+    /// background batch task on the configured Tokio runtime, and returns both
+    /// the `Arc` handle (for reading metrics) and the listener callback.
     ///
-    /// Publishing is non-blocking: the listener returns immediately after
-    /// spawning the async task, keeping the matching engine hot path fast.
+    /// The returned listener clones each [`TradeResult`] into a bounded channel
+    /// and returns immediately — no serialization, no `format!`, and no task
+    /// spawn happen on the matching hot path. The background task drains the
+    /// channel, batches the trades, and publishes each to both
+    /// `{prefix}.{symbol}` and the precomputed `{prefix}.all` subject with a
+    /// unique sequence number per publish.
     ///
     /// # Returns
     ///
     /// A tuple of `(Arc<NatsTradePublisher>, TradeListener)`. The `Arc` handle
     /// allows the caller to read metrics (`publish_count`, `error_count`,
-    /// `sequence`) after wiring the listener into the order book.
+    /// `events_received`, `dropped_events`, `sequence`) after wiring the
+    /// listener into the order book.
     pub fn into_listener(self) -> (Arc<Self>, TradeListener) {
+        let channel_capacity = self.channel_capacity;
         let publisher = Arc::new(self);
         let handle = Arc::clone(&publisher);
+
+        let (tx, rx) = mpsc::channel::<TradeResult>(channel_capacity);
+
+        // Spawn the single background batch task.
+        let task_publisher = Arc::clone(&publisher);
+        publisher
+            .runtime
+            .spawn(Self::publish_task(task_publisher, rx));
+
+        // Build the hot-path listener closure: clone + non-blocking send only.
+        let listener_publisher = Arc::clone(&publisher);
         let listener = Arc::new(move |trade_result: &TradeResult| {
-            let payload = match publisher.serializer.serialize_trade(trade_result) {
+            listener_publisher
+                .events_received
+                .fetch_add(1, Ordering::Relaxed);
+            if tx.try_send(trade_result.clone()).is_err() {
+                listener_publisher
+                    .dropped_events
+                    .fetch_add(1, Ordering::Relaxed);
+                warn!("trade channel full, event dropped");
+            }
+        });
+
+        (handle, listener)
+    }
+
+    /// Background task that drains the trade channel, batches trades, and
+    /// publishes them to NATS.
+    ///
+    /// The task flushes when either:
+    /// - The batch window timer elapses (configurable via `batch_window_ms`)
+    /// - The batch reaches `max_batch_size` trades
+    ///
+    /// When throttling is enabled (`min_publish_interval_ms > 0`), the task
+    /// waits at least that duration between consecutive flushes.
+    async fn publish_task(publisher: Arc<Self>, mut rx: mpsc::Receiver<TradeResult>) {
+        let batch_window = std::time::Duration::from_millis(publisher.batch_window_ms);
+        let min_interval = if publisher.min_publish_interval_ms > 0 {
+            Some(std::time::Duration::from_millis(
+                publisher.min_publish_interval_ms,
+            ))
+        } else {
+            None
+        };
+
+        let mut batch: Vec<TradeResult> = Vec::with_capacity(publisher.max_batch_size);
+        let mut last_publish = tokio::time::Instant::now();
+
+        loop {
+            // Wait for the first trade or channel close.
+            if batch.is_empty() {
+                match rx.recv().await {
+                    Some(trade) => batch.push(trade),
+                    None => break, // Channel closed
+                }
+            }
+
+            // Collect more trades within the batch window.
+            let deadline = tokio::time::Instant::now() + batch_window;
+            while batch.len() < publisher.max_batch_size {
+                match tokio::time::timeout_at(deadline, rx.recv()).await {
+                    Ok(Some(trade)) => batch.push(trade),
+                    Ok(None) => {
+                        // Channel closed — flush remaining and exit.
+                        Self::flush_batch(&publisher, &mut batch, &mut last_publish, min_interval)
+                            .await;
+                        return;
+                    }
+                    Err(_) => break, // Timeout — flush batch
+                }
+            }
+
+            Self::flush_batch(&publisher, &mut batch, &mut last_publish, min_interval).await;
+        }
+
+        // Flush any remaining trades.
+        Self::flush_batch(&publisher, &mut batch, &mut last_publish, min_interval).await;
+    }
+
+    /// Flush the accumulated batch: serialize and publish each trade to its
+    /// per-symbol and aggregate subjects, then apply throttling.
+    ///
+    /// Serialization, subject construction, and the JetStream publish all
+    /// happen here in the background task — never on the matching hot path.
+    async fn flush_batch(
+        publisher: &Arc<Self>,
+        batch: &mut Vec<TradeResult>,
+        last_publish: &mut tokio::time::Instant,
+        min_interval: Option<std::time::Duration>,
+    ) {
+        if batch.is_empty() {
+            return;
+        }
+
+        let trades = std::mem::take(batch);
+        for trade in trades {
+            let payload = match publisher.serializer.serialize_trade(&trade) {
                 Ok(bytes) => bytes,
                 Err(e) => {
                     publisher.error_count.fetch_add(1, Ordering::Relaxed);
                     error!(error = %e, "failed to serialize trade result for NATS");
-                    return;
+                    continue;
                 }
             };
 
             let symbol_seq = publisher.sequence.fetch_add(1, Ordering::Relaxed);
             let all_seq = publisher.sequence.fetch_add(1, Ordering::Relaxed);
-            let symbol_subject = format!("{}.{}", publisher.subject_prefix, trade_result.symbol);
-            let all_subject = format!("{}.all", publisher.subject_prefix);
-
-            let pub_clone = Arc::clone(&publisher);
+            let symbol_subject = format!("{}.{}", publisher.subject_prefix, trade.symbol);
+            let all_subject = publisher.all_subject.clone();
             let payload_bytes: bytes::Bytes = payload.into();
 
-            pub_clone.runtime.spawn(Self::publish_with_retry(
-                Arc::clone(&pub_clone),
+            Self::publish_with_retry(
+                Arc::clone(publisher),
                 symbol_subject,
                 all_subject,
                 payload_bytes,
                 symbol_seq,
                 all_seq,
-            ));
-        });
-        (handle, listener)
+            )
+            .await;
+        }
+
+        publisher.batches_published.fetch_add(1, Ordering::Relaxed);
+
+        // Throttle: wait if needed before allowing the next flush.
+        if let Some(interval) = min_interval {
+            let elapsed = last_publish.elapsed();
+            if elapsed < interval {
+                tokio::time::sleep(interval - elapsed).await;
+            }
+        }
+
+        *last_publish = tokio::time::Instant::now();
     }
 
     /// Publish a trade event to both the symbol-specific and aggregate subjects
@@ -328,10 +586,26 @@ impl std::fmt::Debug for NatsTradePublisher {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("NatsTradePublisher")
             .field("subject_prefix", &self.subject_prefix)
+            .field("batch_window_ms", &self.batch_window_ms)
+            .field("max_batch_size", &self.max_batch_size)
+            .field("channel_capacity", &self.channel_capacity)
+            .field("min_publish_interval_ms", &self.min_publish_interval_ms)
+            .field("max_retries", &self.max_retries)
             .field("sequence", &self.sequence.load(Ordering::Relaxed))
             .field("publish_count", &self.publish_count.load(Ordering::Relaxed))
             .field("error_count", &self.error_count.load(Ordering::Relaxed))
-            .field("max_retries", &self.max_retries)
+            .field(
+                "events_received",
+                &self.events_received.load(Ordering::Relaxed),
+            )
+            .field(
+                "batches_published",
+                &self.batches_published.load(Ordering::Relaxed),
+            )
+            .field(
+                "dropped_events",
+                &self.dropped_events.load(Ordering::Relaxed),
+            )
             .field("serializer", &self.serializer.content_type())
             .finish()
     }
@@ -405,6 +679,15 @@ mod tests {
     }
 
     #[test]
+    fn test_precomputed_all_subject_matches_format() {
+        // The aggregate subject is precomputed once at construction; it must
+        // equal what the per-publish path would otherwise format.
+        let prefix = "trades";
+        let precomputed = format!("{prefix}.all");
+        assert_eq!(precomputed, "trades.all");
+    }
+
+    #[test]
     fn test_default_max_retries() {
         assert_eq!(DEFAULT_MAX_RETRIES, 3);
     }
@@ -412,6 +695,14 @@ mod tests {
     #[test]
     fn test_base_retry_delay() {
         assert_eq!(BASE_RETRY_DELAY_MS, 10);
+    }
+
+    #[test]
+    fn test_default_batch_constants() {
+        assert_eq!(DEFAULT_BATCH_WINDOW_MS, 1);
+        assert_eq!(DEFAULT_MAX_BATCH_SIZE, 100);
+        assert_eq!(DEFAULT_CHANNEL_CAPACITY, 10_000);
+        assert_eq!(DEFAULT_MIN_PUBLISH_INTERVAL_MS, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`NatsTradePublisher::into_listener`'s callback ran synchronously on the matching
thread and, for every fill-producing operation, serialized the payload, did two
`format!` subject allocations, cloned an `Arc`, converted to `Bytes`, and
`runtime.spawn`'d a brand-new Tokio task — with no batching or throttling. That
is per-operation heap allocation plus a task spawn on the matching loop, exactly
where the engine must stay allocation-light; under a burst it floods the runtime
with tiny tasks. The sibling `NatsBookChangePublisher` already does this
correctly via a bounded channel + background batch task.

## Change

Mirror the book-change publisher:

- The hot-path closure now only **clones the `TradeResult` into a bounded mpsc
  channel** and returns — no `format!`, no serialization, no task spawn, no
  `.await`, no lock. On a full channel it bumps `dropped_events` and warns.
- A **single background task** drains the channel, batches trades (up to
  `max_batch_size`, flushed on the `batch_window_ms` timer), optionally
  **throttles** consecutive flushes (`min_publish_interval_ms`), then serializes
  and publishes each trade with the existing retry/backoff.
- The `{prefix}.all` aggregate subject is **precomputed once at construction**;
  only the per-symbol subject is formatted per trade (off the hot path).
- New builders `with_batch_window_ms`, `with_max_batch_size`,
  `with_channel_capacity`, `with_min_publish_interval_ms` and metrics
  `events_received`, `batches_published`, `dropped_events`, matching the
  book-change publisher.

The per-trade wire format, the two subjects, the unique per-publish
`Nats-Sequence`, and the pluggable `EventSerializer` are all unchanged.
`nats`-gated.

## Reviews

- **hot-path review**: PASS — the listener closure is a single relaxed atomic +
  one `TradeResult` clone + non-blocking `try_send`; all serialize/`format!`/
  publish/spawn confined to the background task. Spawn-per-trade eliminated (one
  `spawn` total, at construction).
- **determinism audit**: commit-safe (0 P1/P2) — channel is FIFO single-consumer,
  exactly one background task, sequence numbers assigned in receive order, no
  wall-clock value in the payload or header, no unordered-container iteration.
  Outbound publisher is downstream of the journal, so it cannot affect
  `snapshots_match`. Added a doc note that `Relaxed` on `sequence` is correct
  because `publish_task` is the sole writer.

## Tests

- `cargo test --all-features` — all pass (12 in `nats::tests`; added batch-constant
  and precomputed-subject tests).
- `cargo build --features nats` / `--release --all-features` — clean, zero warnings.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.

A live Criterion throughput bench needs a running NATS server (unavailable in
CI); the hot-path guarantee here is structural — the closure body contains no
serialize / `format!` / spawn.

Closes #108