### PR TITLE
fix(iv): guard NaN/Inf inputs and crossed/locked books in the IV solver (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **IV solver guards NaN/Inf inputs and crossed/locked books (#112).** The
+  Black-Scholes IV solver only checked sign/magnitude — all `false` for NaN — so
+  a NaN/Inf `spot`/`strike`/`time`/`rate`/`market_price` passed validation and
+  propagated NaN through the Newton/bisection loops to a meaningless
+  `ConvergenceFailure { last_iv: NaN }`. `validate_params` now rejects non-finite
+  `spot`/`strike`/`time_to_expiry`/`risk_free_rate`, both solver entry points
+  reject a non-finite `market_price`, and the Newton loop bails with a typed
+  error if a value goes non-finite mid-iteration. Separately, `extract_price_for_iv`
+  computed the spread without checking `bid <= ask`, so a crossed (negative) or
+  locked (zero) spread bypassed the max-spread gate and was classified
+  high-quality; it now rejects such a book with a new `IVError::CrossedBook` before
+  classification (observable via a transient torn read across the independent
+  `best_bid`/`best_ask` calls).
 - **`file_journal` no longer truncates a mapped segment or swallows poisoned
   mutexes (#111).** Two robustness defects in the journal subsystem the recovery
   path depends on. (1) `rotate_segment` called `set_len` to shrink a just-rotated

--- a/src/orderbook/implied_volatility/error.rs
+++ b/src/orderbook/implied_volatility/error.rs
@@ -16,6 +16,15 @@ pub enum IVError {
         threshold_bps: f64,
     },
 
+    /// The book is crossed (best ask below best bid) or locked (best ask equal
+    /// to best bid), so no meaningful mid price exists for IV calculation.
+    CrossedBook {
+        /// Best bid price (scaled to f64).
+        bid: f64,
+        /// Best ask price (scaled to f64).
+        ask: f64,
+    },
+
     /// Newton-Raphson solver did not converge within max iterations.
     ConvergenceFailure {
         /// Number of iterations attempted.
@@ -70,6 +79,12 @@ impl fmt::Display for IVError {
                 write!(
                     f,
                     "spread too wide: {spread_bps:.1} bps exceeds threshold of {threshold_bps:.1} bps"
+                )
+            }
+            IVError::CrossedBook { bid, ask } => {
+                write!(
+                    f,
+                    "book is crossed or locked: best bid {bid:.4} is not below best ask {ask:.4}"
                 )
             }
             IVError::ConvergenceFailure {
@@ -129,6 +144,12 @@ mod tests {
             threshold_bps: 500.0,
         };
         assert!(err.to_string().contains("600.0 bps"));
+
+        let err = IVError::CrossedBook {
+            bid: 10.5,
+            ask: 10.0,
+        };
+        assert!(err.to_string().contains("crossed or locked"));
 
         let err = IVError::ConvergenceFailure {
             iterations: 100,

--- a/src/orderbook/implied_volatility/integration.rs
+++ b/src/orderbook/implied_volatility/integration.rs
@@ -177,6 +177,16 @@ where
             (Some(bid), Some(ask)) => {
                 let bid_f = bid as f64 / price_scale;
                 let ask_f = ask as f64 / price_scale;
+
+                // Reject a crossed (ask < bid) or locked (ask == bid) book
+                // before quality classification: such a book would otherwise
+                // yield a zero/negative spread that slips under the max-spread
+                // guard and is mislabelled high quality, feeding a bogus mid
+                // into the solver. `best_bid`/`best_ask` are two independent
+                // reads, so a transient torn read can surface this even though a
+                // stable book never crosses.
+                reject_crossed_or_locked(bid_f, ask_f)?;
+
                 let mid = (bid_f + ask_f) / 2.0;
 
                 // Calculate spread in basis points
@@ -331,6 +341,24 @@ fn spread_to_quality(spread_bps: f64) -> IVQuality {
     }
 }
 
+/// Rejects a crossed (`ask < bid`) or locked (`ask == bid`) book with
+/// [`IVError::CrossedBook`].
+///
+/// A stable [`OrderBook`] never crosses (the matching engine would have filled
+/// it), so this only fires on a transient torn read between the two independent
+/// `best_bid` / `best_ask` calls — but left unguarded, such a read produces a
+/// zero/negative spread that slips under the max-spread gate and is mislabelled
+/// high quality. Pulled out so the guard is unit-testable without a live race.
+fn reject_crossed_or_locked(bid_f: f64, ask_f: f64) -> Result<(), IVError> {
+    if ask_f <= bid_f {
+        return Err(IVError::CrossedBook {
+            bid: bid_f,
+            ask: ask_f,
+        });
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -464,6 +492,22 @@ mod tests {
         let result = book.implied_volatility_with_config(&params, PriceSource::MidPrice, &config);
 
         assert!(matches!(result, Err(IVError::SpreadTooWide { .. })));
+    }
+
+    #[test]
+    fn test_reject_crossed_or_locked_book() {
+        // Crossed: ask below bid.
+        assert!(matches!(
+            reject_crossed_or_locked(10.0, 9.0),
+            Err(IVError::CrossedBook { .. })
+        ));
+        // Locked: ask equal to bid.
+        assert!(matches!(
+            reject_crossed_or_locked(10.0, 10.0),
+            Err(IVError::CrossedBook { .. })
+        ));
+        // Normal: ask strictly above bid.
+        assert!(reject_crossed_or_locked(10.0, 10.5).is_ok());
     }
 
     #[test]

--- a/src/orderbook/implied_volatility/solver.rs
+++ b/src/orderbook/implied_volatility/solver.rs
@@ -83,6 +83,23 @@ impl SolverConfig {
 /// - `Ok(())` if parameters are valid
 /// - `Err(IVError)` if any parameter is invalid
 fn validate_params(params: &IVParams) -> Result<(), IVError> {
+    // Reject non-finite inputs first: NaN/Inf pass every sign/magnitude check
+    // below (all comparisons against NaN are false) and would otherwise
+    // propagate NaN through the solver loops to a meaningless
+    // `ConvergenceFailure { last_iv: NaN }`.
+    for (name, value) in [
+        ("spot", params.spot),
+        ("strike", params.strike),
+        ("time_to_expiry", params.time_to_expiry),
+        ("risk_free_rate", params.risk_free_rate),
+    ] {
+        if !value.is_finite() {
+            return Err(IVError::InvalidParams {
+                message: format!("{name} must be finite, got {value}"),
+            });
+        }
+    }
+
     if params.spot <= 0.0 {
         return Err(IVError::InvalidParams {
             message: format!("spot price must be positive, got {}", params.spot),
@@ -172,9 +189,9 @@ pub fn solve_iv(
     // Validate inputs
     validate_params(params)?;
 
-    if market_price <= 0.0 {
+    if !market_price.is_finite() || market_price <= 0.0 {
         return Err(IVError::InvalidParams {
-            message: format!("market price must be positive, got {market_price}"),
+            message: format!("market price must be positive and finite, got {market_price}"),
         });
     }
 
@@ -200,6 +217,18 @@ pub fn solve_iv(
     // Newton-Raphson iteration
     for iteration in 0..config.max_iterations {
         let price = BlackScholes::price(params, iv);
+
+        // Inputs are validated finite, so a non-finite price/iv here means the
+        // iteration degenerated numerically. Bail with a typed error instead of
+        // letting NaN poison `iv` and surface as `ConvergenceFailure { last_iv: NaN }`.
+        if !price.is_finite() || !iv.is_finite() {
+            return Err(IVError::InvalidParams {
+                message: format!(
+                    "non-finite value during Newton iteration (iv={iv}, price={price})"
+                ),
+            });
+        }
+
         let diff = price - market_price;
 
         // Check convergence
@@ -269,9 +298,9 @@ pub fn solve_iv_bisection(
 ) -> Result<(f64, u32), IVError> {
     validate_params(params)?;
 
-    if market_price <= 0.0 {
+    if !market_price.is_finite() || market_price <= 0.0 {
         return Err(IVError::InvalidParams {
-            message: format!("market price must be positive, got {market_price}"),
+            message: format!("market price must be positive and finite, got {market_price}"),
         });
     }
 
@@ -419,6 +448,63 @@ mod tests {
 
         let result = solve_iv(&params, 5.0, &config);
         assert!(matches!(result, Err(IVError::InvalidParams { .. })));
+    }
+
+    #[test]
+    fn test_solve_iv_rejects_non_finite_params() {
+        let config = SolverConfig::default();
+        // Each non-finite field must produce an immediate InvalidParams, not a
+        // NaN propagated to ConvergenceFailure.
+        let cases = [
+            IVParams::call(f64::NAN, 100.0, 0.25, 0.05),
+            IVParams::call(f64::INFINITY, 100.0, 0.25, 0.05),
+            IVParams::call(100.0, f64::NAN, 0.25, 0.05),
+            IVParams::call(100.0, 100.0, f64::NAN, 0.05),
+            IVParams::call(100.0, 100.0, f64::INFINITY, 0.05),
+            IVParams::call(100.0, 100.0, 0.25, f64::NAN),
+            IVParams::call(100.0, 100.0, 0.25, f64::INFINITY),
+        ];
+        for params in cases {
+            let result = solve_iv(&params, 5.0, &config);
+            assert!(
+                matches!(result, Err(IVError::InvalidParams { .. })),
+                "non-finite param must yield InvalidParams, got {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_solve_iv_rejects_non_finite_market_price() {
+        let params = IVParams::call(100.0, 100.0, 0.25, 0.05);
+        let config = SolverConfig::default();
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let newton = solve_iv(&params, bad, &config);
+            let bisect = solve_iv_bisection(&params, bad, &config);
+            assert!(
+                matches!(newton, Err(IVError::InvalidParams { .. })),
+                "Newton must reject non-finite market price, got {newton:?}"
+            );
+            assert!(
+                matches!(bisect, Err(IVError::InvalidParams { .. })),
+                "bisection must reject non-finite market price, got {bisect:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_solve_iv_never_returns_nan_convergence_failure() {
+        // Even though non-finite inputs are now rejected up front, assert the
+        // contract directly: no solver path returns ConvergenceFailure with a
+        // NaN last_iv for non-finite inputs.
+        let config = SolverConfig::default();
+        let params = IVParams::call(f64::NAN, 100.0, 0.25, 0.05);
+        match solve_iv(&params, f64::NAN, &config) {
+            Err(IVError::ConvergenceFailure { last_iv, .. }) => {
+                panic!("got ConvergenceFailure with last_iv={last_iv}");
+            }
+            Err(IVError::InvalidParams { .. }) => {}
+            other => panic!("expected InvalidParams, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two boundary-guard defects in the Black-Scholes IV solver that `global_rules.md`
names explicitly (f64 analytics must guard NaN/Inf at the boundary and return a
typed error rather than propagating NaN).

- `validate_params` and the solver entry points only checked sign/magnitude —
  every comparison against NaN is `false` — so a NaN/Inf `spot`/`strike`/`time`/
  `rate`/`market_price` passed validation and propagated NaN through the
  Newton/bisection loops, burning all iterations and returning a meaningless
  `ConvergenceFailure { last_iv: NaN }`.
- `extract_price_for_iv` computed `spread_bps` without checking `bid <= ask`, so
  a crossed (negative) or locked (zero) spread bypassed the max-spread gate and
  was classified `IVQuality::High`, feeding a bogus mid into the solver — exactly
  when the book is most suspect.

## Change

- `validate_params` rejects non-finite `spot`/`strike`/`time_to_expiry`/
  `risk_free_rate` with `IVError::InvalidParams`.
- `solve_iv` and `solve_iv_bisection` reject a non-finite `market_price`.
- The Newton loop bails with a typed error if `price`/`iv` becomes non-finite
  mid-iteration, so **no path returns `ConvergenceFailure { last_iv: NaN }`** for
  non-finite inputs.
- `extract_price_for_iv` rejects a crossed/locked book with a new
  `IVError::CrossedBook` before quality classification. The check is extracted to
  a unit-testable `reject_crossed_or_locked` helper, because a stable `OrderBook`
  never crosses (the matching engine fills it) — the guard exists for a transient
  torn read across the two independent `best_bid`/`best_ask` calls.

## Tests

- NaN/Inf for every param and for `market_price` (both solvers); the
  no-NaN-`ConvergenceFailure` contract asserted directly; crossed / locked /
  normal book inputs; `CrossedBook` Display.
- `cargo test --all-features` — all pass (52 in `implied_volatility`).
- `cargo clippy --all-targets --all-features -- -D warnings` / `cargo fmt --all --check`
  / `cargo build --release --all-features` — clean.

Closes #112