### PR TITLE
fix(risk): cross-multiply the price-band deviation check to stop sub-bps under-enforcement (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Price-band risk check cross-multiplies to stop sub-bps under-enforcement (#113).**
+  `check_limit_admission` computed the deviation via truncating integer division
+  (`diff * 10_000 / reference`) and rejected only when the floored bps exceeded the
+  limit, so an order whose true deviation was fractionally above the band rounded
+  down to the limit and slipped through (e.g. reference 30000, limit 100 bps, price
+  30301 = 100.33 bps was admitted). The check now cross-multiplies — rejects when
+  `diff * 10_000 > bps_limit * reference` — so the band never under-enforces, while
+  an order exactly at the limit is still admitted (strict-`>` boundary preserved).
+  The floored bps is recomputed only for the error-payload display.
 - **IV solver guards NaN/Inf inputs and crossed/locked books (#112).** The
   Black-Scholes IV solver only checked sign/magnitude — all `false` for NaN — so
   a NaN/Inf `spot`/`strike`/`time`/`rate`/`market_price` passed validation and

--- a/src/orderbook/risk.rs
+++ b/src/orderbook/risk.rs
@@ -290,18 +290,26 @@ impl RiskState {
 
         // 3. Price band against a reference price.
         if let (Some(bps_limit), Some(reference)) = (cfg.price_band_bps, reference_price) {
-            // Compute deviation in basis points: |submitted - reference| / reference * 10_000.
-            // Use u128 arithmetic to avoid overflow; saturate at u32::MAX.
+            // Deviation in basis points is |submitted - reference| / reference * 10_000.
+            // Cross-multiply instead of dividing so the band never under-enforces:
+            // truncating integer division floors the bps, letting an order whose
+            // true deviation is fractionally above the band round down to the limit
+            // and slip through. Reject when diff*10_000 > bps_limit*reference, i.e.
+            // the true deviation *strictly* exceeds the band. An order exactly at the
+            // limit (diff*10_000 == bps_limit*reference) is admitted, preserving the
+            // original strict-`>` boundary semantics. u128 throughout with saturation.
             if reference > 0 {
                 let diff = price.abs_diff(reference);
-                // bps = diff * 10_000 / reference
-                let bps_u128 = diff.saturating_mul(10_000) / reference;
-                let deviation_bps = if bps_u128 > u128::from(u32::MAX) {
-                    u32::MAX
-                } else {
-                    bps_u128 as u32
-                };
-                if deviation_bps > bps_limit {
+                let scaled_diff = diff.saturating_mul(10_000);
+                let band = u128::from(bps_limit).saturating_mul(reference);
+                if scaled_diff > band {
+                    // Recompute the floored bps only for the error payload display.
+                    let bps_u128 = scaled_diff / reference;
+                    let deviation_bps = if bps_u128 > u128::from(u32::MAX) {
+                        u32::MAX
+                    } else {
+                        bps_u128 as u32
+                    };
                     return Err(OrderBookError::RiskPriceBand {
                         submitted: price,
                         reference,
@@ -695,6 +703,46 @@ mod tests {
             }
             other => panic!("expected RiskPriceBand, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_check_limit_admission_price_band_fractional_bps_is_rejected() {
+        let mut state = RiskState::new();
+        state.set_config(
+            RiskConfig::new().with_price_band_bps(100, ReferencePriceSource::LastTrade),
+        );
+        let acct = account(11);
+
+        // Reference 30_000, limit 100 bps → the band edge is exactly 30_300
+        // (100 bps = 300 ticks). 30_301 is 100.33 bps: truncating division
+        // floored this to 100 and admitted it; cross-multiplication rejects it.
+        match state.check_limit_admission(acct, 30_301, 1, Some(30_000)) {
+            Err(OrderBookError::RiskPriceBand {
+                deviation_bps,
+                limit_bps,
+                ..
+            }) => {
+                assert_eq!(limit_bps, 100);
+                assert_eq!(deviation_bps, 100, "display still shows the floored bps");
+            }
+            other => panic!("fractional over-band order must be rejected, got {other:?}"),
+        }
+
+        // An order exactly at the band edge (30_300 = 100.0 bps) is admitted —
+        // the strict-`>` boundary semantics are preserved.
+        assert!(
+            state
+                .check_limit_admission(acct, 30_300, 1, Some(30_000))
+                .is_ok(),
+            "exact-limit order must still be admitted"
+        );
+
+        // And just inside the band (30_299) is admitted.
+        assert!(
+            state
+                .check_limit_admission(acct, 30_299, 1, Some(30_000))
+                .is_ok()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`check_limit_admission` computed the price-band deviation via **truncating
integer division** (`diff * 10_000 / reference`) and rejected only when the
floored bps exceeded the limit. Because the division floors, an order whose true
deviation is fractionally above the band rounds down to the integer limit and
slips through — e.g. reference 30000, limit 100 bps, price 30301 = 100.33 bps was
**admitted**. A protective risk band should never under-enforce; flooring is the
wrong rounding direction for a hard band.

## Change

Cross-multiply instead of dividing: reject when
`diff * 10_000 > bps_limit * reference`. This compares the true deviation to the
band without any lossy floor, so the band never under-enforces. An order exactly
at the limit (`diff * 10_000 == bps_limit * reference`) is still admitted,
preserving the original strict-`>` boundary semantics. The floored bps is
recomputed only for the error-payload `deviation_bps` display, on the reject
path. All arithmetic stays `u128` with saturation.

## Tests

- New `test_check_limit_admission_price_band_fractional_bps_is_rejected`:
  reference 30000, limit 100 bps → 30301 (100.33 bps) rejected; 30300 (exact
  100 bps) and 30299 (inside band) admitted.
- `cargo test --all-features` — all pass (15 in `risk::tests`).
- `cargo clippy --all-targets --all-features -- -D warnings` / `cargo fmt --all --check`
  / `cargo build --release --all-features` — clean.

Closes #113