### PR TITLE
feat: restore #![deny(unsafe_code)] and #![warn(missing_docs)] on lib.rs (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Restored `#![deny(unsafe_code)]` and `#![warn(missing_docs)]` on `lib.rs` (#90).**
+  Both crate-level attributes — mandated by `rules/global_rules.md` and `CLAUDE.md` —
+  had drifted off `src/lib.rs`, silently allowing `unsafe` to creep in and `pub`
+  items to ship undocumented (the `counting_allocator` module even documented a
+  `deny` that no longer existed). The deny is restored; the only authorized `unsafe`
+  — the four `memmap2` mmap blocks in `sequencer::file_journal` and the
+  `CountingAllocator` `GlobalAlloc` impl — now carry an explicit
+  `#[allow(unsafe_code)]` alongside their existing `// SAFETY:` rationale. The
+  `missing_docs` warn surfaces zero warnings on `--all-features`.
 - **Protocol counters use `checked_*` instead of `saturating_*` (#91).** Per the
   no-saturating-on-protocol-counters rule, the remaining protocol-state counters
   no longer silently cap on overflow. `file_journal`'s `archive_segments_before`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,6 +548,13 @@
 //!
 //! This analysis confirms that the system design is highly scalable and appropriate for demanding financial applications requiring high-speed processing with data consistency.
 
+// Safety and documentation discipline (rules/global_rules.md, CLAUDE.md):
+// no `unsafe` may ship without an explicit, documented `#[allow(unsafe_code)]`
+// (the mmap blocks in `sequencer::file_journal` and the `CountingAllocator`
+// module), and every `pub` item must carry a doc comment.
+#![deny(unsafe_code)]
+#![warn(missing_docs)]
+
 pub mod orderbook;
 
 pub mod prelude;

--- a/src/orderbook/sequencer/file_journal.rs
+++ b/src/orderbook/sequencer/file_journal.rs
@@ -73,6 +73,7 @@ impl SegmentWriter {
 
         // SAFETY: The file is exclusively owned by this process and will not
         // be truncated or modified externally while the mmap is active.
+        #[allow(unsafe_code)]
         let mmap = unsafe {
             MmapMut::map_mut(&file).map_err(|e| JournalError::Io {
                 message: e.to_string(),
@@ -110,6 +111,7 @@ impl SegmentWriter {
 
         // SAFETY: The file is exclusively owned by this process and will not
         // be truncated or modified externally while the mmap is active.
+        #[allow(unsafe_code)]
         let mmap = unsafe {
             MmapMut::map_mut(&file).map_err(|e| JournalError::Io {
                 message: e.to_string(),
@@ -519,6 +521,7 @@ where
 
             // SAFETY: Read-only mapping of a file we just opened; file is not
             // modified concurrently (single-writer pattern).
+            #[allow(unsafe_code)]
             let mmap = unsafe {
                 memmap2::Mmap::map(&file).map_err(|e| JournalError::Io {
                     message: e.to_string(),
@@ -681,6 +684,7 @@ where
 
         // SAFETY: Read-only mapping; single-writer pattern ensures the
         // segment is not modified concurrently by another writer.
+        #[allow(unsafe_code)]
         let mmap = unsafe {
             memmap2::Mmap::map(&file).map_err(|e| JournalError::Io {
                 message: e.to_string(),


### PR DESCRIPTION
## Summary

`rules/global_rules.md` (Security/Safety, Documentation) and `CLAUDE.md` both
mandate `#![deny(unsafe_code)]` and `#![warn(missing_docs)]` on `src/lib.rs`, but
both crate-level attributes had drifted off — `src/lib.rs` had zero crate-level
inner attributes. This silently allowed `unsafe` to creep in and `pub` items to
ship undocumented. The drift was already self-contradictory: `counting_allocator`
documented a top-level `deny` that did not exist, and the `file_journal` mmap
blocks carried `// SAFETY:` comments but no `#[allow(unsafe_code)]`.

## Change

- Add `#![deny(unsafe_code)]` and `#![warn(missing_docs)]` to `lib.rs` (after the
  crate doc block).
- Add a documented `#[allow(unsafe_code)]` to the **four** `memmap2` mmap blocks
  in `sequencer/file_journal.rs` (`SegmentWriter::create`, `open_existing`, and
  the two read-path maps) — each keeps its existing `// SAFETY:` rationale.
- `counting_allocator`'s module-level `#![allow(unsafe_code)]` already suppresses
  under the restored `deny`; its doc comment referencing the top-level `deny` is
  now accurate (no longer dangling).

No new `unsafe` is introduced beyond these documented mmap / allocator sites.

## Verification

- `cargo build` / `--features journal` / `--all-features` / `--release --all-features`
  — clean (the mmap `unsafe` compiles only because of the documented allows).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo clippy --all-features -- -W missing-docs` — **0** missing-doc warnings.
- `cargo test --all-features` — all pass. `cargo fmt --all --check` — clean.

Closes #90