### PR TITLE
fix(nats): with_channel_capacity clamps to 1 instead of asserting on zero (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`with_channel_capacity` clamps instead of asserting on zero (#128).** The NATS
+  publisher builder used `assert!(channel_capacity > 0, …)` on a caller-supplied
+  argument, so a runtime-derived capacity of `0` aborted the whole process where
+  graceful handling is expected (the error rules reserve `assert!` for truly
+  unrecoverable invariant violations). A `0` capacity is now **clamped up to `1`**
+  with a `tracing::warn!` (the minimum a Tokio mpsc accepts), via a shared
+  `clamp_channel_capacity` helper, and the `# Panics` doc is replaced with the
+  clamp note. Applied to both `NatsTradePublisher` and `NatsBookChangePublisher`.
+  `nats`-gated.
 - **NATS trade publisher metric counters share one per-trade granularity (#127).**
   `publish_count` incremented once per trade (only when both subjects succeeded)
   while `error_count` incremented once per **failed subject** (and once per trade

--- a/src/orderbook/nats.rs
+++ b/src/orderbook/nats.rs
@@ -78,6 +78,21 @@ fn account_publish_outcome(
     }
 }
 
+/// Clamps a caller-supplied bounded-channel capacity up to the minimum a Tokio
+/// mpsc channel accepts (`1`).
+///
+/// A capacity of `0` is recoverable bad input — a runtime-derived `0` should not
+/// abort the process via a builder `assert!`. It is clamped to `1` with a
+/// `tracing::warn!`.
+fn clamp_channel_capacity(requested: usize) -> usize {
+    if requested == 0 {
+        warn!("with_channel_capacity(0) is invalid; clamping to 1");
+        1
+    } else {
+        requested
+    }
+}
+
 /// Default batch window in milliseconds. Trades are drained from the channel
 /// for at most this duration before the accumulated batch is published.
 const DEFAULT_BATCH_WINDOW_MS: u64 = 1;
@@ -287,18 +302,14 @@ impl NatsTradePublisher {
     /// When the channel is full, new trades are dropped and `dropped_events`
     /// is incremented. Defaults to [`DEFAULT_CHANNEL_CAPACITY`] (10,000).
     ///
-    /// # Panics
-    ///
-    /// Panics if `channel_capacity` is zero (Tokio mpsc requires a positive
-    /// capacity).
+    /// A `channel_capacity` of `0` is invalid for a Tokio mpsc channel. Rather
+    /// than panic on caller-supplied (possibly runtime-derived) input, it is
+    /// **clamped up to `1`** with a `tracing::warn!` — the builder never aborts
+    /// the process.
     #[must_use = "builders do nothing unless consumed"]
     #[inline]
     pub fn with_channel_capacity(mut self, channel_capacity: usize) -> Self {
-        assert!(
-            channel_capacity > 0,
-            "channel_capacity must be greater than zero"
-        );
-        self.channel_capacity = channel_capacity;
+        self.channel_capacity = clamp_channel_capacity(channel_capacity);
         self
     }
 
@@ -870,6 +881,14 @@ mod tests {
             // All values saturate rather than panic
             assert!(delay >= BASE_RETRY_DELAY_MS);
         }
+    }
+
+    #[test]
+    fn test_clamp_channel_capacity_handles_zero_without_panicking() {
+        // #128: a 0 capacity must clamp up to 1 (no assert!/abort).
+        assert_eq!(clamp_channel_capacity(0), 1);
+        assert_eq!(clamp_channel_capacity(1), 1);
+        assert_eq!(clamp_channel_capacity(10_000), 10_000);
     }
 
     #[test]

--- a/src/orderbook/nats_book_change.rs
+++ b/src/orderbook/nats_book_change.rs
@@ -33,6 +33,21 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tracing::{error, trace, warn};
 
+/// Clamps a caller-supplied bounded-channel capacity up to the minimum a Tokio
+/// mpsc channel accepts (`1`).
+///
+/// A capacity of `0` is recoverable bad input — a runtime-derived `0` should not
+/// abort the process via a builder `assert!`. It is clamped to `1` with a
+/// `tracing::warn!`.
+fn clamp_channel_capacity(requested: usize) -> usize {
+    if requested == 0 {
+        warn!("with_channel_capacity(0) is invalid; clamping to 1");
+        1
+    } else {
+        requested
+    }
+}
+
 /// Drain every immediately-available item from `rx` into `out` (up to `limit`),
 /// without awaiting new sends. Returns the number drained.
 ///
@@ -313,18 +328,14 @@ impl NatsBookChangePublisher {
     /// When the channel is full, new events are dropped and `dropped_events`
     /// is incremented. Defaults to [`DEFAULT_CHANNEL_CAPACITY`] (10,000).
     ///
-    /// # Panics
-    ///
-    /// Panics if `channel_capacity` is zero (Tokio mpsc requires a positive
-    /// capacity).
+    /// A `channel_capacity` of `0` is invalid for a Tokio mpsc channel. Rather
+    /// than panic on caller-supplied (possibly runtime-derived) input, it is
+    /// **clamped up to `1`** with a `tracing::warn!` — the builder never aborts
+    /// the process.
     #[must_use = "builders do nothing unless consumed"]
     #[inline]
     pub fn with_channel_capacity(mut self, channel_capacity: usize) -> Self {
-        assert!(
-            channel_capacity > 0,
-            "channel_capacity must be greater than zero"
-        );
-        self.channel_capacity = channel_capacity;
+        self.channel_capacity = clamp_channel_capacity(channel_capacity);
         self
     }
 
@@ -788,6 +799,14 @@ impl std::fmt::Debug for NatsBookChangePublisher {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_clamp_channel_capacity_handles_zero_without_panicking() {
+        // #128: a 0 capacity must clamp up to 1 (no assert!/abort).
+        assert_eq!(clamp_channel_capacity(0), 1);
+        assert_eq!(clamp_channel_capacity(1), 1);
+        assert_eq!(clamp_channel_capacity(10_000), 10_000);
+    }
 
     #[test]
     fn test_book_change_entry_from_event() {


### PR DESCRIPTION
## Summary

`with_channel_capacity` used `assert!(channel_capacity > 0, …)` in production
builder code on a **caller-supplied** argument. The error rules reserve `assert!`
for truly-unrecoverable invariant violations; a builder argument of `0` is
recoverable input validation, and a runtime-derived `0` would abort the whole
process via the builder where graceful handling is expected.

## Change

A `0` capacity is now **clamped up to `1`** (the minimum a Tokio mpsc accepts)
with a `tracing::warn!`, via a shared `clamp_channel_capacity` helper. The
`# Panics` doc is replaced with the clamp note. Applied to **both**
`NatsTradePublisher` (whose copy was added in #108) and `NatsBookChangePublisher`
for consistency. The builder signature is unchanged.

## Tests

- `test_clamp_channel_capacity_handles_zero_without_panicking` in each module:
  `0 → 1`, `1 → 1`, `10_000 → 10_000`.
- `cargo test --all-features` — all pass. `cargo clippy --all-targets --all-features
  -- -D warnings` / `cargo fmt --all --check` / `cargo build --release --all-features`
  — clean. `nats`-gated.

Closes #128