### PR TITLE
feat(sequencer): inject book config on replay so non-default-config books replay deterministically (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Replay now reconstructs non-default-config books deterministically (#101).**
+  Every public `ReplayEngine` entry point built the target book with all
+  configuration left at its defaults (`tick_size` / `lot_size` / `min_order_size`
+  / `max_order_size` = `None`, `stp_mode` = `None`, `fee_schedule` = `None`), so
+  replaying a journal produced by a book that used those — for example a
+  `MarketOrderByAmount` rounding per level under a `lot_size` — rebuilt a
+  **structurally different** book and could fail `snapshots_match` at verify.
+  Two caller-supplied config variants now inject the original configuration into
+  the fresh book *before* replay: `ReplayEngine::replay_from_with_config` and
+  `ReplayEngine::replay_from_with_clock_and_config`, both taking a new
+  `ReplayBookConfig` carrier (the same six fields persisted in
+  `OrderBookSnapshotPackage`). Two `Option`-taking book setters back this up —
+  `OrderBook::set_tick_size_opt` and `OrderBook::set_lot_size_opt` — alongside
+  the existing `set_min_order_size` / `set_max_order_size` / `set_fee_schedule` /
+  `set_stp_mode`. The configuration is supplied by the **caller** and is not read
+  from the journal, so the on-disk format is unchanged and
+  `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` is **not** bumped. The plain `replay_from`
+  / `replay_from_with_clock` entry points are now documented as valid only for
+  default-config books. `ReplayBookConfig` is re-exported at the crate root and
+  in the prelude.
+
 - **Atomic modify: a rejected modify no longer destroys the original order (#98).**
   `UpdatePrice` / `UpdatePriceAndQuantity` / `Replace` previously cancelled the
   resting order *before* re-adding it, so a **pre-match admission rejection** in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -601,8 +601,8 @@ pub use orderbook::order_state::{
 pub use orderbook::reject_reason::RejectReason;
 pub use orderbook::risk::{ReferencePriceSource, RiskConfig, RiskState};
 pub use orderbook::sequencer::{
-    InMemoryJournal, Journal, JournalEntry, JournalError, JournalReadIter, ReplayEngine,
-    ReplayError, SequencerCommand, SequencerEvent, SequencerResult, snapshots_match,
+    InMemoryJournal, Journal, JournalEntry, JournalError, JournalReadIter, ReplayBookConfig,
+    ReplayEngine, ReplayError, SequencerCommand, SequencerEvent, SequencerResult, snapshots_match,
 };
 pub use orderbook::serialization::{EventSerializer, JsonEventSerializer, SerializationError};
 pub use orderbook::snapshot::{EnrichedSnapshot, MetricFlags};

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -895,6 +895,25 @@ where
         self.tick_size = Some(tick_size);
     }
 
+    /// Set or clear the minimum price increment from an [`Option`].
+    ///
+    /// `Some(t)` enables tick validation at `t`; `None` disables it. This is
+    /// the setter the sequencer [`ReplayEngine`](crate::ReplayEngine) uses to
+    /// inject `tick_size` into a fresh book before replay so that a journal
+    /// produced by a tick-constrained book reconstructs to the same structure.
+    ///
+    /// Intended for replay / restore on a **fresh** book. Changing the tick
+    /// size on a book that already holds resting orders does not re-validate
+    /// or re-price existing levels — that is the caller's responsibility.
+    ///
+    /// # Arguments
+    /// - `tick_size`: `Some(increment)` to enable (increment must be > 0), or
+    ///   `None` to disable validation.
+    #[inline]
+    pub fn set_tick_size_opt(&mut self, tick_size: Option<u128>) {
+        self.tick_size = tick_size;
+    }
+
     /// Returns the configured tick size, if any.
     ///
     /// `None` means tick size validation is disabled (all prices accepted).
@@ -913,6 +932,26 @@ where
     /// - `lot_size`: Minimum quantity increment. Must be > 0
     pub fn set_lot_size(&mut self, lot_size: u64) {
         self.lot_size = Some(lot_size);
+    }
+
+    /// Set or clear the minimum quantity increment from an [`Option`].
+    ///
+    /// `Some(l)` enables lot validation / rounding at `l`; `None` disables it.
+    /// This is the setter the sequencer [`ReplayEngine`](crate::ReplayEngine)
+    /// uses to inject `lot_size` into a fresh book before replay so that a
+    /// journal produced by a lot-constrained book (e.g. `MarketOrderByAmount`
+    /// rounding per level) reconstructs to the same structure.
+    ///
+    /// Intended for replay / restore on a **fresh** book. Changing the lot
+    /// size on a book that already holds resting orders does not re-validate
+    /// existing levels — that is the caller's responsibility.
+    ///
+    /// # Arguments
+    /// - `lot_size`: `Some(increment)` to enable (increment must be > 0), or
+    ///   `None` to disable validation.
+    #[inline]
+    pub fn set_lot_size_opt(&mut self, lot_size: Option<u64>) {
+        self.lot_size = lot_size;
     }
 
     /// Returns the configured lot size, if any.

--- a/src/orderbook/sequencer/mod.rs
+++ b/src/orderbook/sequencer/mod.rs
@@ -14,6 +14,7 @@
 //! - [`crate::orderbook::sequencer::InMemoryJournal`] — in-memory journal implementation for testing
 //! - [`crate::orderbook::sequencer::ReplayEngine`] — deterministic replay engine for event journals
 //! - [`crate::orderbook::sequencer::ReplayError`] — error type for replay operations
+//! - [`crate::orderbook::sequencer::ReplayBookConfig`] — book configuration injected into a fresh book before replay (non-default-config recovery)
 //! - `FileJournal` — memory-mapped file journal implementation (requires `journal` feature)
 //!
 //! # Feature Gate
@@ -44,5 +45,5 @@ pub use in_memory_journal::InMemoryJournal;
 pub use journal::{
     ENTRY_CRC_SIZE, ENTRY_HEADER_SIZE, ENTRY_OVERHEAD, Journal, JournalEntry, JournalReadIter,
 };
-pub use replay::{ReplayEngine, ReplayError, snapshots_match};
+pub use replay::{ReplayBookConfig, ReplayEngine, ReplayError, snapshots_match};
 pub use types::{SequencerCommand, SequencerEvent, SequencerResult};

--- a/src/orderbook/sequencer/replay.rs
+++ b/src/orderbook/sequencer/replay.rs
@@ -9,11 +9,127 @@ use super::error::JournalError;
 use super::journal::Journal;
 use super::types::{SequencerCommand, SequencerEvent, SequencerResult};
 use crate::orderbook::clock::Clock;
+use crate::orderbook::fees::FeeSchedule;
+use crate::orderbook::stp::STPMode;
 use crate::orderbook::{OrderBook, OrderBookError, OrderBookSnapshot};
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 use std::sync::Arc;
 use thiserror::Error;
+
+/// Book configuration injected into a fresh [`OrderBook`] before replay so
+/// that a journal produced by a **non-default-config** book reconstructs to
+/// the same structure.
+///
+/// The plain [`ReplayEngine::replay_from`] / [`ReplayEngine::replay_from_with_clock`]
+/// entry points build the target book with all configuration left at its
+/// defaults (`tick_size` / `lot_size` / `min_order_size` / `max_order_size`
+/// = `None`, `stp_mode` = [`STPMode::None`], `fee_schedule` = `None`). A book
+/// that used any of these — for example a `MarketOrderByAmount` that rounds
+/// per level under a `lot_size`, a self-cross prevented live by STP, or fees —
+/// would replay into a **structurally different** book, so `snapshots_match`
+/// can fail at verify and the recovered state would be wrong.
+///
+/// To recover such a book deterministically, carry the original configuration
+/// alongside the journal (it is the same set of fields persisted in
+/// [`OrderBookSnapshotPackage`](crate::OrderBookSnapshot)'s package form) and
+/// replay through a `*_with_config` variant
+/// ([`ReplayEngine::replay_from_with_config`] /
+/// [`ReplayEngine::replay_from_with_clock_and_config`]).
+///
+/// The configuration is supplied by the **caller** — replay does not read it
+/// from the journal, so the on-disk journal format is unchanged and
+/// `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` is not bumped.
+///
+/// `Default` yields the all-defaults configuration, equivalent to the plain
+/// replay entry points.
+#[derive(Debug, Clone, Default)]
+pub struct ReplayBookConfig {
+    /// Fee schedule the source book used, or `None` for no fees. Applied via
+    /// [`OrderBook::set_fee_schedule`].
+    pub fee_schedule: Option<FeeSchedule>,
+
+    /// Self-trade prevention mode the source book used. [`STPMode::None`]
+    /// (the default) disables STP. Applied via [`OrderBook::set_stp_mode`].
+    pub stp_mode: STPMode,
+
+    /// Tick size (minimum price increment) the source book used, or `None`
+    /// for no tick validation. Applied via [`OrderBook::set_tick_size_opt`].
+    pub tick_size: Option<u128>,
+
+    /// Lot size (minimum quantity increment) the source book used, or `None`
+    /// for no lot validation / rounding. Applied via
+    /// [`OrderBook::set_lot_size_opt`].
+    pub lot_size: Option<u64>,
+
+    /// Minimum order size the source book used, or `None` for no minimum.
+    /// Applied via [`OrderBook::set_min_order_size`] only when `Some`.
+    pub min_order_size: Option<u64>,
+
+    /// Maximum order size the source book used, or `None` for no maximum.
+    /// Applied via [`OrderBook::set_max_order_size`] only when `Some`.
+    pub max_order_size: Option<u64>,
+}
+
+impl ReplayBookConfig {
+    /// Creates a [`ReplayBookConfig`] from its six fields.
+    ///
+    /// Equivalent to building the struct with public-field syntax; provided so
+    /// callers can construct the carrier without naming every field at the call
+    /// site. Use [`ReplayBookConfig::default`] for the all-defaults case.
+    ///
+    /// # Arguments
+    ///
+    /// * `fee_schedule` — fee schedule the source book used, or `None`
+    /// * `stp_mode` — self-trade prevention mode the source book used
+    /// * `tick_size` — tick size the source book used, or `None`
+    /// * `lot_size` — lot size the source book used, or `None`
+    /// * `min_order_size` — minimum order size the source book used, or `None`
+    /// * `max_order_size` — maximum order size the source book used, or `None`
+    #[must_use]
+    pub fn new(
+        fee_schedule: Option<FeeSchedule>,
+        stp_mode: STPMode,
+        tick_size: Option<u128>,
+        lot_size: Option<u64>,
+        min_order_size: Option<u64>,
+        max_order_size: Option<u64>,
+    ) -> Self {
+        Self {
+            fee_schedule,
+            stp_mode,
+            tick_size,
+            lot_size,
+            min_order_size,
+            max_order_size,
+        }
+    }
+
+    /// Applies this configuration to a freshly-constructed `book` in place,
+    /// before any journal events are replayed into it.
+    ///
+    /// `fee_schedule`, `stp_mode`, `tick_size`, and `lot_size` are applied
+    /// unconditionally (a `None` / [`STPMode::None`] value resets the field to
+    /// its default, which is a no-op on a fresh book). `min_order_size` and
+    /// `max_order_size` are applied only when `Some`, mirroring the existing
+    /// `set_min_order_size` / `set_max_order_size` setters which take a bare
+    /// value rather than an `Option`.
+    fn apply_to<T>(&self, book: &mut OrderBook<T>)
+    where
+        T: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync + Default + 'static,
+    {
+        book.set_fee_schedule(self.fee_schedule);
+        book.set_stp_mode(self.stp_mode);
+        book.set_tick_size_opt(self.tick_size);
+        book.set_lot_size_opt(self.lot_size);
+        if let Some(min) = self.min_order_size {
+            book.set_min_order_size(min);
+        }
+        if let Some(max) = self.max_order_size {
+            book.set_max_order_size(max);
+        }
+    }
+}
 
 /// Errors that can occur during journal replay.
 #[derive(Debug, Error)]
@@ -91,6 +207,19 @@ where
     /// For deterministic replay with a custom clock, see
     /// [`Self::replay_from_with_clock`].
     ///
+    /// # Configuration
+    ///
+    /// This entry point builds the target book with **all configuration at its
+    /// defaults** (`tick_size` / `lot_size` / `min_order_size` /
+    /// `max_order_size` = `None`, `stp_mode` = [`STPMode::None`],
+    /// `fee_schedule` = `None`). It is therefore only valid for replaying a
+    /// journal that was produced by a **default-config** book. A book that used
+    /// tick / lot / STP / fees must be replayed through
+    /// [`Self::replay_from_with_config`] (or
+    /// [`Self::replay_from_with_clock_and_config`]) with the matching
+    /// [`ReplayBookConfig`], or the reconstructed state will diverge from the
+    /// original (and `snapshots_match` will report a mismatch).
+    ///
     /// # Arguments
     ///
     /// * `journal` — the event source
@@ -154,6 +283,57 @@ where
         Ok((book, last_applied_seq))
     }
 
+    /// Like [`Self::replay_from`] but injects a caller-supplied
+    /// [`ReplayBookConfig`] into the fresh book **before** any events are
+    /// replayed.
+    ///
+    /// This is the entry point for recovering a **non-default-config** book:
+    /// the configuration (fees, STP, tick / lot / min / max order size) is
+    /// applied to the target book so that a journal produced under that
+    /// configuration reconstructs to the same structure and passes
+    /// `snapshots_match` against the original. The configuration is supplied by
+    /// the caller — it is not read from the journal, so the journal format is
+    /// unchanged.
+    ///
+    /// For byte-identical timestamp reproduction (e.g. replay tests, or
+    /// disaster-recovery that must match engine-assigned timestamps), use
+    /// [`Self::replay_from_with_clock_and_config`].
+    ///
+    /// # Arguments
+    ///
+    /// * `journal` — the event source
+    /// * `from_sequence` — first sequence number to include (inclusive); pass `0` for full replay
+    /// * `symbol` — symbol used to create the fresh OrderBook
+    /// * `config` — configuration the source book used, applied before replay
+    ///
+    /// # Errors
+    ///
+    /// Same as [`replay_from`](Self::replay_from).
+    #[must_use = "replay result carries the reconstructed book and the last applied sequence"]
+    pub fn replay_from_with_config(
+        journal: &impl Journal<T>,
+        from_sequence: u64,
+        symbol: &str,
+        config: &ReplayBookConfig,
+    ) -> Result<(OrderBook<T>, u64), ReplayError> {
+        let last_seq = match journal.last_sequence() {
+            Some(seq) => seq,
+            None => return Err(ReplayError::EmptyJournal),
+        };
+
+        if from_sequence > last_seq {
+            return Err(ReplayError::InvalidSequence {
+                from_sequence,
+                last_sequence: last_seq,
+            });
+        }
+
+        let mut book = OrderBook::new(symbol);
+        config.apply_to(&mut book);
+        let last_applied_seq = Self::replay_into(&book, journal, from_sequence, |_, _| {})?;
+        Ok((book, last_applied_seq))
+    }
+
     /// Like [`Self::replay_from`] but injects a caller-supplied [`Clock`] into
     /// the reconstructed book.
     ///
@@ -164,6 +344,14 @@ where
     /// replay, or a [`crate::orderbook::clock::MonotonicClock`] for
     /// production disaster-recovery where wall-clock timestamps are
     /// acceptable.
+    ///
+    /// # Configuration
+    ///
+    /// Like [`Self::replay_from`], this builds the target book with **all
+    /// configuration at its defaults** and is only valid for a default-config
+    /// source book. To recover a book that used tick / lot / STP / fees
+    /// deterministically, use [`Self::replay_from_with_clock_and_config`] with
+    /// the matching [`ReplayBookConfig`].
     ///
     /// # Arguments
     ///
@@ -227,6 +415,55 @@ where
 
         let book = OrderBook::with_clock(symbol, clock);
         let last_applied_seq = Self::replay_into(&book, journal, from_sequence, progress)?;
+        Ok((book, last_applied_seq))
+    }
+
+    /// Like [`Self::replay_from_with_clock`] but also injects a caller-supplied
+    /// [`ReplayBookConfig`] into the fresh book **before** any events are
+    /// replayed.
+    ///
+    /// This is the canonical entry point for byte-identical, deterministic
+    /// recovery of a **non-default-config** book: the injected [`Clock`]
+    /// reproduces engine-assigned timestamps and the [`ReplayBookConfig`]
+    /// reproduces the structural configuration (fees, STP, tick / lot / min /
+    /// max order size), so the reconstructed book passes `snapshots_match`
+    /// against the original. The configuration is supplied by the caller — it
+    /// is not read from the journal, so the journal format is unchanged.
+    ///
+    /// # Arguments
+    ///
+    /// * `journal` — the event source
+    /// * `from_sequence` — first sequence number to include (inclusive); pass `0` for full replay
+    /// * `symbol` — symbol used to create the fresh OrderBook
+    /// * `clock` — pre-constructed clock shared across the reconstructed book
+    /// * `config` — configuration the source book used, applied before replay
+    ///
+    /// # Errors
+    ///
+    /// Same as [`replay_from`](Self::replay_from).
+    #[must_use = "replay result carries the reconstructed book and the last applied sequence"]
+    pub fn replay_from_with_clock_and_config(
+        journal: &impl Journal<T>,
+        from_sequence: u64,
+        symbol: &str,
+        clock: Arc<dyn Clock>,
+        config: &ReplayBookConfig,
+    ) -> Result<(OrderBook<T>, u64), ReplayError> {
+        let last_seq = match journal.last_sequence() {
+            Some(seq) => seq,
+            None => return Err(ReplayError::EmptyJournal),
+        };
+
+        if from_sequence > last_seq {
+            return Err(ReplayError::InvalidSequence {
+                from_sequence,
+                last_sequence: last_seq,
+            });
+        }
+
+        let mut book = OrderBook::with_clock(symbol, clock);
+        config.apply_to(&mut book);
+        let last_applied_seq = Self::replay_into(&book, journal, from_sequence, |_, _| {})?;
         Ok((book, last_applied_seq))
     }
 
@@ -712,6 +949,89 @@ mod tests {
             snapshots_match(&live_snap, &replayed_snap),
             "live and replayed snapshots must match after notional market order"
         );
+    }
+
+    /// #101: `replay_from_with_config` applies every config field to the fresh
+    /// book before replaying. A `Default` config leaves the book at defaults;
+    /// a populated config is reflected field-for-field.
+    #[test]
+    fn test_replay_from_with_config_applies_every_field() {
+        let journal: InMemoryJournal<()> = InMemoryJournal::new();
+        let ev = make_add_event(0, Id::new_uuid(), 100, 10, Side::Buy);
+        assert!(journal.append(&ev).is_ok());
+
+        // Default config => all-defaults book.
+        let (book, _) = ReplayEngine::<()>::replay_from_with_config(
+            &journal,
+            0,
+            "TEST",
+            &ReplayBookConfig::default(),
+        )
+        .expect("default config replay");
+        assert_eq!(book.fee_schedule(), None);
+        assert_eq!(book.stp_mode(), STPMode::None);
+        assert_eq!(book.tick_size(), None);
+        assert_eq!(book.lot_size(), None);
+        assert_eq!(book.min_order_size(), None);
+        assert_eq!(book.max_order_size(), None);
+
+        // Populated config => reflected on the reconstructed book. Price 100 is
+        // on the 10-tick grid and qty 10 is a 5-lot multiple within [1, 1000].
+        let fee = FeeSchedule::new(-2, 5);
+        let config = ReplayBookConfig::new(
+            Some(fee),
+            STPMode::None,
+            Some(10),
+            Some(5),
+            Some(1),
+            Some(1_000),
+        );
+        let (book, _) = ReplayEngine::<()>::replay_from_with_config(&journal, 0, "TEST", &config)
+            .expect("populated config replay");
+        assert_eq!(book.fee_schedule(), Some(fee));
+        assert_eq!(book.tick_size(), Some(10));
+        assert_eq!(book.lot_size(), Some(5));
+        assert_eq!(book.min_order_size(), Some(1));
+        assert_eq!(book.max_order_size(), Some(1_000));
+    }
+
+    /// #101: the `*_with_config` variants share the pre-checks of the plain
+    /// entry points — an empty journal is `EmptyJournal`, an out-of-range
+    /// `from_sequence` is `InvalidSequence`.
+    #[test]
+    fn test_replay_with_config_pre_checks_match_plain_variants() {
+        let empty: InMemoryJournal<()> = InMemoryJournal::new();
+        assert!(matches!(
+            ReplayEngine::<()>::replay_from_with_config(
+                &empty,
+                0,
+                "TEST",
+                &ReplayBookConfig::default()
+            ),
+            Err(ReplayError::EmptyJournal)
+        ));
+
+        let journal: InMemoryJournal<()> = InMemoryJournal::new();
+        let ev = make_add_event(0, Id::new_uuid(), 100, 10, Side::Buy);
+        assert!(journal.append(&ev).is_ok());
+        let clock: Arc<dyn Clock> = Arc::new(StubClock::new());
+        match ReplayEngine::<()>::replay_from_with_clock_and_config(
+            &journal,
+            5,
+            "TEST",
+            clock,
+            &ReplayBookConfig::default(),
+        ) {
+            Err(ReplayError::InvalidSequence {
+                from_sequence,
+                last_sequence,
+            }) => {
+                assert_eq!(from_sequence, 5);
+                assert_eq!(last_sequence, 0);
+            }
+            Err(other) => panic!("expected InvalidSequence, got {other:?}"),
+            Ok(_) => panic!("expected InvalidSequence, got Ok(_)"),
+        }
     }
 
     #[test]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -78,8 +78,8 @@ pub use crate::orderbook::nats_book_change::{
 #[cfg(feature = "journal")]
 pub use crate::orderbook::sequencer::FileJournal;
 pub use crate::orderbook::sequencer::{
-    InMemoryJournal, Journal, JournalEntry, JournalError, JournalReadIter, ReplayEngine,
-    ReplayError, SequencerCommand, SequencerEvent, SequencerResult, snapshots_match,
+    InMemoryJournal, Journal, JournalEntry, JournalError, JournalReadIter, ReplayBookConfig,
+    ReplayEngine, ReplayError, SequencerCommand, SequencerEvent, SequencerResult, snapshots_match,
 };
 
 // Utility functions

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -20,6 +20,7 @@ mod operations_coverage_tests_extended;
 mod order_state_tests;
 mod private_coverage_tests;
 mod reject_reason_tests;
