### PR TITLE
docs/api: surface prelude-only outbound event types at the crate root; document current_time_millis determinism (#123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Outbound event types surfaced at the crate root; `current_time_millis` gains a
+  determinism caveat (#123).** `TradeEvent`, `TradeInfo`, `TransactionInfo`,
+  `PriceLevelChangedEvent`, and `PriceLevelChangedListener` were re-exported only
+  from the prelude, so `orderbook_rs::TradeEvent` failed to resolve even though the
+  crate docs name `TradeEvent` / `PriceLevelChangedEvent` as first-class outbound
+  types (`orderbook_rs::TradeResult` already resolved). They are now re-exported at
+  the crate root too. Separately, `current_time_millis` documents that it reads the
+  **non-monotonic wall clock**, truncates to `u64` ms, and must **not** be used on
+  deterministic / matching / replay paths — those must take time from the `Clock`
+  trait (`MonotonicClock` / `StubClock`) — and gained `#[must_use]`.
 - **Doc gaps closed on IV / fee / wire items (#122).** The `Result`-returning IV
   functions (`solve_iv`, `solve_iv_bisection`, `implied_volatility`,
   `implied_volatility_with_config`) and the `TryFrom<&NewOrderWire> for OrderType<()>`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -586,6 +586,7 @@ pub use orderbook::BincodeEventSerializer;
 pub use orderbook::FileJournal;
 #[cfg(feature = "nats")]
 pub use orderbook::NatsTradePublisher;
+pub use orderbook::book_change_event::{PriceLevelChangedEvent, PriceLevelChangedListener};
 pub use orderbook::clock::{Clock, MonotonicClock, StubClock};
 pub use orderbook::implied_volatility::{
     BlackScholes, IVConfig, IVError, IVParams, IVQuality, IVResult, OptionType, PriceSource,
@@ -607,7 +608,7 @@ pub use orderbook::serialization::{EventSerializer, JsonEventSerializer, Seriali
 pub use orderbook::snapshot::{EnrichedSnapshot, MetricFlags};
 pub use orderbook::statistics::{DepthStats, DistributionBin};
 pub use orderbook::stp::STPMode;
-pub use orderbook::trade::{TradeListener, TradeResult};
+pub use orderbook::trade::{TradeEvent, TradeInfo, TradeListener, TradeResult, TransactionInfo};
 #[cfg(feature = "nats")]
 pub use orderbook::{BookChangeBatch, BookChangeEntry, NatsBookChangePublisher};
 pub use orderbook::{

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -1,9 +1,23 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// Returns the current time in milliseconds since UNIX epoch.
+/// Returns the current wall-clock time in milliseconds since the UNIX epoch.
 ///
-/// Returns 0 if the system clock is set before the Unix epoch (1970-01-01),
-/// which should never happen on correctly-configured systems.
+/// The value is the `SystemTime::now()` UNIX-epoch duration truncated to `u64`
+/// milliseconds. Returns `0` if the system clock is set before the epoch
+/// (1970-01-01), which should never happen on correctly-configured systems.
+///
+/// # Determinism
+///
+/// This reads the **wall clock**, so it is **non-monotonic** (it can jump
+/// forward or backward on NTP steps / clock adjustments) and is **not
+/// reproducible** across runs. Do **not** call it on any deterministic or
+/// replay-critical path — the matching engine, sequencer, and journal must take
+/// their time from the injected [`Clock`](crate::Clock) trait
+/// ([`MonotonicClock`](crate::MonotonicClock) in production,
+/// [`StubClock`](crate::StubClock) in tests) so replays reproduce
+/// engine-assigned timestamps byte-for-byte. This helper is for logging,
+/// metrics, and other non-deterministic, non-journaled uses only.
+#[must_use = "the current time is returned and should be used"]
 pub fn current_time_millis() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/tests/unit/book_coverage_tests.rs
+++ b/tests/unit/book_coverage_tests.rs
@@ -70,6 +70,30 @@ mod tests {
     }
 
     #[test]
+    fn test_outbound_event_types_resolve_at_crate_root_issue_123() {
+        // #123: these outbound event types are documented as first-class but
+        // were prelude-only. They must now resolve at the crate root, like
+        // `orderbook_rs::TradeResult` already does.
+        use orderbook_rs::{PriceLevelChangedEvent, TradeEvent, TradeInfo, TransactionInfo};
+        // PriceLevelChangedEvent is a plain struct — construct one to prove the
+        // path resolves to a usable type.
+        let evt = PriceLevelChangedEvent {
+            side: Side::Buy,
+            price: 100,
+            quantity: 5,
+            engine_seq: 1,
+        };
+        assert_eq!(evt.price, 100);
+        // The remaining types only need to name-resolve at the root.
+        fn _assert_resolves(
+            _: Option<TradeEvent>,
+            _: Option<TradeInfo>,
+            _: Option<TransactionInfo>,
+        ) {
+        }
+    }
+
+    #[test]
     fn test_orderbook_serialize_is_deterministic_issue_117() {
         // Regression for #117: the OrderBook Serialize impl must produce
         // byte-identical output for identical state (BTreeMap key ordering, not


### PR DESCRIPTION
## Summary

`prelude.rs` re-exported `TradeEvent`, `TradeInfo`, `TransactionInfo`,
`PriceLevelChangedEvent`, and `PriceLevelChangedListener`, but `lib.rs` did **not**
surface them at the crate root — so `orderbook_rs::TradeEvent` failed to resolve
even though the crate docs name `TradeEvent` / `PriceLevelChangedEvent` as
first-class outbound event types (`orderbook_rs::TradeResult` already resolved).
Separately, `current_time_millis` lacked a determinism caveat and `#[must_use]`.

## Change

- Re-export `TradeEvent`, `TradeInfo`, `TransactionInfo` and
  `PriceLevelChangedEvent`, `PriceLevelChangedListener` at the crate root (parity
  with the prelude and with `TradeResult`).
- `current_time_millis` now documents that it reads the **non-monotonic wall
  clock**, truncates to `u64` ms, and must **not** be used on deterministic /
  matching / replay paths — those take time from the `Clock` trait
  (`MonotonicClock` in production, `StubClock` in tests). Added `#[must_use]`.

## Tests

- `test_outbound_event_types_resolve_at_crate_root_issue_123` constructs a
  `PriceLevelChangedEvent` and name-resolves the trade event types via
  `orderbook_rs::…` paths.
- `cargo test --all-features` — all pass. `cargo clippy --all-targets --all-features
  -- -D warnings` / `cargo fmt --all --check` / `cargo build --release --all-features`
  — clean. Additive re-exports; semver-clean.

Closes #123