### PR TITLE
perf(cache): independent per-side validity so both sides cache + price 0 is representable (#93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Best bid/ask cache serves both sides and represents price 0 (#93).**
+  `PriceLevelCache` stored both sides behind a single shared `cache_valid` flag
+  and overloaded price `0` as the absent sentinel, so `best_bid()` zeroed the ask
+  slot (and vice versa) — two consecutive top-of-book reads never benefited from
+  the cache, and a genuine best level at price `0` was permanently uncacheable.
+  The cache now carries an independent `AtomicBool` validity flag per side (with
+  `Acquire`/`Release` so a `valid` reader sees the stored price): `best_bid()`
+  updates only the bid slot and `best_ask()` only the ask slot, so both-sides
+  readers (`mid_price`, `spread`, `micro_price`, `resolve_reference_price(Mid)`)
+  hit the cache in a single call and price `0` is a valid cached value.
 - **Doc examples use `?` instead of `.unwrap()` (#92).** The remaining `///` doc
   examples that modelled `.unwrap()` on fallible order-book calls — all nine in
   `mass_cancel.rs` — now use `?` inside a hidden `Result`-returning harness,

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -1062,7 +1062,8 @@ where
         // SkipMap maintains sorted order, best bid (highest price) is last
         let best_price = self.bids.iter().next_back().map(|entry| *entry.key());
 
-        self.cache.update_best_prices(best_price, None);
+        // Update only the bid slot — never evict the ask side.
+        self.cache.update_best_bid(best_price);
 
         best_price
     }
@@ -1079,7 +1080,8 @@ where
         // SkipMap maintains sorted order, best ask (lowest price) is first
         let best_price = self.asks.iter().next().map(|entry| *entry.key());
 
-        self.cache.update_best_prices(None, best_price);
+        // Update only the ask slot — never evict the bid side.
+        self.cache.update_best_ask(best_price);
 
         best_price
     }

--- a/src/orderbook/cache.rs
+++ b/src/orderbook/cache.rs
@@ -9,11 +9,29 @@ use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
 use std::sync::atomic::{AtomicBool, Ordering};
 
