### PR TITLE
docs(iv,fees,wire): add # Errors sections, document fee rounding, fix BookUpdateWire layout (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Doc gaps closed on IV / fee / wire items (#122).** The `Result`-returning IV
+  functions (`solve_iv`, `solve_iv_bisection`, `implied_volatility`,
+  `implied_volatility_with_config`) and the `TryFrom<&NewOrderWire> for OrderType<()>`
+  conversion now carry `# Errors` sections enumerating their failure modes.
+  `FeeSchedule::calculate_fee` documents its rounding rule (integer division
+  truncates **toward zero**, symmetric in magnitude for a taker fee and a maker
+  rebate) with a fractional-bps doctest asserting both signs. The `BookUpdateWire`
+  layout rustdoc is corrected to match the code: **25 bytes of fields + a single
+  7-byte `_pad`** at offset 25 (it previously claimed 26 fields + 6 pad with
+  phantom `_pad0`/`_pad`). Docs-only, no functional change.
 - **`#[must_use]` on pure iterator constructors and fallible decoders/IV entry points (#121).**
   Several public functions lacked the project-mandated `#[must_use]`: the
   `OrderBook` iterator constructors (`levels_with_cumulative_depth`,

--- a/src/orderbook/fees.rs
+++ b/src/orderbook/fees.rs
@@ -75,6 +75,18 @@ impl FeeSchedule {
     ///
     /// The fee amount. Positive values represent charges, negative values represent rebates.
     ///
+    /// # Rounding
+    ///
+    /// The fee is `notional × bps / 10_000` computed with integer division, which
+    /// **truncates toward zero** — i.e. it rounds toward `0`, not toward `−∞`. The
+    /// magnitude is computed in the unsigned domain and the sign of `bps` is
+    /// applied afterward, so the rounding is symmetric in magnitude for a taker
+    /// fee (positive `bps`) and a maker rebate (negative `bps`): both drop the
+    /// fractional part rather than rounding it. For example a `notional` of
+    /// `15_003` yields `+7` at `+5` bps and `−3` at `−2` bps (each `floor` of the
+    /// magnitude `7.5015` / `3.0006`, then signed). External fee reconciliation
+    /// should therefore truncate-toward-zero, not round-half-up.
+    ///
     /// # Examples
     ///
     /// ```
@@ -89,6 +101,10 @@ impl FeeSchedule {
     /// // Maker rebate: -2 bps on $10,000 = -$2.00
     /// let maker_rebate = schedule.calculate_fee(10_000_000, true);
     /// assert_eq!(maker_rebate, -2_000);
+    ///
+    /// // Fractional bps × notional truncates toward zero in both directions.
+    /// assert_eq!(schedule.calculate_fee(15_003, false), 7); // floor(7.5015)
+    /// assert_eq!(schedule.calculate_fee(15_003, true), -3); // -floor(3.0006)
     /// ```
     #[must_use = "Fee calculation result must be used"]
     #[inline]

--- a/src/orderbook/implied_volatility/integration.rs
+++ b/src/orderbook/implied_volatility/integration.rs
@@ -83,7 +83,16 @@ where
     ///
     /// # Returns
     /// - `Ok(IVResult)` with calculated IV and metadata
-    /// - `Err(IVError)` if calculation fails
+    ///
+    /// # Errors
+    ///
+    /// Returns the same [`IVError`] variants as
+    /// [`implied_volatility_with_config`](Self::implied_volatility_with_config),
+    /// to which this delegates with the default [`IVConfig`]:
+    /// [`IVError::NoPriceAvailable`], [`IVError::CrossedBook`],
+    /// [`IVError::SpreadTooWide`], [`IVError::PriceBelowIntrinsic`], and any
+    /// solver error ([`IVError::InvalidParams`], [`IVError::TimeToExpiryTooSmall`],
+    /// [`IVError::VolatilityOutOfBounds`], [`IVError::ConvergenceFailure`]).
     ///
     /// # Example
     /// ```ignore
@@ -124,7 +133,19 @@ where
     ///
     /// # Returns
     /// - `Ok(IVResult)` with calculated IV and metadata
-    /// - `Err(IVError)` if calculation fails
+    ///
+    /// # Errors
+    ///
+    /// - [`IVError::NoPriceAvailable`] if the book has neither a usable price nor
+    ///   a last trade to derive one from.
+    /// - [`IVError::CrossedBook`] if the book is crossed or locked (no meaningful mid).
+    /// - [`IVError::SpreadTooWide`] if the bid/ask spread exceeds
+    ///   `config.max_spread_bps`.
+    /// - [`IVError::PriceBelowIntrinsic`] if the extracted price is below the
+    ///   option's intrinsic value.
+    /// - Any solver error from [`solve_iv`](crate::orderbook::implied_volatility::solver::solve_iv):
+    ///   [`IVError::InvalidParams`], [`IVError::TimeToExpiryTooSmall`],
+    ///   [`IVError::VolatilityOutOfBounds`], or [`IVError::ConvergenceFailure`].
     #[must_use = "the implied-volatility result (or error) must be handled"]
     pub fn implied_volatility_with_config(
         &self,

--- a/src/orderbook/implied_volatility/solver.rs
+++ b/src/orderbook/implied_volatility/solver.rs
@@ -168,7 +168,20 @@ fn smart_initial_guess(params: &IVParams, market_price: f64) -> f64 {
 ///
 /// # Returns
 /// - `Ok((iv, iterations))`: Converged IV and number of iterations
-/// - `Err(IVError)`: If solver fails to converge or inputs are invalid
+///
+/// # Errors
+///
+/// - [`IVError::InvalidParams`] if `spot`, `strike`, `time_to_expiry`,
+///   `risk_free_rate`, or `market_price` is non-finite or non-positive, or if a
+///   value becomes non-finite mid-iteration.
+/// - [`IVError::TimeToExpiryTooSmall`] if `time_to_expiry` is below the
+///   numerical-stability minimum.
+/// - [`IVError::PriceBelowIntrinsic`] if `market_price` is below the option's
+///   intrinsic value (an arbitrage / bad-input signal).
+/// - [`IVError::VolatilityOutOfBounds`] if the converged IV falls outside
+///   `[config.min_iv, config.max_iv]`.
+/// - [`IVError::ConvergenceFailure`] if Newton-Raphson does not converge within
+///   `config.max_iterations`.
 ///
 /// # Example
 /// ```ignore
@@ -291,7 +304,18 @@ pub fn solve_iv(
 ///
 /// # Returns
 /// - `Ok((iv, iterations))`: Converged IV and iterations
-/// - `Err(IVError)`: If no solution exists in bounds
+///
+/// # Errors
+///
+/// - [`IVError::InvalidParams`] if `spot`, `strike`, `time_to_expiry`,
+///   `risk_free_rate`, or `market_price` is non-finite or non-positive.
+/// - [`IVError::TimeToExpiryTooSmall`] if `time_to_expiry` is below the
+///   numerical-stability minimum.
+/// - [`IVError::PriceBelowIntrinsic`] if `market_price` is below intrinsic value.
+/// - [`IVError::VolatilityOutOfBounds`] if no solution exists within
+///   `[config.min_iv, config.max_iv]`.
+/// - [`IVError::ConvergenceFailure`] if bisection does not converge within
+///   `config.max_iterations`.
 #[must_use = "the implied-volatility result (or error) must be handled"]
 pub fn solve_iv_bisection(
     params: &IVParams,

--- a/src/wire/inbound/new_order.rs
+++ b/src/wire/inbound/new_order.rs
@@ -91,9 +91,19 @@ pub fn decode_new_order(payload: &[u8]) -> Result<NewOrderWire, WireError> {
     Ok(*view)
 }
 
+/// Converts a decoded [`NewOrderWire`] into a domain [`OrderType<()>`],
+/// validating the reserved padding and the enumerated fields.
 impl TryFrom<&NewOrderWire> for OrderType<()> {
     type Error = WireError;
 
+    /// # Errors
+    ///
+    /// Returns [`WireError::InvalidPayload`] when the wire message is malformed:
+    /// - non-zero reserved padding (`_pad`),
+    /// - a negative `price`,
+    /// - an unknown `side` byte (not `SIDE_BUY` / `SIDE_SELL`),
+    /// - an unknown `time_in_force` byte (not GTC / IOC / FOK / DAY), or
+    /// - an unsupported `order_type` (only `ORDER_TYPE_STANDARD` is accepted).
     fn try_from(value: &NewOrderWire) -> Result<Self, Self::Error> {
         // Copy each packed field into a local first — taking a reference to a
         // packed field is undefined behavior. The `{ value.field }` syntax

--- a/src/wire/outbound/book_update.rs
+++ b/src/wire/outbound/book_update.rs
@@ -14,7 +14,7 @@ pub const BOOK_UPDATE_SIZE: usize = 32;
 
 /// Outbound `BookUpdate` message body.
 ///
-/// Total payload size: **32 bytes** (26 bytes of fields + 6 bytes of trailing
+/// Total payload size: **32 bytes** (25 bytes of fields + 7 bytes of trailing
 /// pad to round to a 32-byte block — keeps the message a comfortable
 /// cache-line slice and leaves room for forward-compatible additions).
 ///
@@ -24,8 +24,7 @@ pub const BOOK_UPDATE_SIZE: usize = 32;
 /// |      8 |    1 | `side`       | u8   | `0` Buy, `1` Sell           |
 /// |      9 |    8 | `price`      | i64  | tick-scaled level price     |
 /// |     17 |    8 | `qty`        | u64  | new total quantity at level |
-/// |     25 |    1 | `_pad0`      | u8   | reserved                    |
-/// |     26 |    6 | `_pad`       | u8×6 | reserved, must be zero      |
+/// |     25 |    7 | `_pad`       | u8×7 | reserved, must be zero      |
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BookUpdateWire {
     /// Global engine sequence (monotonic across outbound streams).


### PR DESCRIPTION
## Summary

`rules/global_rules.md` requires a `# Errors` section on every fallible public
item and accurate units/layout in docs. Several public items had gaps (docs-only,
no functional change).

## Change

- **`# Errors` sections** added to the four IV entry points (`solve_iv`,
  `solve_iv_bisection`, `implied_volatility`, `implied_volatility_with_config`) —
  enumerating the `IVError` variants — and to `TryFrom<&NewOrderWire> for
  OrderType<()>` (the `WireError::InvalidPayload` causes: bad padding, negative
  price, unknown side/TIF/order-type).
- **`FeeSchedule::calculate_fee`** now documents its rounding rule: integer
  division **truncates toward zero**, symmetric in magnitude for a taker fee
  (positive bps) and a maker rebate (negative bps). A fractional-bps doctest
  asserts both signs (`15_003` → `+7` / `−3`).
- **`BookUpdateWire`** layout rustdoc corrected to match `encode`/`decode`:
  **25 bytes of fields + a single 7-byte `_pad`** at offset 25 (it previously
  claimed 26 fields + 6 pad with phantom `_pad0`/`_pad` fields that do not exist
  in the struct).

## Verification

- `cargo doc --no-deps --all-features` builds; the new intra-doc links resolve.
  (The pre-existing nats module-doc link warnings are unrelated to this change.)
- `cargo test --doc --all-features` — green (new fee doctest included).
- `cargo clippy --all-targets --all-features -- -D warnings` / `cargo fmt --all --check`
  / `cargo build --release --all-features` — clean.

Closes #122