### PR TITLE
fix(api): add #[must_use] to pure iterator constructors and Result-returning decoders/IV functions (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`#[must_use]` on pure iterator constructors and fallible decoders/IV entry points (#121).**
+  Several public functions lacked the project-mandated `#[must_use]`: the
+  `OrderBook` iterator constructors (`levels_with_cumulative_depth`,
+  `levels_until_depth`, `levels_in_range` — dropping their result is a silent
+  no-op, so these get a bare `#[must_use]`); the wire decoders (`decode_frame`,
+  `decode_new_order`/`_cancel_order`/`_cancel_replace`/`_mass_cancel`/`_exec_report`/
+  `_trade_print`/`_book_update`) and `MessageKind::from_u8`; and the IV entry
+  points (`solve_iv`, `solve_iv_bisection`, `implied_volatility`,
+  `implied_volatility_with_config`). The `Result`-returning functions use the
+  `#[must_use = "…"]` message form (a bare `#[must_use]` on an
+  already-`#[must_use]` `Result` trips `clippy::double_must_use`). No behavior
+  change.
 - **Analytics paths use ordered skiplist iteration with early exit (#120).**
   `enriched_snapshot_with_metrics` collected every bid/ask key into `Vec`s, sorted
   them, truncated to depth, then did a redundant second skiplist lookup per kept

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -2144,6 +2144,7 @@ where
     ///     }
     /// }
     /// ```
+    #[must_use]
     pub fn levels_with_cumulative_depth(&self, side: Side) -> LevelsWithCumulativeDepth<'_> {
         let price_levels = match side {
             Side::Buy => &self.bids,
@@ -2183,6 +2184,7 @@ where
     /// let levels: Vec<_> = book.levels_until_depth(30, Side::Buy).collect();
     /// println!("Levels needed: {}", levels.len());
     /// ```
+    #[must_use]
     pub fn levels_until_depth(&self, target_depth: u64, side: Side) -> LevelsUntilDepth<'_> {
         let price_levels = match side {
             Side::Buy => &self.bids,
@@ -2226,6 +2228,7 @@ where
     ///     .sum();
     /// println!("Total quantity in range: {}", total_qty);
     /// ```
+    #[must_use]
     pub fn levels_in_range(
         &self,
         min_price: u128,

--- a/src/orderbook/implied_volatility/integration.rs
+++ b/src/orderbook/implied_volatility/integration.rs
@@ -106,6 +106,7 @@ where
     ///     Err(e) => eprintln!("Failed to calculate IV: {}", e),
     /// }
     /// ```
+    #[must_use = "the implied-volatility result (or error) must be handled"]
     pub fn implied_volatility(
         &self,
         params: &IVParams,
@@ -124,6 +125,7 @@ where
     /// # Returns
     /// - `Ok(IVResult)` with calculated IV and metadata
     /// - `Err(IVError)` if calculation fails
+    #[must_use = "the implied-volatility result (or error) must be handled"]
     pub fn implied_volatility_with_config(
         &self,
         params: &IVParams,

--- a/src/orderbook/implied_volatility/solver.rs
+++ b/src/orderbook/implied_volatility/solver.rs
@@ -181,6 +181,7 @@ fn smart_initial_guess(params: &IVParams, market_price: f64) -> f64 {
 /// let (iv, iterations) = solve_iv(&params, market_price, &config)?;
 /// println!("IV: {:.2}%, converged in {} iterations", iv * 100.0, iterations);
 /// ```
+#[must_use = "the implied-volatility result (or error) must be handled"]
 pub fn solve_iv(
     params: &IVParams,
     market_price: f64,
@@ -291,6 +292,7 @@ pub fn solve_iv(
 /// # Returns
 /// - `Ok((iv, iterations))`: Converged IV and iterations
 /// - `Err(IVError)`: If no solution exists in bounds
+#[must_use = "the implied-volatility result (or error) must be handled"]
 pub fn solve_iv_bisection(
     params: &IVParams,
     market_price: f64,

--- a/src/wire/framing.rs
+++ b/src/wire/framing.rs
@@ -68,6 +68,7 @@ pub fn encode_frame<W: Write>(kind: u8, payload: &[u8], out: &mut W) -> io::Resu
 /// Returns [`WireError::Truncated`] if `buf` is shorter than the framing
 /// header or shorter than the body length declared by the header.
 #[inline]
+#[must_use = "the decoded value (or error) must be handled"]
 pub fn decode_frame(buf: &[u8]) -> Result<(u8, &[u8], usize), WireError> {
     if buf.len() < MIN_FRAME_SIZE {
         return Err(WireError::Truncated);

--- a/src/wire/inbound/cancel.rs
+++ b/src/wire/inbound/cancel.rs
@@ -45,6 +45,7 @@ impl CancelOrderWire {
 /// Returns [`WireError::InvalidPayload`] when the buffer length differs from
 /// 24 bytes.
 #[inline]
+#[must_use = "the decoded value (or error) must be handled"]
 pub fn decode_cancel_order(payload: &[u8]) -> Result<CancelOrderWire, WireError> {
     let view = CancelOrderWire::ref_from_bytes(payload)
         .map_err(|_| WireError::InvalidPayload("CancelOrder: payload size mismatch"))?;

--- a/src/wire/inbound/cancel_replace.rs
+++ b/src/wire/inbound/cancel_replace.rs
@@ -51,6 +51,7 @@ impl CancelReplaceWire {
 /// Returns [`WireError::InvalidPayload`] when the buffer length differs from
 /// 40 bytes.
 #[inline]
+#[must_use = "the decoded value (or error) must be handled"]
 pub fn decode_cancel_replace(payload: &[u8]) -> Result<CancelReplaceWire, WireError> {
     let view = CancelReplaceWire::ref_from_bytes(payload)
         .map_err(|_| WireError::InvalidPayload("CancelReplace: payload size mismatch"))?;

--- a/src/wire/inbound/mass_cancel.rs
+++ b/src/wire/inbound/mass_cancel.rs
@@ -59,6 +59,7 @@ impl MassCancelWire {
 /// reserved padding bits are non-zero (for `BySide` only the low bit of
 /// `_pad[0]` is allowed).
 #[inline]
+#[must_use = "the decoded value (or error) must be handled"]
 pub fn decode_mass_cancel(payload: &[u8]) -> Result<MassCancelWire, WireError> {
     let view = MassCancelWire::ref_from_bytes(payload)
         .map_err(|_| WireError::InvalidPayload("MassCancel: payload size mismatch"))?;

--- a/src/wire/inbound/new_order.rs
+++ b/src/wire/inbound/new_order.rs
@@ -84,6 +84,7 @@ impl NewOrderWire {
 /// Returns [`WireError::InvalidPayload`] when the buffer length differs from
 /// 48 bytes.
 #[inline]
+#[must_use = "the decoded value (or error) must be handled"]
 pub fn decode_new_order(payload: &[u8]) -> Result<NewOrderWire, WireError> {
     let view = NewOrderWire::ref_from_bytes(payload)
         .map_err(|_| WireError::InvalidPayload("NewOrder: payload size mismatch"))?;

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -96,6 +96,7 @@ impl MessageKind {
     /// Returns [`WireError::UnknownKind`] for any byte outside the
     /// documented set.
     #[inline]
+    #[must_use = "the decoded value (or error) must be handled"]
     pub fn from_u8(byte: u8) -> Result<Self, WireError> {
         match byte {
             0x01 => Ok(Self::NewOrder),

--- a/src/wire/outbound/book_update.rs
+++ b/src/wire/outbound/book_update.rs
@@ -58,6 +58,7 @@ pub fn encode_book_update(update: &BookUpdateWire, out: &mut Vec<u8>) {
 /// Returns [`WireError::InvalidPayload`] when the buffer length differs from
 /// [`BOOK_UPDATE_SIZE`].
 #[inline]
+#[must_use = "the decoded value (or error) must be handled"]
 pub fn decode_book_update(payload: &[u8]) -> Result<BookUpdateWire, WireError> {
     if payload.len() != BOOK_UPDATE_SIZE {
         return Err(WireError::InvalidPayload(

--- a/src/wire/outbound/exec_report.rs
+++ b/src/wire/outbound/exec_report.rs
@@ -94,6 +94,7 @@ pub fn encode_exec_report(report: &ExecReport, out: &mut Vec<u8>) {
 /// Returns [`WireError::InvalidPayload`] when the buffer length differs from
 /// [`EXEC_REPORT_SIZE`].
 #[inline]
+#[must_use = "the decoded value (or error) must be handled"]
 pub fn decode_exec_report(payload: &[u8]) -> Result<ExecReport, WireError> {
     if payload.len() != EXEC_REPORT_SIZE {
         return Err(WireError::InvalidPayload(

--- a/src/wire/outbound/trade_print.rs
+++ b/src/wire/outbound/trade_print.rs
@@ -54,6 +54,7 @@ pub fn encode_trade_print(trade: &TradePrintWire, out: &mut Vec<u8>) {
 /// Returns [`WireError::InvalidPayload`] when the buffer length differs from
 /// [`TRADE_PRINT_SIZE`].
 #[inline]
+#[must_use = "the decoded value (or error) must be handled"]
 pub fn decode_trade_print(payload: &[u8]) -> Result<TradePrintWire, WireError> {
     if payload.len() != TRADE_PRINT_SIZE {
         return Err(WireError::InvalidPayload(


### PR DESCRIPTION
## Summary

`rules/global_rules.md` and the pre-submission checklist require `#[must_use]` on
pure functions, iterator constructors, and `Result`-returning functions whose
outcome must be handled. Several public functions lacked it while sibling
accessors in the same files already carried it.

## Change

- **Iterator constructors** — `levels_with_cumulative_depth`, `levels_until_depth`,
  `levels_in_range` — get a bare `#[must_use]` (dropping an iterator is a silent
  no-op, and the iterator structs are not themselves `#[must_use]`).
- **Wire decoders** — `decode_frame`, `decode_new_order`, `decode_cancel_order`,
  `decode_cancel_replace`, `decode_mass_cancel`, `decode_exec_report`,
  `decode_trade_print`, `decode_book_update`, and `MessageKind::from_u8` — and the
  **IV entry points** `solve_iv`, `solve_iv_bisection`, `implied_volatility`,
  `implied_volatility_with_config` use the `#[must_use = "…"]` **message form**.

> A bare `#[must_use]` on an already-`#[must_use]` `Result` trips
> `clippy::double_must_use` under `-D warnings`, so the `Result`-returning
> functions use the message form (which the lint allows) — this is the
> clippy-clean way to honor the documented attribute policy on those functions.

No behavior change.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` — clean (default +
  `wire` + all-features).
- `cargo test --all-features` — all pass. `cargo fmt --all --check` /
  `cargo build --release --all-features` — clean.

Closes #121