### PR TITLE
perf(analytics): ordered skiplist iteration + iterator short-circuit instead of collect/sort/scan (#120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Analytics paths use ordered skiplist iteration with early exit (#120).**
+  `enriched_snapshot_with_metrics` collected every bid/ask key into `Vec`s, sorted
+  them, truncated to depth, then did a redundant second skiplist lookup per kept
+  level — despite the `SkipMap` already being price-ordered; it now iterates
+  `bids.iter().rev().take(depth)` / `asks.iter().take(depth)` and snapshots the
+  entry directly (O(N log N)+2N-lookups → O(depth)). `LevelsInRange` scanned every
+  remaining entry and never short-circuited at the band edge (its comment falsely
+  claimed it did); it now threads the side and terminates as soon as iteration
+  passes the far edge (Sell/ascending price > max; Buy/descending price < min),
+  turning a narrow-band query on a wide book from O(N) into O(band). Answers are
+  unchanged. `create_snapshot` has the same collect/sort idiom but is left
+  untouched here — it is on the replay-critical path and out of this issue's scope.
 - **`SerializationError` is a typed `thiserror` enum that bridges into `OrderBookError` (#118).**
   The `EventSerializer` error was a hand-rolled `struct { message: String }` with
   manual `Display`/`Error` impls and no `#[from]` bridge, flattening the structured

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -2904,32 +2904,24 @@ where
         depth: usize,
         flags: MetricFlags,
     ) -> EnrichedSnapshot {
-        // Get all bid prices and sort them in descending order
-        let mut bid_prices: Vec<u128> = self.bids.iter().map(|item| *item.key()).collect();
-        bid_prices.sort_by(|a, b| b.cmp(a)); // Descending order
-        bid_prices.truncate(depth);
+        // The SkipMap is already price-ordered, so iterate it directly and take
+        // only the requested depth — no collect/sort/truncate of all keys and no
+        // redundant second lookup per kept level. Bids are highest-first (reverse
+        // iteration); asks are lowest-first.
+        let bid_levels: Vec<_> = self
+            .bids
+            .iter()
+            .rev()
+            .take(depth)
+            .map(|entry| entry.value().snapshot())
+            .collect();
 
-        // Get all ask prices and sort them in ascending order
-        let mut ask_prices: Vec<u128> = self.asks.iter().map(|item| *item.key()).collect();
-        ask_prices.sort(); // Ascending order
-        ask_prices.truncate(depth);
-
-        let mut bid_levels = Vec::with_capacity(bid_prices.len());
-        let mut ask_levels = Vec::with_capacity(ask_prices.len());
-
-        // Create snapshots for each bid level
-        for price in bid_prices {
-            if let Some(entry) = self.bids.get(&price) {
-                bid_levels.push(entry.value().snapshot());
-            }
-        }
-
-        // Create snapshots for each ask level
-        for price in ask_prices {
-            if let Some(entry) = self.asks.get(&price) {
-                ask_levels.push(entry.value().snapshot());
-            }
-        }
+        let ask_levels: Vec<_> = self
+            .asks
+            .iter()
+            .take(depth)
+            .map(|entry| entry.value().snapshot())
+            .collect();
 
         // Create enriched snapshot with pre-calculated metrics
         EnrichedSnapshot::with_metrics(

--- a/src/orderbook/iterators.rs
+++ b/src/orderbook/iterators.rs
@@ -151,6 +151,7 @@ impl<'a> Iterator for LevelsUntilDepth<'a> {
 /// Useful for analyzing liquidity in specific price bands.
 pub struct LevelsInRange<'a> {
     iter: PriceLevelIter<'a>,
+    side: Side,
     min_price: u128,
     max_price: u128,
     finished: bool,
@@ -177,6 +178,7 @@ impl<'a> LevelsInRange<'a> {
 
         Self {
             iter,
+            side,
             min_price,
             max_price,
             finished: false,
@@ -195,7 +197,21 @@ impl<'a> Iterator for LevelsInRange<'a> {
         for entry in self.iter.by_ref() {
             let price = *entry.key();
 
-            // Check if price is within range
+            // Ordered early exit: the underlying SkipMap iteration is sorted, so
+            // once a price passes the FAR edge of the band no later entry can be
+            // in range. Buy iterates descending (high→low): a price below the
+            // band ends it. Sell iterates ascending (low→high): a price above the
+            // band ends it.
+            let past_far_edge = match self.side {
+                Side::Buy => price < self.min_price,
+                Side::Sell => price > self.max_price,
+            };
+            if past_far_edge {
+                self.finished = true;
+                return None;
+            }
+
+            // Check if price is within range.
             if price >= self.min_price && price <= self.max_price {
                 let quantity = entry.value().total_quantity().unwrap_or(0);
 
@@ -205,12 +221,67 @@ impl<'a> Iterator for LevelsInRange<'a> {
                     cumulative_depth: 0, // Not tracked in range iterator
                 });
             }
-
-            // For efficiency, we can stop early if we've passed the range
-            // This works because skipmap iteration is ordered
+            // Otherwise we are still on the NEAR side of the band (Buy: above
+            // max; Sell: below min) — keep scanning toward it.
         }
 
         self.finished = true;
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_map(prices: impl IntoIterator<Item = u128>) -> SkipMap<u128, Arc<PriceLevel>> {
+        let map = SkipMap::new();
+        for p in prices {
+            map.insert(p, Arc::new(PriceLevel::new(p)));
+        }
+        map
+    }
+
+    #[test]
+    fn test_levels_in_range_terminates_at_far_edge_sell() {
+        // Wide ascending book 1..=1000, narrow band [10, 12] near the low end.
+        let map = make_map(1..=1000u128);
+        let mut it = LevelsInRange::new(&map, Side::Sell, 10, 12);
+        let prices: Vec<u128> = (&mut it).map(|l| l.price).collect();
+        assert_eq!(prices, vec![10, 11, 12], "only in-band levels are yielded");
+        assert!(
+            it.finished,
+            "iterator marks itself finished at the far edge"
+        );
+        // Early-exit proof: the underlying iterator was NOT drained to the end —
+        // entries past the far edge (13..=1000) remain. A non-short-circuiting
+        // scan would have consumed all of them.
+        assert!(
+            it.iter.next().is_some(),
+            "iteration must stop at the far edge, leaving later entries unconsumed"
+        );
+    }
+
+    #[test]
+    fn test_levels_in_range_terminates_at_far_edge_buy() {
+        // Buy iterates descending; narrow band [988, 990] near the high end.
+        let map = make_map(1..=1000u128);
+        let mut it = LevelsInRange::new(&map, Side::Buy, 988, 990);
+        let prices: Vec<u128> = (&mut it).map(|l| l.price).collect();
+        assert_eq!(prices, vec![990, 989, 988], "descending in-band yield");
+        assert!(it.finished);
+        assert!(
+            it.iter.next().is_some(),
+            "iteration must stop below the band, leaving lower entries unconsumed"
+        );
+    }
+
+    #[test]
+    fn test_levels_in_range_empty_when_band_outside_book() {
+        let map = make_map(1..=10u128);
+        let got: Vec<u128> = LevelsInRange::new(&map, Side::Sell, 100, 200)
+            .map(|l| l.price)
+            .collect();
+        assert!(got.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Two analytics-path inefficiencies (off the matching hot path; answers unchanged):

- **`enriched_snapshot_with_metrics`** collected every bid/ask key into `Vec`s,
  sorted them, truncated to `depth`, then did a **redundant second skiplist
  lookup** per kept level — despite the `SkipMap` already being price-ordered. It
  now iterates `bids.iter().rev().take(depth)` and `asks.iter().take(depth)`,
  snapshotting `entry.value()` directly (O(N log N) + 2N lookups → O(depth)).
- **`LevelsInRange::next`** scanned every remaining entry and never
  short-circuited when iteration passed the band edge (its comment falsely
  claimed it did). It now threads the `side` and returns `None` as soon as a
  price crosses the **far edge** (Sell/ascending `price > max_price`;
  Buy/descending `price < min_price`), so a narrow-band query on a wide book is
  O(band) instead of O(N). Comment corrected.

`create_snapshot` has the identical collect/sort idiom but is **intentionally
left untouched** — it feeds the replay-critical snapshot path and is out of this
issue's analytics scope (a separate, determinism-reviewed change if desired).

## Tests

- Co-located iterator tests prove **early termination** by asserting the
  underlying iterator is left non-drained past the far edge (both Buy descending
  and Sell ascending), plus a band-outside-book empty case.
- Existing analytics / snapshot correctness tests unchanged and green.
- The existing `enriched_snapshot_all` / `enriched_snapshot_mid_price` Criterion
  benches (`benches/order_book/snapshot.rs`) cover the changed snapshot path.
- `cargo test --all-features` — all pass. `cargo clippy --all-targets --all-features
  -- -D warnings` / `cargo fmt --all --check` / `cargo build --release --all-features`
  — clean.

Closes #120