+mod replay_config_tests;
 mod replay_coverage_tests;
 #[cfg(feature = "journal")]
 mod replay_determinism;

--- a/tests/unit/replay_config_tests.rs
+++ b/tests/unit/replay_config_tests.rs
@@ -1,0 +1,430 @@
+/******************************************************************************
+   Unit tests for issue #101 — caller-injected book config on replay.
+
+   A journal produced by a non-default-config book (lot_size rounding, STP,
+   fees) must be replayed through a `*_with_config` variant with the matching
+   `ReplayBookConfig`, or the reconstructed book diverges structurally. These
+   tests demonstrate the divergence without config and the parity with it.
+******************************************************************************/
+
+use orderbook_rs::orderbook::sequencer::{
+    InMemoryJournal, Journal, ReplayBookConfig, ReplayEngine, SequencerCommand, SequencerEvent,
+    SequencerResult, snapshots_match,
+};
+use orderbook_rs::orderbook::trade::TradeResult;
+use orderbook_rs::{Clock, FeeSchedule, OrderBook, STPMode, StubClock};
+use pricelevel::{
+    Hash32, Id, MatchResult, OrderType, Price, Quantity, Side, TimeInForce, TimestampMs,
+};
+use std::sync::Arc;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+fn make_add_event(
+    seq: u64,
+    id: Id,
+    price: u128,
+    qty: u64,
+    side: Side,
+    user_id: Hash32,
+) -> SequencerEvent<()> {
+    let order = OrderType::Standard {
+        id,
+        price: Price::new(price),
+        quantity: Quantity::new(qty),
+        side,
+        time_in_force: TimeInForce::Gtc,
+        user_id,
+        timestamp: TimestampMs::new(0),
+        extra_fields: (),
+    };
+    SequencerEvent {
+        sequence_num: seq,
+        timestamp_ns: 0,
+        command: SequencerCommand::AddOrder(order),
+        result: SequencerResult::OrderAdded { order_id: id },
+    }
+}
+
+fn make_market_by_amount_event(
+    seq: u64,
+    taker_id: Id,
+    amount: u128,
+    side: Side,
+) -> SequencerEvent<()> {
+    SequencerEvent {
+        sequence_num: seq,
+        timestamp_ns: 0,
+        command: SequencerCommand::MarketOrderByAmount {
+            id: taker_id,
+            amount,
+            side,
+        },
+        // Informational only — replay re-executes the command. Use
+        // TradeExecuted so the journal entry is not skipped as Rejected.
+        result: SequencerResult::TradeExecuted {
+            trade_result: TradeResult::new(
+                "TEST".to_string(),
+                MatchResult::new(taker_id, Quantity::new(0)),
+            ),
+        },
+    }
+}
+
+fn stub_clock() -> Arc<dyn Clock> {
+    Arc::new(StubClock::starting_at(0))
+}
+
+// ─── Round-trip: ReplayBookConfig application on a fresh book ────────────────
+
+/// A fresh book plus the `set_*` calls `ReplayBookConfig` performs must yield a
+/// book whose configuration matches the carrier field-for-field. This is the
+/// pure application round-trip independent of any replay.
+#[test]
+fn replay_book_config_applies_to_fresh_book() {
+    let fee = FeeSchedule::new(-2, 5);
+    let config = ReplayBookConfig::new(
+        Some(fee),
+        STPMode::CancelTaker,
+        Some(10),
+        Some(5),
+        Some(2),
+        Some(1_000),
+    );
+
+    // Replay applies the config via the `*_with_config` path on a one-event
+    // journal; the reconstructed book must carry the configured fields. The
+    // single add carries a non-zero user id (STP is CancelTaker and bare
+    // orders are rejected with `MissingUserId`), a price on the 10-tick grid,
+    // and a quantity that is a multiple of the 5-lot and within [2, 1000].
+    let journal: InMemoryJournal<()> = InMemoryJournal::new();
+    let id = Id::new_uuid();
+    assert!(
+        journal
+            .append(&make_add_event(
+                0,
+                id,
+                100,
+                10,
+                Side::Buy,
+                Hash32::new([3u8; 32])
+            ))
+            .is_ok()
+    );
+
+    let (book, _) = ReplayEngine::<()>::replay_from_with_config(&journal, 0, "TEST", &config)
+        .expect("config replay should succeed");
+
+    assert_eq!(book.fee_schedule(), Some(fee), "fee schedule injected");
+    assert_eq!(book.stp_mode(), STPMode::CancelTaker, "stp mode injected");
+    assert_eq!(book.tick_size(), Some(10), "tick size injected");
+    assert_eq!(book.lot_size(), Some(5), "lot size injected");
+    assert_eq!(book.min_order_size(), Some(2), "min order size injected");
+    assert_eq!(
+        book.max_order_size(),
+        Some(1_000),
+        "max order size injected"
+    );
+}
+
+/// `ReplayBookConfig::default` leaves a replayed book at all-defaults, matching
+/// the plain `replay_from` entry point.
+#[test]
+fn replay_book_config_default_is_all_defaults() {
+    let journal: InMemoryJournal<()> = InMemoryJournal::new();
+    let id = Id::new_uuid();
+    assert!(
+        journal
+            .append(&make_add_event(0, id, 100, 10, Side::Buy, Hash32::zero()))
+            .is_ok()
+    );
+
+    let (book, _) = ReplayEngine::<()>::replay_from_with_config(
+        &journal,
+        0,
+        "TEST",
+        &ReplayBookConfig::default(),
+    )
+    .expect("default config replay should succeed");
+
+    assert_eq!(book.fee_schedule(), None);
+    assert_eq!(book.stp_mode(), STPMode::None);
+    assert_eq!(book.tick_size(), None);
+    assert_eq!(book.lot_size(), None);
+    assert_eq!(book.min_order_size(), None);
+    assert_eq!(book.max_order_size(), None);
+}
+
+// ─── lot_size divergence / parity via MarketOrderByAmount rounding ──────────
+
+/// Builds the shared journal: one resting ask wall, then a notional market buy
+/// that rounds differently under `lot_size`.
+///
+/// Ask wall: 10 @ 100. Market buy by amount 700 ⇒ 7 base units at price 100.
+/// With `lot_size = 5` the per-level fill rounds **down** to 5, leaving 5 @ 100.
+/// Without lot_size, 7 fill, leaving 3 @ 100. Same journal, divergent residual.
+fn lot_size_journal() -> (InMemoryJournal<()>, u64) {
+    let journal: InMemoryJournal<()> = InMemoryJournal::new();
+    let mut seq = 0u64;
+
+    let ask_id = Id::new_uuid();
+    assert!(
+        journal
+            .append(&make_add_event(
+                seq,
+                ask_id,
+                100,
+                10,
+                Side::Sell,
+                Hash32::zero()
+            ))
+            .is_ok()
+    );
+    seq += 1;
+
+    let taker_id = Id::new_uuid();
+    assert!(
+        journal
+            .append(&make_market_by_amount_event(seq, taker_id, 700, Side::Buy))
+            .is_ok()
+    );
+
+    (journal, seq)
+}
+
+/// The lot-constrained source book leaves a different residual than a
+/// default-config book replaying the same journal — proving the bug: replaying
+/// without the config reconstructs a STRUCTURALLY DIFFERENT book.
+#[test]
+fn lot_size_replay_without_config_diverges() {
+    let (journal, last_seq) = lot_size_journal();
+
+    // Ground-truth: a live book WITH lot_size = 5 driven through the same ops.
+    let mut live = OrderBook::<()>::with_clock("TEST", stub_clock());
+    live.set_lot_size(5);
+    live.add_order(OrderType::Standard {
+        id: Id::new_uuid(),
+        price: Price::new(100),
+        quantity: Quantity::new(10),
+        side: Side::Sell,
+        time_in_force: TimeInForce::Gtc,
+        user_id: Hash32::zero(),
+        timestamp: TimestampMs::new(0),
+        extra_fields: (),
+    })
+    .expect("seed ask");
+    let _ = live.match_market_order_by_amount(Id::new_uuid(), 700, Side::Buy);
+    let live_snap = live.create_snapshot(usize::MAX);
+
+    // Replay WITHOUT config — fresh book has no lot_size, so it takes 7 (not 5).
+    let (replayed, seq) =
+        ReplayEngine::<()>::replay_from_with_clock(&journal, 0, "TEST", stub_clock())
+            .expect("plain replay should succeed");
+    assert_eq!(seq, last_seq);
+    let replayed_snap = replayed.create_snapshot(usize::MAX);
+
+    assert!(
+        !snapshots_match(&live_snap, &replayed_snap),
+        "default-config replay must DIVERGE from a lot-constrained source book"
+    );
+}
+
+/// Replaying the SAME journal through `replay_from_with_clock_and_config` with
+/// the matching `lot_size` reconstructs the original residual exactly —
+/// `snapshots_match` is true only with the config injected.
+#[test]
+fn lot_size_replay_with_config_matches() {
+    let (journal, last_seq) = lot_size_journal();
+
+    // Ground-truth live book WITH lot_size = 5.
+    let mut live = OrderBook::<()>::with_clock("TEST", stub_clock());
+    live.set_lot_size(5);
+    live.add_order(OrderType::Standard {
+        id: Id::new_uuid(),
+        price: Price::new(100),
+        quantity: Quantity::new(10),
+        side: Side::Sell,
+        time_in_force: TimeInForce::Gtc,
+        user_id: Hash32::zero(),
+        timestamp: TimestampMs::new(0),
+        extra_fields: (),
+    })
+    .expect("seed ask");
+    let _ = live.match_market_order_by_amount(Id::new_uuid(), 700, Side::Buy);
+    let live_snap = live.create_snapshot(usize::MAX);
+
+    // Replay WITH the matching config.
+    let config = ReplayBookConfig {
+        lot_size: Some(5),
+        ..ReplayBookConfig::default()
+    };
+    let (replayed, seq) = ReplayEngine::<()>::replay_from_with_clock_and_config(
+        &journal,
+        0,
+        "TEST",
+        stub_clock(),
+        &config,
+    )
+    .expect("config replay should succeed");
+    assert_eq!(seq, last_seq);
+    let replayed_snap = replayed.create_snapshot(usize::MAX);
+
+    assert!(
+        snapshots_match(&live_snap, &replayed_snap),
+        "config-injected replay must match the lot-constrained source book"
+    );
+}
+
+// ─── STP: prevented order is recorded Rejected and skipped on replay ─────────
+
+/// Self-trade prevention surfaces as a rejected command at write time, so a
+/// faithful journal records the prevented order with a `Rejected` result. The
+/// replay engine skips `Rejected` events, so the prevented order never crosses
+/// on replay — independent of whether STP config is injected. This documents
+/// *why* STP, unlike `lot_size`, does not need structural reconstruction: the
+/// non-determinism (the prevention decision) was resolved upstream and baked
+/// into the recorded result, exactly as the replay-determinism rule requires.
+#[test]
+fn stp_prevented_order_recorded_rejected_is_skipped_on_replay() {
+    let user = Hash32::new([7u8; 32]);
+    let journal: InMemoryJournal<()> = InMemoryJournal::new();
+
+    // Resting ask from user U (succeeds even under STP — nothing to cross).
+    let ask_id = Id::new_uuid();
+    assert!(
+        journal
+            .append(&make_add_event(0, ask_id, 100, 10, Side::Sell, user))
+            .is_ok()
+    );
+
+    // Same-user crossing buy: under STP = CancelTaker this was prevented at
+    // write time, so the sequencer recorded it as Rejected.
+    let buy_id = Id::new_uuid();
+    let rejected_buy = SequencerEvent::<()> {
+        sequence_num: 1,
+        timestamp_ns: 0,
+        command: SequencerCommand::AddOrder(OrderType::Standard {
+            id: buy_id,
+            price: Price::new(100),
+            quantity: Quantity::new(10),
+            side: Side::Buy,
+            time_in_force: TimeInForce::Gtc,
+            user_id: user,
+            timestamp: TimestampMs::new(0),
+            extra_fields: (),
+        }),
+        result: SequencerResult::Rejected {
+            reason: "self-trade prevented".to_string(),
+        },
+    };
+    assert!(journal.append(&rejected_buy).is_ok());
+
+    // Ground truth: a live STP book where the second add is prevented. The
+    // resting ask stays in the book.
+    let mut live = OrderBook::<()>::with_clock("TEST", stub_clock());
+    live.set_stp_mode(STPMode::CancelTaker);
+    live.add_order(OrderType::Standard {
+        id: Id::new_uuid(),
+        price: Price::new(100),
+        quantity: Quantity::new(10),
+        side: Side::Sell,
+        time_in_force: TimeInForce::Gtc,
+        user_id: user,
+        timestamp: TimestampMs::new(0),
+        extra_fields: (),
+    })
+    .expect("seed ask");
+    // The crossing buy is rejected by STP — tolerate the error, the ask rests.
+    let _ = live.add_order(OrderType::Standard {
+        id: Id::new_uuid(),
+        price: Price::new(100),
+        quantity: Quantity::new(10),
+        side: Side::Buy,
+        time_in_force: TimeInForce::Gtc,
+        user_id: user,
+        timestamp: TimestampMs::new(0),
+        extra_fields: (),
+    });
+    let live_snap = live.create_snapshot(usize::MAX);
+
+    // Replaying WITH the matching STP config skips the Rejected buy and rebuilds
+    // the resting ask, matching the live book.
+    let config = ReplayBookConfig {
+        stp_mode: STPMode::CancelTaker,
+        ..ReplayBookConfig::default()
+    };
+    let (replayed, seq) = ReplayEngine::<()>::replay_from_with_clock_and_config(
+        &journal,
+        0,
+        "TEST",
+        stub_clock(),
+        &config,
+    )
+    .expect("config replay should succeed");
+    assert_eq!(
+        seq, 0,
+        "only the ask (seq 0) is applied; the buy is skipped"
+    );
+    let replayed_snap = replayed.create_snapshot(usize::MAX);
+
+    assert!(
+        snapshots_match(&live_snap, &replayed_snap),
+        "STP-config replay must match the STP-protected source book"
+    );
+}
+
+// ─── Config injection is complete and harmless to non-structural fields ─────
+
+/// Injecting a fully-populated config (fees + STP-None + wide min/max) on top
+/// of the structural `lot_size` still reconstructs the lot-constrained residual
+/// exactly — extra non-structural configuration does not perturb parity. This
+/// guards against `apply_to` mis-wiring a field or rejecting a valid order.
+#[test]
+fn full_config_injection_preserves_lot_size_parity() {
+    let (journal, last_seq) = lot_size_journal();
+
+    // Ground-truth live book WITH the same full config.
+    let fee = FeeSchedule::new(-2, 5);
+    let mut live = OrderBook::<()>::with_clock("TEST", stub_clock());
+    live.set_lot_size(5);
+    live.set_fee_schedule(Some(fee));
+    live.set_min_order_size(1);
+    live.set_max_order_size(1_000);
+    live.add_order(OrderType::Standard {
+        id: Id::new_uuid(),
+        price: Price::new(100),
+        quantity: Quantity::new(10),
+        side: Side::Sell,
+        time_in_force: TimeInForce::Gtc,
+        user_id: Hash32::zero(),
+        timestamp: TimestampMs::new(0),
+        extra_fields: (),
+    })
+    .expect("seed ask");
+    let _ = live.match_market_order_by_amount(Id::new_uuid(), 700, Side::Buy);
+    let live_snap = live.create_snapshot(usize::MAX);
+
+    let config = ReplayBookConfig::new(
+        Some(fee),
+        STPMode::None,
+        None,
+        Some(5),
+        Some(1),
+        Some(1_000),
+    );
+    let (replayed, seq) = ReplayEngine::<()>::replay_from_with_clock_and_config(
+        &journal,
+        0,
+        "TEST",
+        stub_clock(),
+        &config,
+    )
+    .expect("config replay should succeed");
+    assert_eq!(seq, last_seq);
+    let replayed_snap = replayed.create_snapshot(usize::MAX);
+
+    assert!(
+        snapshots_match(&live_snap, &replayed_snap),
+        "full config injection must preserve lot_size parity"
+    );
+}


