### PR TITLE
docs(mass_cancel): use ? instead of .unwrap() in doc examples (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Doc examples use `?` instead of `.unwrap()` (#92).** The remaining `///` doc
+  examples that modelled `.unwrap()` on fallible order-book calls — all nine in
+  `mass_cancel.rs` — now use `?` inside a hidden `Result`-returning harness,
+  matching the idiomatic error handling the rules ask downstream users to follow
+  (the other modules were already swept). Doc-comments only; `#[cfg(test)]` and
+  `tests/` keep their `.unwrap()` per the testing allowance. `cargo test --doc`
+  stays green.
 - **Restored `#![deny(unsafe_code)]` and `#![warn(missing_docs)]` on `lib.rs` (#90).**
   Both crate-level attributes — mandated by `rules/global_rules.md` and `CLAUDE.md` —
   had drifted off `src/lib.rs`, silently allowing `unsafe` to creep in and `pub`

--- a/src/orderbook/mass_cancel.rs
+++ b/src/orderbook/mass_cancel.rs
@@ -114,16 +114,19 @@ where
     /// use orderbook_rs::OrderBook;
     /// use pricelevel::{Id, Side, TimeInForce};
     ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let book: OrderBook<()> = OrderBook::new("TEST");
     /// let id1 = Id::new_uuid();
     /// let id2 = Id::new_uuid();
-    /// book.add_limit_order(id1, 100, 10, Side::Buy, TimeInForce::Gtc, None).unwrap();
-    /// book.add_limit_order(id2, 110, 5, Side::Sell, TimeInForce::Gtc, None).unwrap();
+    /// book.add_limit_order(id1, 100, 10, Side::Buy, TimeInForce::Gtc, None)?;
+    /// book.add_limit_order(id2, 110, 5, Side::Sell, TimeInForce::Gtc, None)?;
     ///
     /// let result = book.cancel_all_orders();
     /// assert_eq!(result.cancelled_count(), 2);
     /// assert_eq!(book.best_bid(), None);
     /// assert_eq!(book.best_ask(), None);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn cancel_all_orders(&self) -> MassCancelResult {
         self.cache.invalidate();
@@ -227,14 +230,17 @@ where
     /// use orderbook_rs::OrderBook;
     /// use pricelevel::{Id, Side, TimeInForce};
     ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let book: OrderBook<()> = OrderBook::new("TEST");
-    /// book.add_limit_order(Id::new_uuid(), 100, 10, Side::Buy, TimeInForce::Gtc, None).unwrap();
-    /// book.add_limit_order(Id::new_uuid(), 110, 5, Side::Sell, TimeInForce::Gtc, None).unwrap();
+    /// book.add_limit_order(Id::new_uuid(), 100, 10, Side::Buy, TimeInForce::Gtc, None)?;
+    /// book.add_limit_order(Id::new_uuid(), 110, 5, Side::Sell, TimeInForce::Gtc, None)?;
     ///
     /// let result = book.cancel_orders_by_side(Side::Buy);
     /// assert_eq!(result.cancelled_count(), 1);
     /// assert_eq!(book.best_bid(), None);
     /// assert!(book.best_ask().is_some());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn cancel_orders_by_side(&self, side: Side) -> MassCancelResult {
         trace!(
@@ -266,19 +272,22 @@ where
     /// use orderbook_rs::OrderBook;
     /// use pricelevel::{Hash32, Id, Side, TimeInForce};
     ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let book: OrderBook<()> = OrderBook::new("TEST");
     /// let user_a = Hash32::new([1u8; 32]);
     /// let user_b = Hash32::new([2u8; 32]);
     ///
     /// book.add_limit_order_with_user(
     ///     Id::new_uuid(), 100, 10, Side::Buy, TimeInForce::Gtc, user_a, None,
-    /// ).unwrap();
+    /// )?;
     /// book.add_limit_order_with_user(
     ///     Id::new_uuid(), 110, 5, Side::Sell, TimeInForce::Gtc, user_b, None,
-    /// ).unwrap();
+    /// )?;
     ///
     /// let result = book.cancel_orders_by_user(user_a);
     /// assert_eq!(result.cancelled_count(), 1);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn cancel_orders_by_user(&self, user_id: Hash32) -> MassCancelResult {
         trace!(
@@ -320,14 +329,17 @@ where
     /// use orderbook_rs::OrderBook;
     /// use pricelevel::{Id, Side, TimeInForce};
     ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let book: OrderBook<()> = OrderBook::new("TEST");
-    /// book.add_limit_order(Id::new_uuid(), 100, 10, Side::Buy, TimeInForce::Gtc, None).unwrap();
-    /// book.add_limit_order(Id::new_uuid(), 200, 10, Side::Buy, TimeInForce::Gtc, None).unwrap();
-    /// book.add_limit_order(Id::new_uuid(), 300, 10, Side::Buy, TimeInForce::Gtc, None).unwrap();
+    /// book.add_limit_order(Id::new_uuid(), 100, 10, Side::Buy, TimeInForce::Gtc, None)?;
+    /// book.add_limit_order(Id::new_uuid(), 200, 10, Side::Buy, TimeInForce::Gtc, None)?;
+    /// book.add_limit_order(Id::new_uuid(), 300, 10, Side::Buy, TimeInForce::Gtc, None)?;
     ///
     /// let result = book.cancel_orders_by_price_range(Side::Buy, 100, 200);
     /// assert_eq!(result.cancelled_count(), 2);
     /// assert_eq!(book.best_bid(), Some(300));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn cancel_orders_by_price_range(
         &self,


### PR DESCRIPTION
## Summary

`rules/global_rules.md` (Documentation) requires doc examples to compile and use
`?` instead of `.unwrap()` — these examples are the copy-paste template downstream
users reach for, so they should model idiomatic error handling. The earlier
crate-wide sweep left `mass_cancel.rs` as the only module still calling
`.unwrap()` on fallible order-book operations in `///` examples (nine calls
across the four mass-cancel methods).

## Change

Each of the four doc examples (`cancel_all_orders`, `cancel_orders_by_side`,
`cancel_orders_by_user`, `cancel_orders_by_price_range`) now wraps its body in a
hidden `# fn main() -> Result<(), Box<dyn std::error::Error>>` harness and uses
`?` on the `add_limit_order*` calls instead of `.unwrap()`. The rendered docs
show clean `?`-based code; the harness lines are hidden.

Doc-comments only — `#[cfg(test)]` modules and `tests/` keep their `.unwrap()`
per the testing allowance. No `lib.rs` module-doc example changed, so `README.md`
needs no regeneration.

## Verification

- No `.unwrap()` remains in any `///` doc example crate-wide.
- `cargo test --doc --all-features` — 48 doctests, all green.
- `cargo clippy --all-targets --all-features -- -D warnings` / `cargo fmt --all --check`
  — clean.

Closes #92