### PR TITLE
docs(manager): document unbounded trade-event channels + start-processor-before-submit (#129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Manager trade-event channel semantics documented (#129).** `BookManagerStd`
+  (std `mpsc`) and `BookManagerTokio` (tokio `unbounded_channel`) push trade events
+  onto an **unbounded** channel by design — the matching path must never block to
+  deliver an audit event, so the producer applies no backpressure (a bounded
+  channel would force the synchronous matching path to block or drop events). This
+  was previously unstated; the type-level docs and both `start_trade_processor`
+  methods now document the unbounded design and the requirement to **start the
+  processor before submitting orders** (otherwise events buffer without bound).
+  Docs-only; no channel-type or hot-path change.
 - **`with_channel_capacity` clamps instead of asserting on zero (#128).** The NATS
   publisher builder used `assert!(channel_capacity > 0, …)` on a caller-supplied
   argument, so a runtime-derived capacity of `0` aborted the whole process where

--- a/src/orderbook/manager.rs
+++ b/src/orderbook/manager.rs
@@ -49,6 +49,21 @@ where
 }
 
 /// BookManager implementation using standard library mpsc channels.
+///
+/// # Trade-event channel is unbounded by design
+///
+/// Trade events are pushed onto a `std::sync::mpsc` channel, which is
+/// **unbounded**. This is deliberate: the matching path must never block to
+/// deliver an audit event, so the producer cannot apply backpressure (a bounded
+/// channel would force the synchronous matching path to block or to silently
+/// drop trade events — both unacceptable).
+///
+/// **Start the processor before submitting orders.** The receiver sits in an
+/// `Option` until [`start_trade_processor`](Self::start_trade_processor) is
+/// called. If the consumer is never started — or lags persistently — trade
+/// events buffer **without bound** and grow memory. Call `start_trade_processor`
+/// before routing order flow, and keep the consumer draining at least as fast as
+/// trades are produced.
 pub struct BookManagerStd<T>
 where
     T: Clone + Send + Sync + Default + 'static,
@@ -78,7 +93,16 @@ where
 
     /// Start the trade event processor in a separate thread.
     ///
-    /// Returns an error if the processor has already been started.
+    /// **Call this before submitting orders.** The trade-event channel is
+    /// unbounded (see the [type-level docs](BookManagerStd)); until the processor
+    /// is running, every trade event buffers in the channel without bound. Once
+    /// started, the spawned thread drains the receiver for the manager's
+    /// lifetime.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ManagerError::ProcessorAlreadyStarted`] if the processor has
+    /// already been started (the receiver was already taken).
     pub fn start_trade_processor(&mut self) -> Result<std::thread::JoinHandle<()>, ManagerError> {
         let receiver = self
             .trade_receiver
@@ -253,6 +277,21 @@ where
 }
 
 /// BookManager implementation using Tokio mpsc channels.
+///
+/// # Trade-event channel is unbounded by design
+///
+/// Trade events are pushed onto a `tokio::sync::mpsc::unbounded_channel`. As with
+/// [`BookManagerStd`], this is deliberate: the matching path must never block to
+/// deliver an audit event, so the producer applies no backpressure (a bounded
+/// channel would force the synchronous matching path to block or to silently drop
+/// trade events).
+///
+/// **Start the processor before submitting orders.** The receiver sits in an
+/// `Option` until [`start_trade_processor`](Self::start_trade_processor) is
+/// called. If the consumer is never started — or lags persistently — trade
+/// events buffer **without bound** and grow memory. Start the processor before
+/// routing order flow and keep the consumer draining at least as fast as trades
+/// are produced.
 pub struct BookManagerTokio<T>
 where
     T: Clone + Send + Sync + Default + 'static,
@@ -282,8 +321,16 @@ where
 
     /// Start the trade event processor as an async task.
     ///
-    /// Returns a JoinHandle for the spawned task, or an error if the
-    /// processor has already been started.
+    /// **Call this before submitting orders.** The trade-event channel is
+    /// unbounded (see the [type-level docs](BookManagerTokio)); until the
+    /// processor is running, every trade event buffers in the channel without
+    /// bound. Once started, the spawned task drains the receiver for the
+    /// manager's lifetime.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ManagerError::ProcessorAlreadyStarted`] if the processor has
+    /// already been started (the receiver was already taken).
     pub fn start_trade_processor(&mut self) -> Result<tokio::task::JoinHandle<()>, ManagerError> {
         let mut receiver = self
             .trade_receiver


### PR DESCRIPTION
## Summary

`BookManagerTokio` uses a tokio `unbounded_channel` and `BookManagerStd` a std
`mpsc` channel for trade events; the receiver sits in an `Option` until
`start_trade_processor` is called. If the consumer lags or is never started,
events buffer **without bound**.

This unbounded behavior is **deliberate** — the rules bless the non-blocking
push-into-a-channel design, and a bounded channel would force the synchronous
matching path to block or drop audit events — but it was unstated and can
surprise operators.

## Change (docs-only)

Documented on both `BookManagerStd` / `BookManagerTokio` (type-level) and their
`start_trade_processor` methods:
- the trade-event channel is **unbounded by design** to keep the matching hot
  path non-blocking, and
- the processor **must be started before submitting orders** to avoid unbounded
  buffering.

Also added `# Errors` sections to both `start_trade_processor`
(`ManagerError::ProcessorAlreadyStarted`). No channel-type or hot-path change.

## Verification

- `cargo doc --no-deps --all-features` builds; the new intra-doc links resolve.
- `cargo test --all-features` — all pass. `cargo clippy --all-targets --all-features
  -- -D warnings` / `cargo fmt --all --check` / `cargo build --release --all-features`
  — clean.

Closes #129