### PR DESCRIPTION
## Summary

Every public replay entry built the target book with `OrderBook::new` /
`with_clock`, leaving `tick_size` / `lot_size` / `min/max_order_size` / `stp_mode`
/ `fee_schedule` unset. A journal produced by a book that used those rebuilt a
**structurally different** book (e.g. `MarketOrderByAmount` consumes a different
quantity under lot rounding), so `snapshots_match` could fail at verify and the
recovered state was wrong. Maintainer decision: **config is passed by the
caller** — no journal-format change.

## Change

- **`ReplayBookConfig`** — a `Debug, Clone, Default` carrier with the six config
  fields mirroring `OrderBookSnapshotPackage`; re-exported at the crate root and
  prelude.
- **`replay_from_with_config`** / **`replay_from_with_clock_and_config`** — build
  the fresh book, then `ReplayBookConfig::apply_to(&mut book)` **before**
  `replay_into`, so every replayed event sees the right config.
- Two new `Option`-taking book setters `set_tick_size_opt` / `set_lot_size_opt`
  (add the clear-to-`None` capability; the existing value-setters are untouched —
  non-breaking).
- Documented that default-config replay is only valid for default-config books.

## Reviews

- **determinism-auditor**: all PASS / replay-safe — config is applied before the
  first event, `apply_to` is a deterministic fixed sequence of scalar setters
  (idempotent; `default()` == plain `replay_from`), and the lot_size
  divergence/parity proof is sound (same journal → `3@100` without config vs
  `5@100` with `lot_size=5`). STP reasoning confirmed: an STP-prevented order is
  journaled `Rejected` and skipped identically on replay, so STP config affects
  what gets journaled live, not how a journaled command replays.

## Tests

- `lot_size_replay_without_config_diverges` (`!snapshots_match`) +
  `lot_size_replay_with_config_matches` (`snapshots_match`) on the **same** journal
  — proves config genuinely changes the replayed structure and injecting it
  restores parity (shared-clock-independent via per-call `StubClock`).
- `stp_prevented_order_recorded_rejected_is_skipped_on_replay`,
  `full_config_injection_preserves_lot_size_parity`, and a `ReplayBookConfig`
  round-trip.
- `cargo test --all-features` — 1168 pass. clippy `-D warnings` / fmt /
  `--release --all-features` — clean.

Closes #101