### PR TITLE
fix(modifications): replace redundant Arc::try_unwrap(order.clone()) with a direct deep clone in modify (#124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`modify` uses a direct deep clone instead of a no-op `Arc::try_unwrap` (#124).**
+  The `UpdatePrice` / `UpdatePriceAndQuantity` paths used
+  `Arc::try_unwrap(order.clone()).unwrap_or_else(|arc| (*arc).clone())`, which
+  cloned the `Arc` (strong count ≥ 2) and so the `try_unwrap` always failed and
+  fell through to the deep clone — the cheap branch was dead and the intermediate
+  `Arc` clone was pure overhead. Both now use `(*order).clone()`. Behavior
+  unchanged.
 - **Outbound event types surfaced at the crate root; `current_time_millis` gains a
   determinism caveat (#123).** `TradeEvent`, `TradeInfo`, `TransactionInfo`,
   `PriceLevelChangedEvent`, and `PriceLevelChangedListener` were re-exported only

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -168,7 +168,7 @@ where
                     // Get the original order without holding locks
                     let original_order = if let Some(order) = self.get_order(order_id) {
                         // Create a copy of the order
-                        Arc::try_unwrap(order.clone()).unwrap_or_else(|arc| (*arc).clone())
+                        (*order).clone()
                     } else {
                         return Ok(None); // Order not found
                     };
@@ -274,7 +274,7 @@ where
                     // Get the original order without holding locks
                     let original_order = if let Some(order) = self.get_order(order_id) {
                         // Create a copy of the order
-                        Arc::try_unwrap(order.clone()).unwrap_or_else(|arc| (*arc).clone())
+                        (*order).clone()
                     } else {
                         return Ok(None); // Order not found
                     };


### PR DESCRIPTION
## Summary

In `UpdatePrice` and `UpdatePriceAndQuantity`,
`Arc::try_unwrap(order.clone()).unwrap_or_else(|arc| (*arc).clone())` cloned the
`Arc` (bumping the strong count to ≥ 2) **then** tried to unwrap it. Because the
clone keeps the count ≥ 2, `try_unwrap` always fails and falls through to the
full deep clone — so the "cheap" unwrap branch is dead code and the intermediate
`Arc` clone is pure overhead. It reads as an optimization but never takes the
cheap branch.

## Change

Both occurrences now use `(*order).clone()` directly. `order` is not used after
this point.

## Tests

- Behavior is unchanged — the 22 `modifications` tests pass.
- `cargo test --all-features` — all pass. `cargo clippy --all-targets --all-features
  -- -D warnings` / `cargo fmt --all --check` / `cargo build --release --all-features`
  — clean.

Closes #124