### PR TITLE
test(risk): add Barrier-synchronized concurrency tests for over-admission and counter wrap-safety (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Barrier-synchronized risk concurrency tests (#116).** The risk module's core
+  safety claim — bounded over-admission and no wrap-to-MAX lockout under fill /
+  cancel races — was uncovered by any concurrency test (all existing risk tests
+  were single-threaded). Added two `std::thread::Barrier`-synchronized,
+  sleep-free, deterministic tests: an N-thread admission race asserting
+  `open_count` equals the admissions that incremented it and stays within
+  `limit + thread_count` (bounded over-admission), and a full-fill-vs-cancel race
+  over many orders asserting the saturating decrements land both `open_count` and
+  `resting_notional` at `0` and never wrap to a large value. Test-only; no
+  behavior change.
 - **Manager trade-event channel semantics documented (#129).** `BookManagerStd`
   (std `mpsc`) and `BookManagerTokio` (tokio `unbounded_channel`) push trade events
   onto an **unbounded** channel by design — the matching path must never block to

--- a/src/orderbook/risk.rs
+++ b/src/orderbook/risk.rs
@@ -508,6 +508,127 @@ mod tests {
         Hash32::new([byte; 32])
     }
 
+    fn open_count_of(state: &RiskState, acct: Hash32) -> u64 {
+        state
+            .counters
+            .get(&acct)
+            .map(|c| c.open_count.load(Ordering::Relaxed))
+            .unwrap_or(0)
+    }
+
+    #[test]
+    fn test_concurrent_admission_over_admission_is_bounded_issue_116() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        const THREADS: usize = 16;
+        const LIMIT: u64 = 4;
+
+        let mut state = RiskState::new();
+        state.set_config(RiskConfig::new().with_max_open_orders_per_account(LIMIT));
+        let state = Arc::new(state);
+        let acct = account(7);
+        // Barrier releases all threads together to maximize the documented
+        // check-then-increment race window.
+        let barrier = Arc::new(Barrier::new(THREADS));
+
+        let handles: Vec<_> = (0..THREADS)
+            .map(|i| {
+                let state = Arc::clone(&state);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    if state.check_limit_admission(acct, 100, 1, Some(100)).is_ok() {
+                        state.on_admission(Id::from_u64(i as u64), acct, 100, 1);
+                        1u64
+                    } else {
+                        0
+                    }
+                })
+            })
+            .collect();
+
+        let admitted: u64 = handles
+            .into_iter()
+            .map(|h| h.join().expect("admission thread"))
+            .sum();
+
+        let open_count = open_count_of(&state, acct);
+
+        // The counter must equal the number of successful admissions.
+        assert_eq!(
+            open_count, admitted,
+            "open_count must match the admissions that incremented it"
+        );
+        // A reject can only happen once the count reaches the limit, so at least
+        // `LIMIT` admissions always occur.
+        assert!(open_count >= LIMIT, "at least the limit is admitted");
+        // Documented bound: over-admission never exceeds the limit by more than
+        // one in-flight admission per racing thread.
+        assert!(
+            open_count <= LIMIT + THREADS as u64,
+            "over-admission must stay bounded by limit + thread_count, got {open_count}"
+        );
+    }
+
+    #[test]
+    fn test_concurrent_fill_cancel_never_wraps_open_count_issue_116() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        const ORDERS: u64 = 32;
+
+        let mut state = RiskState::new();
+        state.set_config(RiskConfig::new().with_max_open_orders_per_account(10_000));
+        let acct = account(9);
+        // Pre-admit ORDERS resting orders (open_count == ORDERS).
+        for i in 0..ORDERS {
+            state.on_admission(Id::from_u64(i), acct, 100, 10);
+        }
+        assert_eq!(open_count_of(&state, acct), ORDERS);
+
+        let state = Arc::new(state);
+        // Race a full fill against a cancel for every order: the saturating
+        // decrement must never wrap `open_count` to a huge value (which would
+        // lock the account out by reading as "at limit" forever).
+        let barrier = Arc::new(Barrier::new((ORDERS * 2) as usize));
+        let mut handles = Vec::new();
+        for i in 0..ORDERS {
+            for which in 0..2u8 {
+                let state = Arc::clone(&state);
+                let barrier = Arc::clone(&barrier);
+                handles.push(thread::spawn(move || {
+                    barrier.wait();
+                    if which == 0 {
+                        state.on_fill(Id::from_u64(i), 10, 100); // full fill
+                    } else {
+                        state.on_cancel(Id::from_u64(i));
+                    }
+                }));
+            }
+        }
+        for h in handles {
+            h.join().expect("fill/cancel thread");
+        }
+
+        let open_count = open_count_of(&state, acct);
+        let resting_notional = state
+            .counters
+            .get(&acct)
+            .map(|c| c.resting_notional.load())
+            .unwrap_or(0);
+
+        // Each order is decremented exactly once (whichever of fill/cancel wins
+        // the DashMap entry removal; the other is a no-op), and a saturating
+        // decrement never wraps — so both counters land at 0, never at a huge
+        // wrapped value that would lock the account out.
+        assert_eq!(open_count, 0, "all orders removed exactly once; no wrap");
+        assert_eq!(
+            resting_notional, 0,
+            "resting_notional also reaches 0 without wrap"
+        );
+    }
+
     #[test]
     fn test_risk_config_builder() {
         let cfg = RiskConfig::new()


### PR DESCRIPTION
## Summary

`check_limit_admission` reads counters with `Relaxed` and is not atomic with the
subsequent `on_admission` increment (a documented single-order race window). All
existing risk tests were single-threaded and only asserted the saturating clamps
— nothing exercised the concurrent path or proved the module's core safety claim
(bounded over-admission; no wrap-to-MAX lockout under fill/cancel races), so a
regression widening the race window or reintroducing a wrapping decrement would
not be caught by CI.

## Change (test-only)

Two co-located, deterministic, `std::thread::Barrier`-synchronized tests (the
internal `pub(super)` `check_limit_admission` / `on_admission` / `on_fill` /
`on_cancel` are not reachable from `tests/unit/`, so the tests live in
`risk.rs`):

- **`test_concurrent_admission_over_admission_is_bounded_issue_116`** — 16 threads
  race `check_limit_admission` + `on_admission` against a shared `RiskState` with
  a tight `max_open_orders = 4`; asserts `open_count` equals the admissions that
  incremented it, is `>= limit`, and stays `<= limit + thread_count` (bounded
  over-admission).
- **`test_concurrent_fill_cancel_never_wraps_open_count_issue_116`** — pre-admits
  32 orders, then races a full fill against a cancel for every order; asserts the
  saturating decrements land both `open_count` and `resting_notional` at `0` and
  never wrap to a large value (which would lock the account out).

`Barrier` for lockstep start, no `sleep`; both pass repeatedly.

## Verification

- `cargo test --all-features` — all pass (ran the two new tests 3×, deterministic).
- `cargo clippy --all-targets --all-features -- -D warnings` / `cargo fmt --all --check`
  / `cargo build --release --all-features` — clean.

Closes #116