+/// A best bid / ask fast-path cache for an [`OrderBook`](crate::OrderBook).
+///
+/// Each side carries its own validity flag, so reading one side never evicts
+/// the other: after a `best_bid()` then `best_ask()` with no intervening
+/// mutation, both are served from cache. Validity is tracked by a dedicated
+/// `AtomicBool` per side rather than overloading price `0` as an "absent"
+/// sentinel, so a genuine best level at price `0` is representable and
+/// cacheable.
+///
+/// The cache is advisory: any book mutation calls [`invalidate`](Self::invalidate)
+/// to clear both sides, and a missing side is recomputed from the skiplist. Only
+/// non-empty sides are cached — an empty side leaves its flag clear and is
+/// recomputed (an O(1) skiplist probe) on the next read.
 #[derive(Debug, Default)]
 pub struct PriceLevelCache {
+    /// Cached best bid price. Meaningful only when `bid_valid` is set.
     best_bid_price: AtomicCell<u128>,
+    /// Cached best ask price. Meaningful only when `ask_valid` is set.
     best_ask_price: AtomicCell<u128>,
-    cache_valid: AtomicBool,
+    /// Whether `best_bid_price` currently holds a trustworthy value.
+    bid_valid: AtomicBool,
+    /// Whether `best_ask_price` currently holds a trustworthy value.
+    ask_valid: AtomicBool,
 }
 
 impl Serialize for PriceLevelCache {
@@ -21,58 +39,136 @@ impl Serialize for PriceLevelCache {
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("PriceLevelCache", 3)?;
+        let mut state = serializer.serialize_struct("PriceLevelCache", 4)?;
         state.serialize_field("best_bid_price", &self.best_bid_price.load())?;
         state.serialize_field("best_ask_price", &self.best_ask_price.load())?;
-        state.serialize_field("cache_valid", &self.cache_valid.load(Ordering::Relaxed))?;
+        state.serialize_field("bid_valid", &self.bid_valid.load(Ordering::Relaxed))?;
+        state.serialize_field("ask_valid", &self.ask_valid.load(Ordering::Relaxed))?;
         state.end()
     }
 }
 
 impl PriceLevelCache {
+    /// Create an empty cache with both sides invalid.
     pub fn new() -> Self {
         Self {
             best_bid_price: AtomicCell::new(0),
             best_ask_price: AtomicCell::new(0),
-            cache_valid: AtomicBool::new(false),
+            bid_valid: AtomicBool::new(false),
+            ask_valid: AtomicBool::new(false),
         }
     }
 
+    /// Invalidate both sides. Called by every book mutation.
     pub fn invalidate(&self) {
-        self.cache_valid.store(false, Ordering::Relaxed);
+        self.bid_valid.store(false, Ordering::Relaxed);
+        self.ask_valid.store(false, Ordering::Relaxed);
     }
 
+    /// Returns the cached best bid, or `None` on a cache miss (an empty or
+    /// invalidated bid side). A cached price of `0` is a valid hit.
     pub fn get_cached_best_bid(&self) -> Option<u128> {
-        if self.cache_valid.load(Ordering::Relaxed) {
-            let price = self.best_bid_price.load();
-            if price > 0 { Some(price) } else { None }
+        // Acquire pairs with the Release in `update_best_bid`, so a reader that
+        // observes `bid_valid == true` also observes the price stored before it.
+        if self.bid_valid.load(Ordering::Acquire) {
+            Some(self.best_bid_price.load())
         } else {
             None
         }
     }
 
+    /// Returns the cached best ask, or `None` on a cache miss (an empty or
+    /// invalidated ask side). A cached price of `0` is a valid hit.
     pub fn get_cached_best_ask(&self) -> Option<u128> {
-        if self.cache_valid.load(Ordering::Relaxed) {
-            let price = self.best_ask_price.load();
-            if price > 0 { Some(price) } else { None }
+        if self.ask_valid.load(Ordering::Acquire) {
+            Some(self.best_ask_price.load())
         } else {
             None
         }
     }
 
-    pub fn update_best_prices(&self, best_bid: Option<u128>, best_ask: Option<u128>) {
-        if let Some(bid) = best_bid {
-            self.best_bid_price.store(bid);
-        } else {
-            self.best_bid_price.store(0);
+    /// Update only the bid slot. `Some(price)` caches the price (including `0`);
+    /// `None` (an empty side) leaves the slot invalid so the next read
+    /// recomputes. The ask slot is never touched.
+    pub fn update_best_bid(&self, best_bid: Option<u128>) {
+        match best_bid {
+            Some(price) => {
+                self.best_bid_price.store(price);
+                // Release so the price store above is visible to any reader that
+                // sees `bid_valid == true`.
+                self.bid_valid.store(true, Ordering::Release);
+            }
+            None => self.bid_valid.store(false, Ordering::Relaxed),
         }
+    }
 
-        if let Some(ask) = best_ask {
-            self.best_ask_price.store(ask);
-        } else {
-            self.best_ask_price.store(0);
+    /// Update only the ask slot. `Some(price)` caches the price (including `0`);
+    /// `None` (an empty side) leaves the slot invalid so the next read
+    /// recomputes. The bid slot is never touched.
+    pub fn update_best_ask(&self, best_ask: Option<u128>) {
+        match best_ask {
+            Some(price) => {
+                self.best_ask_price.store(price);
+                self.ask_valid.store(true, Ordering::Release);
+            }
+            None => self.ask_valid.store(false, Ordering::Relaxed),
         }
+    }
+}
 
-        self.cache_valid.store(true, Ordering::Relaxed);
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reading_one_side_does_not_evict_the_other() {
+        let cache = PriceLevelCache::new();
+        // Prime the bid side only (mirrors OrderBook::best_bid).
+        cache.update_best_bid(Some(100));
+        assert_eq!(cache.get_cached_best_bid(), Some(100));
+
+        // Prime the ask side only (mirrors OrderBook::best_ask). This must NOT
+        // clear the bid slot — the pre-fix shared flag + zero sentinel did.
+        cache.update_best_ask(Some(110));
+        assert_eq!(
+            cache.get_cached_best_bid(),
+            Some(100),
+            "bid slot must survive an ask-side update"
+        );
+        assert_eq!(cache.get_cached_best_ask(), Some(110));
+    }
+
+    #[test]
+    fn test_price_zero_is_cacheable() {
+        let cache = PriceLevelCache::new();
+        cache.update_best_bid(Some(0));
+        assert_eq!(
+            cache.get_cached_best_bid(),
+            Some(0),
+            "a genuine best level at price 0 must be a cache hit, not treated as absent"
+        );
+        cache.update_best_ask(Some(0));
+        assert_eq!(cache.get_cached_best_ask(), Some(0));
+    }
+
+    #[test]
+    fn test_empty_side_is_a_miss_and_does_not_touch_the_other() {
+        let cache = PriceLevelCache::new();
+        cache.update_best_bid(Some(100));
+        // Ask side is empty: leaves the ask slot invalid (a miss → recompute),
+        // and must not disturb the cached bid.
+        cache.update_best_ask(None);
+        assert_eq!(cache.get_cached_best_ask(), None);
+        assert_eq!(cache.get_cached_best_bid(), Some(100));
+    }
+
+    #[test]
+    fn test_invalidate_clears_both_sides() {
+        let cache = PriceLevelCache::new();
+        cache.update_best_bid(Some(100));
+        cache.update_best_ask(Some(110));
+        cache.invalidate();
+        assert_eq!(cache.get_cached_best_bid(), None);
+        assert_eq!(cache.get_cached_best_ask(), None);
     }
 }

--- a/tests/unit/book_coverage_tests.rs
+++ b/tests/unit/book_coverage_tests.rs
@@ -70,6 +70,28 @@ mod tests {
     }
 
     #[test]
+    fn test_both_sides_cached_after_sequential_reads_issue_93() {
+        // Regression for #93: reading one side must not evict the other, and
+        // mid_price()/spread() (which read both sides in sequence on the same
+        // unmutated book) must return correct values on a populated two-sided
+        // book in a single call.
+        let book = OrderBook::<()>::new("TEST");
+        let _ = book.add_limit_order(Id::from_u64(1), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(Id::from_u64(2), 110, 5, Side::Sell, TimeInForce::Gtc, None);
+
+        // best_bid() primes the bid cache; best_ask() must still return Some and
+        // must not have caused best_bid() to come back empty.
+        assert_eq!(book.best_bid(), Some(100));
+        assert_eq!(book.best_ask(), Some(110));
+        assert_eq!(book.best_bid(), Some(100), "bid must survive the ask read");
+
+        // mid_price and spread read both sides; both must be correct without a
+        // mutation between them.
+        assert_eq!(book.mid_price(), Some(105.0));
+        assert_eq!(book.spread(), Some(10));
+    }
+
+    #[test]
     fn test_best_ask_with_cache_miss() {
         // Test best_ask when cache is empty (lines 301, 321)
         let book = OrderBook::<()>::new("TEST");


### PR DESCRIPTION
## Summary

`PriceLevelCache` stored both sides behind a single shared `cache_valid` flag and
overloaded price `0` as the absent sentinel. `best_bid()` called
`update_best_prices(best, None)`, which zeroed the ask slot; a following
`best_ask()` then recomputed from the skiplist (and re-zeroed the bid). So two
consecutive top-of-book reads never benefited from the cache, and `mid_price()`,
`spread()`, `micro_price()`, and `resolve_reference_price(Mid)` (the pre-trade
risk path) — all of which read both sides in sequence on an unmutated book — paid
a full recompute. A genuine best level at price `0` was also permanently
uncacheable.

> Per the triage note, `get_cached_*` treated a zeroed slot as a miss and
> recomputed, so there was no stale-`None` correctness bug — this is a
> perf/robustness fix (and price-0 representability).

## Change

- The cache now carries an **independent `AtomicBool` validity flag per side**.
  `best_bid()` updates only the bid slot (`update_best_bid`); `best_ask()` only
  the ask slot (`update_best_ask`); neither evicts the other.
- Validity is a dedicated flag rather than the value `0`, so a best level at
  price `0` is a cache **hit**.
- The validity flag is stored `Release` (after the price) and loaded `Acquire`,
  so a reader observing `valid == true` is guaranteed to see the stored price —
  closing a latent `Relaxed`-flag / non-atomic-`u128`-payload visibility hole in
  the old design. The hit path is now a single branch (the zero-sentinel branch
  is gone).

## Reviews

- **hot-path review**: PASS on all points — strict correctness + branch-count
  improvement, no new allocation/lock/clone, Acquire/Release correct and the
  minimum. The pre-existing `AtomicCell<u128>` seqlock fallback (non-x86-64) and
  the advisory lost-update race are unchanged and out of scope.

## Tests

- Cache-unit tests: cross-side survival, price-0 representability, empty-side miss
  without cross-eviction, `invalidate` clears both.
- Integration test `test_both_sides_cached_after_sequential_reads_issue_93`:
  `best_bid()`/`best_ask()` both correct after sequential reads, and
  `mid_price()`/`spread()` correct on a populated two-sided book in one call.
- `cargo test --all-features` — all pass. `cargo clippy --all-targets --all-features
  -- -D warnings` / `cargo fmt --all --check` / `cargo build --release --all-features`
  — clean.

Closes #93