### PR TITLE
fix(modifications): validate-first atomic modify so a rejected modify never loses the order (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Atomic modify: a rejected modify no longer destroys the original order (#98).**
+  `UpdatePrice` / `UpdatePriceAndQuantity` / `Replace` previously cancelled the
+  resting order *before* re-adding it, so a **pre-match admission rejection** in
+  `add_order` (risk admission, missing `user_id` under STP, tick / lot size,
+  min/max order size, expiry, post-only-would-cross, or FOK insufficient
+  liquidity) destroyed the live order and returned only an error. These paths are
+  now **validate-first**: a new pure, side-effect-free `validate_order_shape` runs
+  every non-risk admission check (the same checks, in the same order, returning
+  the same typed errors, but without mutating the book, recording state, emitting
+  metrics, or invalidating the cache), and a new modify-aware risk check runs
+  *before* the cancel. The original order is only cancelled once both pass; on
+  any of these pre-match rejections it survives unchanged — no book mutation, no
+  events, no trades. `add_order` now calls the same validator as its single
+  source of truth, preserving its existing reject side-effects on the direct
+  submit path. (Scope: the enumerated pre-match admission rejects. A re-price that
+  would self-cross the same user's resting liquidity under `CancelTaker` /
+  `CancelBoth` STP is a *post-match* cancellation not covered here — tracked as a
+  follow-up; and a concurrent kill-switch flip between the guard and the cancel is
+  a pre-existing, inherent two-step race.)
+- **Modify-aware risk admission (#98).** Added `RiskState::check_modify_admission`
+  for in-place modifies. A modify keeps the account's `open_count` unchanged
+  (one order out, one in) and the original order is still counted in the
+  account's counters at validation time, so the normal limit-admission check
+  would double-count the original and falsely reject. The modify-aware check
+  therefore (a) skips the open-order-count limit entirely, (b) runs the price
+  band on the new price, and (c) checks notional against the *projected* resting
+  notional `current − old_price·old_qty + new_price·new_qty` (saturating `u128`;
+  the old order's contribution is already inside `current`), so a valid modify
+  by an account sitting exactly at `max_open_orders_per_account` now succeeds.
 - **Barrier-synchronized risk concurrency tests (#116).** The risk module's core
   safety claim — bounded over-admission and no wrap-to-MAX lockout under fill /
   cancel races — was uncovered by any concurrency test (all existing risk tests

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -673,6 +673,38 @@ where
             .check_limit_admission(account, price, quantity, reference)
     }
 
+    /// Apply the pre-trade risk gates to an in-place **modify** of a
+    /// resting order (`UpdatePrice` / `UpdatePriceAndQuantity` /
+    /// `Replace`).
+    ///
+    /// Returns `Ok(())` immediately when no risk config is installed.
+    /// Otherwise resolves the reference price (the same way as
+    /// [`Self::check_risk_limit_admission`]) and delegates to
+    /// [`RiskState::check_modify_admission`], which checks the price band
+    /// on `new_price` and the notional *projected* by swapping the
+    /// original order's `old_price * old_qty` contribution for
+    /// `new_price * new_qty` — but does not re-check the open-order count,
+    /// because a modify keeps it unchanged. Allocation-free on the happy
+    /// path; cold rejection allocates one error variant.
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn check_risk_modify_admission(
+        &self,
+        order_id: pricelevel::Id,
+        account: pricelevel::Hash32,
+        new_price: u128,
+        new_qty: u64,
+    ) -> Result<(), OrderBookError> {
+        let Some(cfg) = self.risk_state.config() else {
+            return Ok(());
+        };
+        let reference = cfg
+            .reference_price
+            .and_then(|src| self.resolve_reference_price(src));
+        self.risk_state
+            .check_modify_admission(order_id, account, new_price, new_qty, reference)
+    }
+
     /// Create a new order book for the given symbol with tick size validation.
     ///
     /// Orders added to this book must have prices that are exact multiples

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -173,11 +173,8 @@ where
                         return Ok(None); // Order not found
                     };
 
-                    // Cancel the original order
-                    self.cancel_order(order_id)?;
-
                     // Create a new order with the updated price
-                    let mut new_order = original_order;
+                    let mut new_order = original_order.clone();
 
                     // Update the price based on order type
                     match &mut new_order {
@@ -190,7 +187,28 @@ where
                         OrderType::ReserveOrder { price, .. } => *price = new_price,
                     }
 
-                    // Add the updated order
+                    // Validate-first atomic modify (#98): validate the new
+                    // order's shape and run the modify-aware risk check
+                    // *before* removing the original. On any rejection we
+                    // return the typed error and the original order is
+                    // never cancelled — no book mutation, no events, no
+                    // trades. These checks are pure functions of the new
+                    // order + the opposite book side, so evaluating them
+                    // while the same-side original still rests yields the
+                    // same verdict as after cancel.
+                    self.validate_order_shape(&new_order)?;
+                    self.check_risk_modify_admission(
+                        order_id,
+                        new_order.user_id(),
+                        new_order.price().as_u128(),
+                        new_order.total_quantity(),
+                    )?;
+
+                    // Both checks passed: cancel the original and add the
+                    // updated order. `add_order` re-runs its own checks;
+                    // post-cancel the account count is restored so its risk
+                    // check passes — consistent with the pre-guard.
+                    self.cancel_order(order_id)?;
                     let result = self.add_order(new_order)?;
                     Ok(Some(result))
                 } else {
@@ -270,7 +288,7 @@ where
                 // Get order location without locking
                 let location = self.order_locations.get(&order_id).map(|val| *val);
 
-                if let Some((_, _)) = location {
+                if location.is_some() {
                     // Get the original order without holding locks
                     let original_order = if let Some(order) = self.get_order(order_id) {
                         // Create a copy of the order
@@ -279,11 +297,8 @@ where
                         return Ok(None); // Order not found
                     };
 
-                    // Cancel the original order
-                    self.cancel_order(order_id)?;
-
                     // Create a new order with the updated price and quantity
-                    let mut new_order = original_order;
+                    let mut new_order = original_order.clone();
 
                     // Update the price based on order type
                     match &mut new_order {
@@ -299,7 +314,21 @@ where
                     // Update the quantity using the trait method
                     new_order.set_quantity(new_quantity.as_u64());
 
-                    // Add the updated order
+                    // Validate-first atomic modify (#98): validate the new
+                    // order's shape and run the modify-aware risk check
+                    // *before* removing the original. On any rejection the
+                    // original order is never cancelled.
+                    self.validate_order_shape(&new_order)?;
+                    self.check_risk_modify_admission(
+                        order_id,
+                        new_order.user_id(),
+                        new_order.price().as_u128(),
+                        new_order.total_quantity(),
+                    )?;
+
+                    // Both checks passed: cancel the original and add the
+                    // updated order.
+                    self.cancel_order(order_id)?;
                     let result = self.add_order(new_order)?;
                     Ok(Some(result))
                 } else {
@@ -465,10 +494,22 @@ where
                         }
                     }
 
-                    // Cancel the original order
-                    self.cancel_order(order_id)?;
+                    // Validate-first atomic modify (#98): validate the new
+                    // order's shape and run the modify-aware risk check
+                    // *before* removing the original. On any rejection the
+                    // original order is never cancelled — no book mutation,
+                    // no events, no trades.
+                    self.validate_order_shape(&new_order)?;
+                    self.check_risk_modify_admission(
+                        order_id,
+                        new_order.user_id(),
+                        new_order.price().as_u128(),
+                        new_order.total_quantity(),
+                    )?;
 
-                    // Add the new order
+                    // Both checks passed: cancel the original and add the
+                    // new order.
+                    self.cancel_order(order_id)?;
                     let result = self.add_order(new_order)?;
                     Ok(Some(result))
                 } else {
@@ -660,48 +701,37 @@ where
         }
     }
 
-    /// Add a new order to the book, automatically matching it if it's aggressive.
+    /// Validate the *shape* of an order against this book's admission
+    /// rules **without** mutating any book state.
+    ///
+    /// This is the single source of truth for the non-risk admission
+    /// checks that [`Self::add_order`] performs, in the same order and
+    /// returning the same typed [`OrderBookError`] variants. Unlike
+    /// `add_order` it is pure: it never calls
+    /// [`track_state`](Self::track_state), [`reject_with_risk`](Self::reject_with_risk),
+    /// emits metrics, or invalidates the cache. Every check here is a
+    /// function of the new order plus the *opposite* book side, so it
+    /// yields the same verdict whether evaluated before or after the
+    /// original (same-side) order has been cancelled — which is what
+    /// makes the validate-first atomic modify (#98) safe.
+    ///
+    /// Checks, in order:
+    /// 1. STP `MissingUserId` (when STP is enabled and `user_id` is zero).
+    /// 2. Tick size (`InvalidTickSize`).
+    /// 3. Lot size (`InvalidLotSize`, iceberg visible/hidden split).
+    /// 4. Min/max order size (`OrderSizeOutOfRange`).
+    /// 5. Expiry (`InvalidOperation` — already expired).
+    /// 6. Post-only would cross (`PriceCrossing`).
+    /// 7. FOK feasibility (`InsufficientLiquidity`).
     ///
     /// # Errors
-    /// Returns [`OrderBookError::KillSwitchActive`] when the kill switch
-    /// is engaged. The check runs before any cache invalidation, STP
-    /// validation, tick/lot validation, or matching work.
-    pub fn add_order(&self, mut order: OrderType<T>) -> Result<Arc<OrderType<T>>, OrderBookError> {
-        self.check_kill_switch_or_reject(order.id())?;
-        // Pre-trade risk gate: per-account open-orders / notional /
-        // price band. No-op when no `RiskConfig` is installed.
-        // Documented order: kill_switch → risk → STP → fees → match.
-        // On the cold reject path, record an `OrderStatus::Rejected`
-        // transition with the closed `RejectReason` taxonomy before
-        // propagating the typed error.
-        if let Err(err) = self.check_risk_limit_admission(
-            order.user_id(),
-            order.price().as_u128(),
-            order.total_quantity(),
-        ) {
-            self.reject_with_risk(order.id(), &err);
-            return Err(err);
-        }
-        self.cache.invalidate();
-
-        trace!(
-            "Order book {}: Adding order {} at price {}",
-            self.symbol,
-            order.id(),
-            order.price()
-        );
-
+    /// Returns the first failing check's typed [`OrderBookError`].
+    pub(super) fn validate_order_shape(&self, order: &OrderType<T>) -> Result<(), OrderBookError> {
         // STP user_id enforcement: when STP is enabled, all orders must carry
         // a non-zero user_id so that self-trade checks can identify the owner.
         if self.stp_mode != crate::orderbook::stp::STPMode::None
             && order.user_id() == pricelevel::Hash32::zero()
         {
-            self.track_state(
-                order.id(),
-                OrderStatus::Rejected {
-                    reason: RejectReason::MissingUserId,
-                },
-            );
             return Err(OrderBookError::MissingUserId {
                 order_id: order.id(),
             });
@@ -712,12 +742,6 @@ where
             && tick > 0
             && !order.price().as_u128().is_multiple_of(tick)
         {
-            self.track_state(
-                order.id(),
-                OrderStatus::Rejected {
-                    reason: RejectReason::InvalidPrice,
-                },
-            );
             return Err(OrderBookError::InvalidTickSize {
                 price: order.price().as_u128(),
                 tick_size: tick,
@@ -729,31 +753,19 @@ where
         if let Some(lot) = self.lot_size
             && lot > 0
         {
-            match &order {
+            match order {
                 OrderType::IcebergOrder {
                     visible_quantity,
                     hidden_quantity,
                     ..
                 } => {
                     if visible_quantity.as_u64() % lot != 0 {
-                        self.track_state(
-                            order.id(),
-                            OrderStatus::Rejected {
-                                reason: RejectReason::InvalidQuantity,
-                            },
-                        );
                         return Err(OrderBookError::InvalidLotSize {
                             quantity: visible_quantity.as_u64(),
                             lot_size: lot,
                         });
                     }
                     if hidden_quantity.as_u64() % lot != 0 {
-                        self.track_state(
-                            order.id(),
-                            OrderStatus::Rejected {
-                                reason: RejectReason::InvalidQuantity,
-                            },
-                        );
                         return Err(OrderBookError::InvalidLotSize {
                             quantity: hidden_quantity.as_u64(),
                             lot_size: lot,
@@ -762,12 +774,6 @@ where
                 }
                 _ => {
                     if order.total_quantity() % lot != 0 {
-                        self.track_state(
-                            order.id(),
-                            OrderStatus::Rejected {
-                                reason: RejectReason::InvalidQuantity,
-                            },
-                        );
                         return Err(OrderBookError::InvalidLotSize {
                             quantity: order.total_quantity(),
                             lot_size: lot,
@@ -782,12 +788,6 @@ where
         if let Some(min) = self.min_order_size
             && qty < min
         {
-            self.track_state(
-                order.id(),
-                OrderStatus::Rejected {
-                    reason: RejectReason::OrderSizeOutOfRange,
-                },
-            );
             return Err(OrderBookError::OrderSizeOutOfRange {
                 quantity: qty,
                 min: Some(min),
@@ -797,12 +797,6 @@ where
         if let Some(max) = self.max_order_size
             && qty > max
         {
-            self.track_state(
-                order.id(),
-                OrderStatus::Rejected {
-                    reason: RejectReason::OrderSizeOutOfRange,
-                },
-            );
             return Err(OrderBookError::OrderSizeOutOfRange {
                 quantity: qty,
                 min: self.min_order_size,
@@ -810,19 +804,13 @@ where
             });
         }
 
-        if self.has_expired(&order) {
+        if self.has_expired(order) {
             return Err(OrderBookError::InvalidOperation {
                 message: "Order has already expired".to_string(),
             });
         }
 
         if order.is_post_only() && self.will_cross_market(order.price().as_u128(), order.side()) {
-            self.track_state(
-                order.id(),
-                OrderStatus::Rejected {
-                    reason: RejectReason::PostOnlyWouldCross,
-                },
-            );
             return Err(OrderBookError::PriceCrossing {
                 price: order.price().as_u128(),
                 side: order.side(),
@@ -846,6 +834,70 @@ where
                 order.user_id(),
             );
             if potential_match < order.total_quantity() {
+                return Err(OrderBookError::InsufficientLiquidity {
+                    side: order.side(),
+                    requested: order.total_quantity(),
+                    available: potential_match,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Record the terminal state transition (and metric) that the direct
+    /// [`Self::add_order`] path historically emitted for each shape
+    /// rejection returned by [`Self::validate_order_shape`].
+    ///
+    /// Keeping this mapping next to the validator preserves the exact
+    /// pre-#98 reject side-effects of `add_order` while letting the
+    /// validate-first modify path reuse the same pure validator without
+    /// recording any state. Errors that previously had no side-effect
+    /// (e.g. the already-expired `InvalidOperation`) are intentionally
+    /// no-ops here.
+    fn record_shape_rejection(&self, order: &OrderType<T>, err: &OrderBookError) {
+        match err {
+            OrderBookError::MissingUserId { .. } => {
+                self.track_state(
+                    order.id(),
+                    OrderStatus::Rejected {
+                        reason: RejectReason::MissingUserId,
+                    },
+                );
+            }
+            OrderBookError::InvalidTickSize { .. } => {
+                self.track_state(
+                    order.id(),
+                    OrderStatus::Rejected {
+                        reason: RejectReason::InvalidPrice,
+                    },
+                );
+            }
+            OrderBookError::InvalidLotSize { .. } => {
+                self.track_state(
+                    order.id(),
+                    OrderStatus::Rejected {
+                        reason: RejectReason::InvalidQuantity,
+                    },
+                );
+            }
+            OrderBookError::OrderSizeOutOfRange { .. } => {
+                self.track_state(
+                    order.id(),
+                    OrderStatus::Rejected {
+                        reason: RejectReason::OrderSizeOutOfRange,
+                    },
+                );
+            }
+            OrderBookError::PriceCrossing { .. } => {
+                self.track_state(
+                    order.id(),
+                    OrderStatus::Rejected {
+                        reason: RejectReason::PostOnlyWouldCross,
+                    },
+                );
+            }
+            OrderBookError::InsufficientLiquidity { .. } => {
                 self.track_state(
                     order.id(),
                     OrderStatus::Cancelled {
@@ -854,12 +906,52 @@ where
                     },
                 );
                 crate::orderbook::metrics::record_reject(RejectReason::InsufficientLiquidity);
-                return Err(OrderBookError::InsufficientLiquidity {
-                    side: order.side(),
-                    requested: order.total_quantity(),
-                    available: potential_match,
-                });
             }
+            // The already-expired `InvalidOperation` path historically
+            // recorded no terminal transition; preserve that.
+            _ => {}
+        }
+    }
+
+    /// Add a new order to the book, automatically matching it if it's aggressive.
+    ///
+    /// # Errors
+    /// Returns [`OrderBookError::KillSwitchActive`] when the kill switch
+    /// is engaged. The check runs before any cache invalidation, STP
+    /// validation, tick/lot validation, or matching work.
+    pub fn add_order(&self, mut order: OrderType<T>) -> Result<Arc<OrderType<T>>, OrderBookError> {
+        self.check_kill_switch_or_reject(order.id())?;
+        // Pre-trade risk gate: per-account open-orders / notional /
+        // price band. No-op when no `RiskConfig` is installed.
+        // Documented order: kill_switch → risk → STP → fees → match.
+        // On the cold reject path, record an `OrderStatus::Rejected`
+        // transition with the closed `RejectReason` taxonomy before
+        // propagating the typed error.
+        if let Err(err) = self.check_risk_limit_admission(
+            order.user_id(),
+            order.price().as_u128(),
+            order.total_quantity(),
+        ) {
+            self.reject_with_risk(order.id(), &err);
+            return Err(err);
+        }
+
+        trace!(
+            "Order book {}: Adding order {} at price {}",
+            self.symbol,
+            order.id(),
+            order.price()
+        );
+
+        // Non-risk admission checks are owned by `validate_order_shape`
+        // (the single source of truth shared with the validate-first
+        // atomic modify path, #98). On the cold reject path we still
+        // record the matching terminal state transition / metric here so
+        // the direct (non-modify) `add_order` behavior is preserved
+        // exactly.
+        if let Err(err) = self.validate_order_shape(&order) {
+            self.record_shape_rejection(&order, &err);
+            return Err(err);
         }
 
         self.cache.invalidate();

--- a/src/orderbook/risk.rs
+++ b/src/orderbook/risk.rs
@@ -289,15 +289,34 @@ impl RiskState {
         }
 
         // 3. Price band against a reference price.
+        self.check_price_band(cfg, price, reference_price)?;
+
+        Ok(())
+    }
+
+    /// Price-band check shared by [`Self::check_limit_admission`] and
+    /// [`Self::check_modify_admission`].
+    ///
+    /// Rejects when the deviation of `price` from the resolved
+    /// `reference_price` *strictly* exceeds `cfg.price_band_bps`. The
+    /// comparison cross-multiplies (`diff * 10_000` vs.
+    /// `bps_limit * reference`) instead of dividing so the band never
+    /// under-enforces: truncating integer division would floor the bps,
+    /// letting an order whose true deviation is fractionally above the
+    /// band round down to the limit and slip through (#113). An order
+    /// exactly at the limit is admitted, preserving the original
+    /// strict-`>` boundary semantics. `u128` throughout with saturation.
+    ///
+    /// Skips silently (warning once per book) when the band is configured
+    /// but no reference price is currently available.
+    #[inline]
+    fn check_price_band(
+        &self,
+        cfg: &RiskConfig,
+        price: u128,
+        reference_price: Option<u128>,
+    ) -> Result<(), OrderBookError> {
         if let (Some(bps_limit), Some(reference)) = (cfg.price_band_bps, reference_price) {
-            // Deviation in basis points is |submitted - reference| / reference * 10_000.
-            // Cross-multiply instead of dividing so the band never under-enforces:
-            // truncating integer division floors the bps, letting an order whose
-            // true deviation is fractionally above the band round down to the limit
-            // and slip through. Reject when diff*10_000 > bps_limit*reference, i.e.
-            // the true deviation *strictly* exceeds the band. An order exactly at the
-            // limit (diff*10_000 == bps_limit*reference) is admitted, preserving the
-            // original strict-`>` boundary semantics. u128 throughout with saturation.
             if reference > 0 {
                 let diff = price.abs_diff(reference);
                 let scaled_diff = diff.saturating_mul(10_000);
@@ -336,6 +355,94 @@ impl RiskState {
                 );
             }
         }
+
+        Ok(())
+    }
+
+    /// Pre-trade admission check for an in-place **modify** of a resting
+    /// order (`UpdatePrice` / `UpdatePriceAndQuantity` / `Replace`).
+    ///
+    /// A modify replaces one resting order with another: the account's
+    /// `open_count` is unchanged (one out, one in) and — critically — the
+    /// *original* order's contribution is still counted in the account's
+    /// counters at the moment this runs (the validate-first guard checks
+    /// admission *before* cancelling, #98). Reusing
+    /// [`Self::check_limit_admission`] here would therefore double-count
+    /// the original and falsely reject. This check instead:
+    ///
+    /// - runs the **price band** on `new_price` (same logic as the
+    ///   limit-admission band, via [`Self::check_price_band`]),
+    /// - runs the **notional** check against `max_notional_per_account`
+    ///   using the *projected* resting notional
+    ///   `current - old_price*old_qty + new_price*new_qty` (the old
+    ///   order's contribution is already inside `current`), with `u128`
+    ///   saturating arithmetic,
+    /// - does **not** check `max_open_orders_per_account` (a modify cannot
+    ///   change the resting order count).
+    ///
+    /// Returns `Ok(())` when no [`RiskConfig`] is installed.
+    ///
+    /// # Errors
+    /// Returns [`OrderBookError::RiskMaxNotional`] or
+    /// [`OrderBookError::RiskPriceBand`] when the projected modify would
+    /// breach the corresponding limit.
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn check_modify_admission(
+        &self,
+        order_id: Id,
+        account: Hash32,
+        new_price: u128,
+        new_qty: u64,
+        reference_price: Option<u128>,
+    ) -> Result<(), OrderBookError> {
+        let Some(cfg) = self.config.as_ref() else {
+            return Ok(());
+        };
+
+        // Look up the original order's tracked risk contribution. If it is NOT
+        // tracked — admitted while no `RiskConfig` was installed, then a config
+        // was installed before this modify — the modify is, from the risk
+        // layer's view, a genuinely new admission: `on_cancel` will be a no-op
+        // for the untracked original and `add_order` runs FULL admission
+        // post-cancel. Mirror that exactly (full `check_limit_admission`,
+        // including the open-order count) so the validate-first guard predicts
+        // the post-cancel verdict and never passes a modify that `add_order`
+        // would then reject — which would destroy the original.
+        let old_contribution = {
+            let Some(entry) = self.orders.get(&order_id) else {
+                return self.check_limit_admission(account, new_price, new_qty, reference_price);
+            };
+            u128::from(entry.remaining_qty).saturating_mul(entry.price)
+        };
+
+        // Tracked original: a modify is net one-out-one-in, so `open_count` is
+        // unchanged (skip that gate) and only the notional and price band can
+        // newly breach. Project the account's resting notional by swapping the
+        // original's contribution (already inside `current`) for the new one.
+        // Saturating throughout: a transient under-count floors at zero.
+        if let Some(limit) = cfg.max_notional_per_account {
+            let current = self
+                .counters
+                .get(&account)
+                .map(|c| c.resting_notional.load())
+                .unwrap_or(0);
+            let new_contribution = (new_qty as u128).saturating_mul(new_price);
+            let projected = current
+                .saturating_sub(old_contribution)
+                .saturating_add(new_contribution);
+            if projected > limit {
+                return Err(OrderBookError::RiskMaxNotional {
+                    account,
+                    current,
+                    attempted: new_contribution,
+                    limit,
+                });
+            }
+        }
+
+        // Price band against the reference price on the new limit price.
+        self.check_price_band(cfg, new_price, reference_price)?;
 
         Ok(())
     }
@@ -977,5 +1084,149 @@ mod tests {
         let counters = state.counters.get(&acct).expect("counters present");
         assert_eq!(counters.open_count.load(Ordering::Relaxed), 0);
         assert_eq!(counters.resting_notional.load(), 0);
+    }
+
+    // ───────────────────────────────────────────────────────────────
+    // Modify-aware admission (#98)
+    // ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_check_modify_admission_no_config_is_passthrough() {
+        let state = RiskState::new();
+        assert!(
+            state
+                .check_modify_admission(Id::new_uuid(), account(1), 999_999, 999, Some(100))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_check_modify_admission_ignores_open_order_count() {
+        // A modify of a TRACKED order must never reject on the open-order
+        // count: an account sitting exactly at the limit can still modify a
+        // resting order (count is net unchanged).
+        let mut state = RiskState::new();
+        state.set_config(RiskConfig::new().with_max_open_orders_per_account(1));
+        let acct = account(20);
+        let id = Id::new_uuid();
+        state.on_admission(id, acct, 100, 10); // account at the limit
+
+        assert!(
+            state
+                .check_modify_admission(id, acct, 110, 10, Some(105))
+                .is_ok(),
+            "modify of a tracked order must not be gated by max_open_orders_per_account"
+        );
+    }
+
+    #[test]
+    fn test_check_modify_admission_projects_notional_swapping_old_for_new() {
+        // Notional ceiling 1_000. Original order contributes 100*8 = 800.
+        let mut state = RiskState::new();
+        state.set_config(RiskConfig::new().with_max_notional_per_account(1_000));
+        let acct = account(21);
+        let id = Id::new_uuid();
+        state.on_admission(id, acct, 100, 8); // resting_notional = 800
+
+        // Modify to 100*9 = 900 projects to 800 - 800 + 900 = 900 ≤ 1_000.
+        assert!(
+            state
+                .check_modify_admission(id, acct, 100, 9, Some(100))
+                .is_ok(),
+            "projected notional 900 must be within the 1_000 ceiling"
+        );
+
+        // Modify to 100*11 = 1_100 projects to 800 - 800 + 1_100 = 1_100 > 1_000.
+        match state.check_modify_admission(id, acct, 100, 11, Some(100)) {
+            Err(OrderBookError::RiskMaxNotional {
+                account: a,
+                attempted,
+                limit,
+                ..
+            }) => {
+                assert_eq!(a, acct);
+                assert_eq!(attempted, 1_100);
+                assert_eq!(limit, 1_000);
+            }
+            other => panic!("expected RiskMaxNotional, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_check_modify_admission_projection_does_not_double_count_original() {
+        // Regression: the naive limit-admission check would add the new
+        // contribution on top of the (still-counted) original and falsely
+        // reject. The projection subtracts the original's tracked contribution.
+        let mut state = RiskState::new();
+        state.set_config(RiskConfig::new().with_max_notional_per_account(1_000));
+        let acct = account(22);
+        let id = Id::new_uuid();
+        state.on_admission(id, acct, 100, 10); // resting_notional = 1_000 (at ceiling)
+
+        // Re-price to the same notional: 1_000 - 1_000 + 1_000 = 1_000 ≤ 1_000.
+        assert!(
+            state
+                .check_modify_admission(id, acct, 200, 5, Some(150))
+                .is_ok(),
+            "an unchanged-notional modify must not double-count the original"
+        );
+    }
+
+    #[test]
+    fn test_check_modify_admission_price_band_on_new_price() {
+        let mut state = RiskState::new();
+        state.set_config(
+            RiskConfig::new().with_price_band_bps(100, ReferencePriceSource::LastTrade),
+        );
+        let acct = account(23);
+        let id = Id::new_uuid();
+        state.on_admission(id, acct, 1_000_000, 1);
+
+        // New price 1_100_000 vs reference 1_000_000 → +1_000 bps, far over band.
+        match state.check_modify_admission(id, acct, 1_100_000, 1, Some(1_000_000)) {
+            Err(OrderBookError::RiskPriceBand {
+                submitted,
+                reference,
+                limit_bps,
+                ..
+            }) => {
+                assert_eq!(submitted, 1_100_000);
+                assert_eq!(reference, 1_000_000);
+                assert_eq!(limit_bps, 100);
+            }
+            other => panic!("expected RiskPriceBand, got {other:?}"),
+        }
+
+        // A new price inside the band is admitted.
+        assert!(
+            state
+                .check_modify_admission(id, acct, 1_005_000, 1, Some(1_000_000))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_check_modify_admission_untracked_original_runs_full_admission() {
+        // If the original order has no RiskEntry (admitted while no RiskConfig
+        // was installed, then a config was installed before this modify), the
+        // modify is a genuinely new admission from the risk layer's view — full
+        // admission applies, INCLUDING the open-order count. This mirrors
+        // `add_order`'s post-cancel check so the validate-first guard predicts
+        // the post-cancel verdict and never destroys the original.
+        let mut state = RiskState::new();
+        state.set_config(RiskConfig::new().with_max_open_orders_per_account(1));
+        let acct = account(24);
+        // One OTHER tracked resting order already at the limit.
+        state.on_admission(Id::new_uuid(), acct, 100, 10);
+
+        // The order being modified is NOT tracked → full admission → rejected
+        // on the open-order count (would be a 2nd order for the account).
+        let untracked = Id::new_uuid();
+        match state.check_modify_admission(untracked, acct, 110, 5, Some(105)) {
+            Err(OrderBookError::RiskMaxOpenOrders { .. }) => {}
+            other => panic!(
+                "untracked modify must run full admission and reject on open count, got {other:?}"
+            ),
+        }
     }
 }

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -14,6 +14,7 @@ mod mass_cancel_tests;
 mod matching_coverage_tests;
 mod matching_coverage_tests_extended;
 mod modifications_coverage_tests;
+mod modify_atomic_tests;
 mod operations_coverage_tests;
 mod operations_coverage_tests_extended;
 mod order_state_tests;

--- a/tests/unit/modify_atomic_tests.rs
+++ b/tests/unit/modify_atomic_tests.rs
@@ -1,0 +1,253 @@
+//! Atomic-modify regression tests (#98).
+//!
+//! `UpdatePrice` / `UpdatePriceAndQuantity` / `Replace` are validate-first:
+//! the new order is validated (shape checks + modify-aware risk check)
+//! *before* the original is cancelled. A rejected modify must therefore
+//! leave the original resting order completely untouched — no book
+//! mutation, no events, no trades — and surface the typed error.
+
+use orderbook_rs::orderbook::trade::{TradeListener, TradeResult};
+use orderbook_rs::{OrderBook, OrderBookError, ReferencePriceSource, RiskConfig};
+use pricelevel::{Hash32, Id, OrderUpdate, Price, Quantity, Side, TimeInForce};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn account(byte: u8) -> Hash32 {
+    Hash32::new([byte; 32])
+}
+
+/// Build a book that counts every emitted trade through a listener so we can
+/// assert that a rejected modify emits no trade at all.
+fn book_with_trade_counter() -> (OrderBook<()>, Arc<AtomicU64>) {
+    let count = Arc::new(AtomicU64::new(0));
+    let listener_count = Arc::clone(&count);
+    let listener: TradeListener = Arc::new(move |_: &TradeResult| {
+        listener_count.fetch_add(1, Ordering::Relaxed);
+    });
+    let book = OrderBook::<()>::with_trade_listener("TEST", listener);
+    (book, count)
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Post-only modify that would cross the spread
+// ───────────────────────────────────────────────────────────────────────
+
+#[test]
+fn post_only_modify_that_would_cross_leaves_original_untouched_and_emits_no_trade() {
+    let (book, trade_count) = book_with_trade_counter();
+
+    // Resting ask at 110 to be crossed by an aggressive buy.
+    book.add_limit_order(Id::new_uuid(), 110, 10, Side::Sell, TimeInForce::Gtc, None)
+        .expect("resting ask admitted");
+
+    // Resting post-only buy at 100 (does not cross the 110 ask).
+    let buy_id = Id::new_uuid();
+    book.add_post_only_order(buy_id, 100, 5, Side::Buy, TimeInForce::Gtc, None)
+        .expect("post-only buy admitted");
+
+    // No trades yet.
+    assert_eq!(trade_count.load(Ordering::Relaxed), 0);
+
+    // Modify the post-only buy up to 115 — this would cross the 110 ask, so a
+    // post-only must be rejected with PriceCrossing.
+    let result = book.update_order(OrderUpdate::UpdatePrice {
+        order_id: buy_id,
+        new_price: Price::new(115),
+    });
+    match result {
+        Err(OrderBookError::PriceCrossing { price, side, .. }) => {
+            assert_eq!(price, 115);
+            assert_eq!(side, Side::Buy);
+        }
+        other => panic!("expected PriceCrossing, got {other:?}"),
+    }
+
+    // The original order must survive completely unchanged.
+    let survivor = book
+        .get_order(buy_id)
+        .expect("original order still resting");
+    assert_eq!(survivor.id(), buy_id);
+    assert_eq!(survivor.price().as_u128(), 100, "price unchanged");
+    assert_eq!(
+        survivor.visible_quantity(),
+        Quantity::new(5),
+        "quantity unchanged"
+    );
+    assert_eq!(survivor.side(), Side::Buy);
+
+    // Still tracked at the original price/side.
+    assert_eq!(book.best_bid(), Some(100));
+
+    // And crucially: no trade was emitted by the rejected modify.
+    assert_eq!(
+        trade_count.load(Ordering::Relaxed),
+        0,
+        "a rejected modify must not emit any trade"
+    );
+}
+
+#[test]
+fn post_only_replace_that_would_cross_leaves_original_untouched() {
+    let book: OrderBook<()> = OrderBook::new("TEST");
+
+    book.add_limit_order(Id::new_uuid(), 110, 10, Side::Sell, TimeInForce::Gtc, None)
+        .expect("resting ask admitted");
+
+    let buy_id = Id::new_uuid();
+    book.add_post_only_order(buy_id, 100, 5, Side::Buy, TimeInForce::Gtc, None)
+        .expect("post-only buy admitted");
+
+    // Replace re-prices the post-only buy up to 120 (crosses the 110 ask).
+    let result = book.update_order(OrderUpdate::Replace {
+        order_id: buy_id,
+        price: Price::new(120),
+        quantity: Quantity::new(7),
+        side: Side::Buy,
+    });
+    assert!(
+        matches!(result, Err(OrderBookError::PriceCrossing { .. })),
+        "expected PriceCrossing, got {result:?}"
+    );
+
+    let survivor = book
+        .get_order(buy_id)
+        .expect("original survives the rejected replace");
+    assert_eq!(survivor.price().as_u128(), 100);
+    assert_eq!(survivor.visible_quantity(), Quantity::new(5));
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Risk-limit-breaching modify
+// ───────────────────────────────────────────────────────────────────────
+
+#[test]
+fn modify_outside_price_band_leaves_original_untouched() {
+    let mut book: OrderBook<()> = OrderBook::new("TEST");
+    // 100 bps = 1% band around the mid.
+    book.set_risk_config(RiskConfig::new().with_price_band_bps(100, ReferencePriceSource::Mid));
+    let acct = account(31);
+
+    // Two-sided book establishes a mid of 100.
+    book.add_limit_order_with_user(
+        Id::new_uuid(),
+        90,
+        10,
+        Side::Buy,
+        TimeInForce::Gtc,
+        acct,
+        None,
+    )
+    .expect("bid admitted");
+    book.add_limit_order_with_user(
+        Id::new_uuid(),
+        110,
+        10,
+        Side::Sell,
+        TimeInForce::Gtc,
+        acct,
+        None,
+    )
+    .expect("ask admitted");
+
+    // Resting order we will try to modify.
+    let order_id = Id::new_uuid();
+    book.add_limit_order_with_user(order_id, 99, 5, Side::Buy, TimeInForce::Gtc, acct, None)
+        .expect("order admitted within band");
+
+    // Modify to 200 — far outside the 1% band around mid 100. Rejected.
+    let result = book.update_order(OrderUpdate::UpdatePrice {
+        order_id,
+        new_price: Price::new(200),
+    });
+    assert!(
+        matches!(result, Err(OrderBookError::RiskPriceBand { .. })),
+        "expected RiskPriceBand, got {result:?}"
+    );
+
+    // Original survives unchanged.
+    let survivor = book.get_order(order_id).expect("original survives");
+    assert_eq!(survivor.price().as_u128(), 99);
+    assert_eq!(survivor.visible_quantity(), Quantity::new(5));
+}
+
+#[test]
+fn modify_over_max_notional_leaves_original_untouched() {
+    let mut book: OrderBook<()> = OrderBook::new("TEST");
+    // Notional ceiling 1_000 per account.
+    book.set_risk_config(RiskConfig::new().with_max_notional_per_account(1_000));
+    let acct = account(32);
+
+    // Resting order contributes 100 * 5 = 500 of notional.
+    let order_id = Id::new_uuid();
+    book.add_limit_order_with_user(order_id, 100, 5, Side::Buy, TimeInForce::Gtc, acct, None)
+        .expect("order admitted within notional");
+
+    // Modify to 100 * 20 = 2_000 → projected 500 - 500 + 2_000 = 2_000 > 1_000.
+    let result = book.update_order(OrderUpdate::UpdatePriceAndQuantity {
+        order_id,
+        new_price: Price::new(100),
+        new_quantity: Quantity::new(20),
+    });
+    match result {
+        Err(OrderBookError::RiskMaxNotional {
+            account: a,
+            attempted,
+            limit,
+            ..
+        }) => {
+            assert_eq!(a, acct);
+            assert_eq!(attempted, 2_000);
+            assert_eq!(limit, 1_000);
+        }
+        other => panic!("expected RiskMaxNotional, got {other:?}"),
+    }
+
+    // Original survives unchanged.
+    let survivor = book.get_order(order_id).expect("original survives");
+    assert_eq!(survivor.price().as_u128(), 100);
+    assert_eq!(survivor.visible_quantity(), Quantity::new(5));
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Valid modify at exactly max_open_orders_per_account must succeed
+// ───────────────────────────────────────────────────────────────────────
+
+#[test]
+fn modify_at_max_open_orders_succeeds() {
+    let mut book: OrderBook<()> = OrderBook::new("TEST");
+    // Account may hold at most 2 resting orders.
+    book.set_risk_config(RiskConfig::new().with_max_open_orders_per_account(2));
+    let acct = account(33);
+
+    // Fill the open-order quota: account is now exactly at the limit.
+    let target_id = Id::new_uuid();
+    book.add_limit_order_with_user(target_id, 100, 3, Side::Buy, TimeInForce::Gtc, acct, None)
+        .expect("first order admitted");
+    book.add_limit_order_with_user(
+        Id::new_uuid(),
+        101,
+        3,
+        Side::Buy,
+        TimeInForce::Gtc,
+        acct,
+        None,
+    )
+    .expect("second order admitted (now at limit)");
+
+    // A modify keeps the count unchanged (one out, one in) so it must SUCCEED
+    // even though the account is at max_open_orders. This is the regression
+    // guard for the false rejection the modify-aware risk check prevents: a
+    // naive re-use of the limit-admission check would reject here.
+    let result = book.update_order(OrderUpdate::UpdatePrice {
+        order_id: target_id,
+        new_price: Price::new(95),
+    });
+    assert!(
+        result.is_ok(),
+        "modify at max_open_orders must succeed, got {result:?}"
+    );
+
+    let modified = book.get_order(target_id).expect("modified order resting");
+    assert_eq!(modified.price().as_u128(), 95, "price was updated");
+    assert_eq!(modified.visible_quantity(), Quantity::new(3));
+}


### PR DESCRIPTION
## Summary

`UpdatePrice` / `UpdatePriceAndQuantity` / `Replace` did `cancel_order(id)?` then
`add_order(new)?` with no rollback — any **pre-match admission rejection** in
`add_order` (risk, STP missing `user_id`, tick / lot / size, expiry,
post-only-would-cross, FOK) fired **after** the original was removed, destroying
the live order. Maintainer decision: **validate-first**.

## Change

- **`validate_order_shape`** — pure, side-effect-free; runs every non-risk
  admission check (same checks, same order, same typed errors; no
  mutation/`track_state`/metrics/`cache.invalidate`). `add_order` now calls it as
  the single source of truth, with `record_shape_rejection` preserving its
  historical reject side-effects on the direct submit path.
- **`check_modify_admission`** (modify-aware risk) — a modify is net one-out-one-in,
  so it skips `max_open_orders`, runs the price band on the new price, and checks
  notional against the **projected** resting notional (swap old contribution for
  new). It looks up the original's `RiskEntry` by id: **if the original is not
  risk-tracked** (admitted before a `RiskConfig` was installed) it falls back to
  the **full** `check_limit_admission`, mirroring `add_order`'s post-cancel verdict
  — closing the risk-toggle order-loss edge the review flagged.
- Each modify branch runs `validate_order_shape` + the modify-aware risk check
  **before** `cancel_order`; only on success does it cancel+add. Removed a
  redundant double `cache.invalidate` in `add_order`.

## Reviews (pre-PR)

- **microstructure-critic**: seven enumerated pre-match rejects fully covered,
  success-path semantics unchanged, notional projection correct. Flagged the
  **risk-toggle edge** (fixed here via the untracked-original full-admission
  fallback) and an **STP self-cross** post-match cancellation (out of scope →
  follow-up **#168**). CHANGELOG/docstring prose narrowed to "pre-match admission
  rejects."
- **determinism-auditor**: PASS / replay-safe — the reject path now emits **no**
  events (fixing the prior journal/state divergence); replay skips `Rejected`
  commands correctly.

## Tests

- 5 integration (`modify_atomic_tests`): post-only modify & replace that cross
  leave the original untouched + no trade; over-band and over-notional modify
  leave it untouched; **modify at `max_open_orders` succeeds** (false-rejection
  regression guard).
- 6 risk unit (`check_modify_admission`): no-config passthrough, ignores open-count,
  notional swap-projection (+ no double-count), price band on new price, and the
  **untracked-original full-admission** path.
- `cargo test --all-features` / clippy `-D warnings` / fmt / `--release --all-features`
  — all clean.

Closes #98