### PR TITLE
fix: replace saturating_* with checked_* + typed error on protocol counters (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Protocol counters use `checked_*` instead of `saturating_*` (#91).** Per the
+  no-saturating-on-protocol-counters rule, the remaining protocol-state counters
+  no longer silently cap on overflow. `file_journal`'s `archive_segments_before`
+  tally and the `SegmentIterator` segment index now use `checked_add` and surface
+  overflow as a new typed `JournalError::CounterOverflow`. The two NATS retry
+  bounds (`max_attempts = max_retries + 1`) are computed in `u64` so the `+ 1`
+  cannot overflow even at `max_retries == u32::MAX` — no saturating cap — while the
+  backoff-delay `saturating_mul` clamps stay (they bound a duration, not a
+  counter). The replay sequence counters (#126) and the dead `saturating_sub(0)`
+  in `encode_entry` (#110) were already converted earlier in this cycle. Unreachable
+  at any realistic journal size; the value is rule compliance and correct failure
+  semantics at the boundary.
 - **Boundary arithmetic in fee/analytics math is overflow-safe (#114).** Several
   monetary/price sites used unguarded casts or sums that wrap/panic on extreme
   inputs. `FeeSchedule::calculate_fee` cast `notional: u128` to `i128` with a bare

--- a/src/orderbook/nats.rs
+++ b/src/orderbook/nats.rs
@@ -629,7 +629,12 @@ impl NatsTradePublisher {
         payload: bytes::Bytes,
         headers: async_nats::HeaderMap,
     ) -> bool {
-        let max_attempts = publisher.max_retries.saturating_add(1);
+        // Widen to u64 so the `+ 1` cannot overflow even when `max_retries`
+        // is `u32::MAX` — no saturating cap on this retry counter (per the
+        // no-saturating-on-protocol-counters rule). The delay-clamp
+        // `saturating_mul` below intentionally stays: it bounds the backoff
+        // duration, not a protocol counter.
+        let max_attempts = u64::from(publisher.max_retries) + 1;
 
         for attempt in 0..max_attempts {
             let publish_result = publisher
@@ -667,7 +672,8 @@ impl NatsTradePublisher {
             // Exponential backoff: 10ms, 20ms, 40ms, ... clamped to avoid
             // panic from over-shifting when max_retries is large.
             if attempt + 1 < max_attempts {
-                let shift = u32::min(attempt, 63);
+                // `attempt.min(63)` is ≤ 63, so the cast to u32 is lossless.
+                let shift = attempt.min(63) as u32;
                 let delay_ms =
                     BASE_RETRY_DELAY_MS.saturating_mul(1u64.checked_shl(shift).unwrap_or(u64::MAX));
                 tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;

--- a/src/orderbook/nats_book_change.rs
+++ b/src/orderbook/nats_book_change.rs
@@ -699,7 +699,12 @@ impl NatsBookChangePublisher {
         payload: bytes::Bytes,
         headers: async_nats::HeaderMap,
     ) -> bool {
-        let max_attempts = publisher.max_retries.saturating_add(1);
+        // Widen to u64 so the `+ 1` cannot overflow even when `max_retries`
+        // is `u32::MAX` — no saturating cap on this retry counter (per the
+        // no-saturating-on-protocol-counters rule). The delay-clamp
+        // `saturating_mul` below intentionally stays: it bounds the backoff
+        // duration, not a protocol counter.
+        let max_attempts = u64::from(publisher.max_retries) + 1;
 
         for attempt in 0..max_attempts {
             let publish_result = publisher
@@ -737,7 +742,8 @@ impl NatsBookChangePublisher {
             // Exponential backoff: 10ms, 20ms, 40ms, ... clamped to avoid
             // panic from over-shifting when max_retries is large.
             if attempt + 1 < max_attempts {
-                let shift = u32::min(attempt, 63);
+                // `attempt.min(63)` is ≤ 63, so the cast to u32 is lossless.
+                let shift = attempt.min(63) as u32;
                 let delay_ms =
                     BASE_RETRY_DELAY_MS.saturating_mul(1u64.checked_shl(shift).unwrap_or(u64::MAX));
                 tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;

--- a/src/orderbook/sequencer/error.rs
+++ b/src/orderbook/sequencer/error.rs
@@ -73,6 +73,15 @@ pub enum JournalError {
         /// Description of the header problem.
         message: String,
     },
+
+    /// A protocol counter (archived-segment tally, segment index) overflowed
+    /// while advancing. Surfaced as a typed error rather than silently capping,
+    /// per the no-saturating-on-protocol-counters rule. Unreachable at any
+    /// realistic journal size.
+    CounterOverflow {
+        /// Name of the counter that overflowed.
+        counter: &'static str,
+    },
 }
 
 impl fmt::Display for JournalError {
@@ -130,6 +139,9 @@ impl fmt::Display for JournalError {
                     "invalid journal entry header at offset {offset}: {message}"
                 )
             }
+            JournalError::CounterOverflow { counter } => {
+                write!(f, "journal counter overflowed: {counter}")
+            }
         }
     }
 }
@@ -143,5 +155,20 @@ impl From<std::io::Error> for JournalError {
             message: err.to_string(),
             path: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_counter_overflow_display() {
+        let err = JournalError::CounterOverflow {
+            counter: "archived segment count",
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("counter overflowed"));
+        assert!(msg.contains("archived segment count"));
     }
 }

--- a/src/orderbook/sequencer/file_journal.rs
+++ b/src/orderbook/sequencer/file_journal.rs
@@ -308,7 +308,13 @@ where
                     message: e.to_string(),
                     path: Some(src),
                 })?;
-                archived = archived.saturating_add(1);
+                // checked_add (not saturating) so an overflow surfaces as a
+                // typed error rather than silently capping the tally.
+                archived = archived
+                    .checked_add(1)
+                    .ok_or(JournalError::CounterOverflow {
+                        counter: "archived segment count",
+                    })?;
             }
         }
 
@@ -658,7 +664,14 @@ where
 
         let start_seq = self.segments[self.segment_idx];
         let path = segment_path(&self.dir, start_seq);
-        self.segment_idx = self.segment_idx.saturating_add(1);
+        // checked_add (not saturating) so an overflow surfaces as a typed error
+        // rather than silently stalling the segment cursor.
+        self.segment_idx =
+            self.segment_idx
+                .checked_add(1)
+                .ok_or(JournalError::CounterOverflow {
+                    counter: "segment index",
+                })?;
         self.offset = 0;
 
         let file = File::open(&path).map_err(|e| JournalError::Io {


### PR DESCRIPTION
## Summary

`rules/global_rules.md` (Arithmetic, DO NOT) forbids `saturating_*` / `wrapping_*`
on counters tied to protocol state (sequencer ids, journal seq/segment ids, NATS
retry counters) and requires `checked_*` with overflow surfaced as a typed error.
Several protocol counters silently capped instead of erroring.

Two of the sites the issue listed were already converted earlier in this cycle:
the replay sequence counters (#126 → `ReplayError::SequenceOverflow`) and the dead
`saturating_sub(0)` in `encode_entry` (#110). This PR handles the remainder.

## Change

- **`file_journal.rs`** — `archive_segments_before`'s `archived` tally and the
  `SegmentIterator` `segment_idx` now use `checked_add`, surfacing overflow as a
  new typed `JournalError::CounterOverflow { counter }` (the enum is
  `#[non_exhaustive]`, so the variant is additive).
- **`nats.rs` / `nats_book_change.rs`** — the retry bound
  `max_attempts = max_retries + 1` is computed in `u64`, so the `+ 1` cannot
  overflow even at `max_retries == u32::MAX` (no saturating cap, no error path
  needed). The shift derives from `attempt.min(63) as u32` (lossless).

## Out of scope (audited, intentionally kept)

The backoff-delay `saturating_mul` clamps in the NATS retry loop (they bound a
delay duration, not a protocol counter), and the analytics `saturating_sub` sites
in `file_journal` (`remaining()` bytes; the binary-search-result index). The
issue explicitly excludes these.

## Tests

- New Display test for `JournalError::CounterOverflow`.
- The overflow → typed-error path for the replay sequence counter is covered by
  the existing `test_replay_sequence_counter_overflow_is_a_typed_error` (#126).
- The archive/segment-index overflow is unreachable at any realistic journal size
  (bounded by segment-file count), so no synthetic 2^64-segment test is added.
- `cargo test --all-features` — all pass. `cargo clippy --all-targets --all-features
  -- -D warnings` / `cargo fmt --all --check` / `cargo build --release --all-features`
  — clean.

Closes #91