### PR TITLE
test(metrics): make metrics_do_not_affect_order_semantics deterministic under coverage (#150)

### DIFF
--- a/tests/metrics/metrics_tests.rs
+++ b/tests/metrics/metrics_tests.rs
@@ -244,10 +244,37 @@ fn metrics_do_not_affect_order_semantics() {
     let snap_a = book_a.create_snapshot(10);
     let snap_b = book_b.create_snapshot(10);
 
-    let json_a = serde_json::to_string(&snap_a).expect("serialize snap_a");
-    let json_b = serde_json::to_string(&snap_b).expect("serialize snap_b");
+    // Compare the matched book *structure*, not the per-level `statistics`.
+    // Those statistics carry `pricelevel` wall-clock fields (first_arrival_time,
+    // last_execution_time, sum_waiting_time) that are captured from the real
+    // clock at order arrival/execution, independent of the injected StubClock.
+    // Two books built sequentially can therefore straddle a millisecond boundary
+    // and differ there (notably under slow coverage instrumentation), even
+    // though the determinism contract this test guards is that metric emission
+    // does not alter the resting order/price/quantity state. Strip the volatile
+    // statistics so the assertion is exact on book state and immune to timing.
+    let value_a = strip_level_statistics(serde_json::to_value(&snap_a).expect("serialize snap_a"));
+    let value_b = strip_level_statistics(serde_json::to_value(&snap_b).expect("serialize snap_b"));
     assert_eq!(
-        json_a, json_b,
-        "metrics emission must not affect book state — snapshots differ"
+        value_a, value_b,
+        "metrics emission must not affect book state — structural snapshots differ"
     );
+}
+
+/// Removes the per-level `statistics` object from each bid/ask level of a
+/// serialized order-book snapshot. Those statistics carry wall-clock timestamps
+/// not governed by the injected clock; stripping them makes a snapshot equality
+/// comparison depend only on the matched order/price/quantity state. See
+/// `metrics_do_not_affect_order_semantics` for why.
+fn strip_level_statistics(mut value: serde_json::Value) -> serde_json::Value {
+    for side in ["bids", "asks"] {
+        if let Some(levels) = value.get_mut(side).and_then(|s| s.as_array_mut()) {
+            for level in levels {
+                if let Some(obj) = level.as_object_mut() {
+                    obj.remove("statistics");
+                }
+            }
+        }
+    }
+    value
 }


### PR DESCRIPTION
## Summary

`metrics_tests::metrics_do_not_affect_order_semantics` built two `StubClock`
books with identical inputs and asserted their serialized `OrderBookSnapshot`
JSON was byte-identical. It passed under normal `cargo test` but **flaked under
`cargo tarpaulin`** (the `code_coverage_report` CI job), repeatedly blocking
unrelated PRs (observed on #147/#111 and #149/#113).

## Root cause

The snapshots diverged only in each level's `statistics` object — specifically
`first_arrival_time` (and potentially `last_execution_time` / `sum_waiting_time`).
Those are `pricelevel` `PriceLevelStatistics` **wall-clock** timestamps captured
at order arrival/execution, independent of the injected `StubClock` (which only
governs the orderbook-engine timestamps). Under tarpaulin's slow instrumentation,
`book_a` and `book_b` are built far enough apart to straddle a millisecond
boundary, so the byte-equality assertion fails even though the matched book state
is identical.

Example divergence (ask @ 101): `"first_arrival_time":...937` vs `...938`.

## Fix

Compare the snapshots with the per-level `statistics` stripped (new
`strip_level_statistics` helper), so the determinism contract is asserted on the
order/price/quantity/order-count **structure** — exactly what metric emission
could corrupt — without depending on wall-clock timing. The assertion still
fails if metric emission alters the resting book structure.

## Tests

- The test passes 5/5 locally and is deterministic by construction (no wall-clock
  field participates in the comparison).
- `cargo test --all-features --test metrics_tests` — 3 pass.
- `cargo clippy --all-targets --all-features -- -D warnings` / `cargo fmt --all --check`
  — clean.

Closes #150