### PR TITLE
fix(book): make OrderBook Serialize deterministic + document it as lossy/inspection-only (#117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`OrderBook` Serialize is deterministic and documented as lossy (#117).** The
+  hand-written `Serialize` for `OrderBook<T>` collected bids/asks/order_locations
+  into `HashMap`s (non-deterministic JSON key order across runs) and serialized
+  the volatile best-bid/ask cache, while omitting the matching configuration
+  (`stp_mode`, tick/lot/min/max order size, engine sequence, kill switch, risk
+  config) that `create_snapshot_package` preserves — with no `Deserialize`, so it
+  is a one-way inspection dump, not a persistence path. The collectors now use
+  `BTreeMap` (deterministic key order; order_locations keyed by the id string),
+  the cache is no longer serialized, and the impl carries rustdoc documenting it
+  as a lossy debug/inspection view, steering callers to `snapshot_to_json` /
+  `create_snapshot_package` for durable, reproducible persistence.
 - **Best bid/ask cache serves both sides and represents price 0 (#93).**
   `PriceLevelCache` stored both sides behind a single shared `cache_valid` flag
   and overloaded price `0` as the absent sentinel, so `best_bid()` zeroed the ask

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -159,6 +159,20 @@ pub struct OrderBook<T = ()> {
     pub(super) clock: Arc<dyn Clock>,
 }
 
+/// A **lossy, inspection-only** serialization of the order book.
+///
+/// This `Serialize` impl is a human-readable debug/inspection dump, **not** a
+/// persistence or round-trip path. It intentionally omits matching
+/// configuration that [`OrderBook::create_snapshot_package`] preserves —
+/// `stp_mode`, tick/lot/min/max order size, the engine sequence, the kill
+/// switch, and the risk config — and there is no corresponding `Deserialize`,
+/// so it cannot reconstruct a book. The bids, asks, and order-location maps use
+/// `BTreeMap` so the JSON key ordering is deterministic across process runs, and
+/// the volatile best-bid/ask cache is not serialized.
+///
+/// For durable, reproducible persistence or replay, use
+/// [`OrderBook::snapshot_to_json`] / [`OrderBook::create_snapshot_package`]
+/// instead — those are the determinism-critical paths.
 impl<T> Serialize for OrderBook<T>
 where
     T: Serialize,
@@ -168,35 +182,37 @@ where
         S: serde::Serializer,
     {
         use serde::ser::SerializeStruct;
-        use std::collections::HashMap;
+        use std::collections::BTreeMap;
         use std::sync::atomic::Ordering;
 
-        let mut state = serializer.serialize_struct("OrderBook", 10)?;
+        let mut state = serializer.serialize_struct("OrderBook", 9)?;
 
         // Serialize symbol
         state.serialize_field("symbol", &self.symbol)?;
 
-        // Serialize bids as HashMap<u128, PriceLevel> using snapshots
-        let bids: HashMap<u128, _> = self
+        // Serialize bids as a BTreeMap<u128, PriceLevelSnapshot> so the key
+        // ordering is deterministic (a HashMap would vary across runs).
+        let bids: BTreeMap<u128, _> = self
             .bids
             .iter()
             .map(|entry| (*entry.key(), entry.value().snapshot()))
             .collect();
         state.serialize_field("bids", &bids)?;
 
-        // Serialize asks as HashMap<u128, PriceLevel> using snapshots
-        let asks: HashMap<u128, _> = self
+        // Serialize asks as a BTreeMap<u128, PriceLevelSnapshot> (deterministic).
+        let asks: BTreeMap<u128, _> = self
             .asks
             .iter()
             .map(|entry| (*entry.key(), entry.value().snapshot()))
             .collect();
         state.serialize_field("asks", &asks)?;
 
-        // Serialize order_locations as HashMap
-        let order_locations: HashMap<Id, (u128, Side)> = self
+        // Serialize order_locations keyed by the order id's string form so the
+        // map is both valid-JSON (string keys) and deterministically ordered.
+        let order_locations: BTreeMap<String, (u128, Side)> = self
             .order_locations
             .iter()
-            .map(|entry| (*entry.key(), *entry.value()))
+            .map(|entry| (entry.key().to_string(), *entry.value()))
             .collect();
         state.serialize_field("order_locations", &order_locations)?;
 
@@ -212,8 +228,8 @@ where
             &self.has_market_close.load(Ordering::Relaxed),
         )?;
 
-        // Serialize cache
-        state.serialize_field("cache", &self.cache)?;
+        // The volatile best-bid/ask cache is intentionally NOT serialized — it
+        // is a recomputable optimization, not book state.
 
         // Serialize fee schedule
         state.serialize_field("fee_schedule", &self.fee_schedule)?;

--- a/src/orderbook/tests/serialize_tests.rs
+++ b/src/orderbook/tests/serialize_tests.rs
@@ -80,9 +80,10 @@ mod tests {
             json.contains("order_locations"),
             "Serialized JSON should contain order_locations field"
         );
+        // #117: the volatile best-bid/ask cache is intentionally NOT serialized.
         assert!(
-            json.contains("cache"),
-            "Serialized JSON should contain cache field"
+            !json.contains("\"cache\""),
+            "Serialized JSON must not contain the volatile cache field"
         );
 
         // Verify the JSON is valid by parsing it back

--- a/tests/unit/book_coverage_tests.rs
+++ b/tests/unit/book_coverage_tests.rs
@@ -70,6 +70,38 @@ mod tests {
     }
 
     #[test]
+    fn test_orderbook_serialize_is_deterministic_issue_117() {
+        // Regression for #117: the OrderBook Serialize impl must produce
+        // byte-identical output for identical state (BTreeMap key ordering, not
+        // HashMap), and must not serialize the volatile cache.
+        let book = OrderBook::<()>::new("DET-SER");
+        for i in 0..8u64 {
+            let side = if i % 2 == 0 { Side::Buy } else { Side::Sell };
+            let price = if side == Side::Buy {
+                100 - i as u128
+            } else {
+                200 + i as u128
+            };
+            let _ =
+                book.add_limit_order(Id::from_u64(i + 1), price, 10, side, TimeInForce::Gtc, None);
+        }
+        // Prime the cache so the old impl would have serialized a populated cache.
+        let _ = book.best_bid();
+        let _ = book.best_ask();
+
+        let first = serde_json::to_string(&book).expect("serialize book");
+        let second = serde_json::to_string(&book).expect("serialize book again");
+        assert_eq!(
+            first, second,
+            "OrderBook Serialize must be byte-identical for identical state"
+        );
+        assert!(
+            !first.contains("\"cache\""),
+            "the volatile cache must not be serialized"
+        );
+    }
+
+    #[test]
     fn test_both_sides_cached_after_sequential_reads_issue_93() {
         // Regression for #93: reading one side must not evict the other, and
         // mid_price()/spread() (which read both sides in sequence on the same


### PR DESCRIPTION
## Summary

The hand-written `Serialize` for `OrderBook<T>` collected bids/asks/order_locations
into `HashMap`s — so JSON key ordering was non-deterministic across process runs —
serialized the volatile best-bid/ask cache, and omitted the matching configuration
(`stp_mode`, tick/lot/min/max order size, engine sequence, kill switch, risk config)
that `create_snapshot_package` preserves. With no `Deserialize`, it is a one-way
inspection dump, but a caller could mistake `serde_json::to_string(&book)` for
complete, reproducible persistence. (Determinism-critical paths use
`OrderBookSnapshotPackage` and are unaffected — this is API clarity, not a
correctness regression.)

## Change

- bids/asks now collect into `BTreeMap<u128, _>` and order_locations into
  `BTreeMap<String, (u128, Side)>` (keyed by the order id's string form, which is
  exactly how `Id` already serializes), so output is **deterministic** for
  identical state.
- The volatile cache is **no longer serialized** (struct field count 10 → 9).
- The impl carries rustdoc documenting it as a lossy debug/inspection view that
  does not preserve matching configuration, pointing callers to
  `snapshot_to_json` / `create_snapshot_package` for durable, reproducible
  persistence.

## Tests

- New `test_orderbook_serialize_is_deterministic_issue_117`: byte-identical output
  across repeated serialization of the same book, and asserts the `cache` field
  is absent.
- Updated `serialize_tests::test_orderbook_serialize_with_orders` to assert the
  cache is now omitted.
- `cargo test --all-features` — all pass. `cargo clippy --all-targets --all-features
  -- -D warnings` / `cargo fmt --all --check` / `cargo build --release --all-features`
  — clean.

Closes #117