### PR TITLE
fix(manager): add_book must not silently overwrite an existing book (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`add_book` refuses to overwrite an existing book (#105, breaking).** Both
+  `BookManagerStd` and `BookManagerTokio` did `self.books.insert(symbol, book)` and
+  ignored the returned `Option`, so a second `add_book` for the same symbol
+  silently replaced the first book — dropping all its resting orders and order
+  locations with no warning. `BookManager::add_book` now returns
+  `Result<(), ManagerError>` and returns the new `ManagerError::BookAlreadyExists { symbol }`
+  instead of overwriting; both managers stay in parity. Breaking: callers must
+  handle the `Result` (the trait method signature changed) — permitted under the
+  0.8 → 0.9 window.
 - **Wire `NewOrder` rejects `account_id == 0` (#103).** `TryFrom<&NewOrderWire>`
   encoded the numeric `account_id` into the low 8 bytes of a `Hash32` to build the
   `user_id`, with a comment claiming it avoided colliding with `Hash32::zero()`

--- a/src/orderbook/error.rs
+++ b/src/orderbook/error.rs
@@ -519,6 +519,14 @@ impl Clone for OrderBookError {
 pub enum ManagerError {
     /// Trade processor has already been started
     ProcessorAlreadyStarted,
+
+    /// An order book already exists for the symbol; `add_book` refuses to
+    /// overwrite it (which would silently drop the existing book's resting
+    /// orders).
+    BookAlreadyExists {
+        /// The symbol that already has a book.
+        symbol: String,
+    },
 }
 
 impl fmt::Display for ManagerError {
@@ -526,6 +534,9 @@ impl fmt::Display for ManagerError {
         match self {
             ManagerError::ProcessorAlreadyStarted => {
                 write!(f, "trade processor already started")
+            }
+            ManagerError::BookAlreadyExists { symbol } => {
+                write!(f, "order book already exists for symbol: {symbol}")
             }
         }
     }

--- a/src/orderbook/manager.rs
+++ b/src/orderbook/manager.rs
@@ -27,7 +27,13 @@ where
     T: Clone + Send + Sync + Default + 'static,
 {
     /// Add a new order book for a symbol with an automatically configured trade listener.
-    fn add_book(&mut self, symbol: &str);
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ManagerError::BookAlreadyExists`] if a book already exists for
+    /// `symbol` — `add_book` refuses to overwrite it, which would silently drop
+    /// the existing book's resting orders and order locations.
+    fn add_book(&mut self, symbol: &str) -> Result<(), ManagerError>;
 
     /// Get a reference to an order book by symbol.
     fn get_book(&self, symbol: &str) -> Option<&OrderBook<T>>;
@@ -159,9 +165,10 @@ where
     /// use orderbook_rs::orderbook::manager::{BookManager, BookManagerStd};
     /// use pricelevel::{Id, Side, TimeInForce};
     ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut mgr: BookManagerStd<()> = BookManagerStd::new();
-    /// mgr.add_book("BTC/USD");
-    /// mgr.add_book("ETH/USD");
+    /// mgr.add_book("BTC/USD")?;
+    /// mgr.add_book("ETH/USD")?;
     ///
     /// if let Some(book) = mgr.get_book("BTC/USD") {
     ///     book.add_limit_order(Id::new_uuid(), 100, 10, Side::Buy, TimeInForce::Gtc, None).ok();
@@ -169,6 +176,8 @@ where
     ///
     /// let results = mgr.cancel_all_across_books();
     /// assert!(results.contains_key("BTC/USD"));
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn cancel_all_across_books(&self) -> HashMap<String, MassCancelResult> {
@@ -216,7 +225,13 @@ impl<T> BookManager<T> for BookManagerStd<T>
 where
     T: Clone + Send + Sync + Default + 'static,
 {
-    fn add_book(&mut self, symbol: &str) {
+    fn add_book(&mut self, symbol: &str) -> Result<(), ManagerError> {
+        if self.books.contains_key(symbol) {
+            return Err(ManagerError::BookAlreadyExists {
+                symbol: symbol.to_string(),
+            });
+        }
+
         let sender = self.trade_sender.clone();
         let symbol_clone = symbol.to_string();
 
@@ -236,6 +251,7 @@ where
         let book = OrderBook::with_trade_listener(symbol, trade_listener);
         self.books.insert(symbol.to_string(), book);
         info!("Added order book for symbol: {}", symbol);
+        Ok(())
     }
 
     fn get_book(&self, symbol: &str) -> Option<&OrderBook<T>> {
@@ -426,7 +442,13 @@ impl<T> BookManager<T> for BookManagerTokio<T>
 where
     T: Clone + Send + Sync + Default + 'static,
 {
-    fn add_book(&mut self, symbol: &str) {
+    fn add_book(&mut self, symbol: &str) -> Result<(), ManagerError> {
+        if self.books.contains_key(symbol) {
+            return Err(ManagerError::BookAlreadyExists {
+                symbol: symbol.to_string(),
+            });
+        }
+
         let sender = self.trade_sender.clone();
         let symbol_clone = symbol.to_string();
 
@@ -446,6 +468,7 @@ where
         let book = OrderBook::with_trade_listener(symbol, trade_listener);
         self.books.insert(symbol.to_string(), book);
         info!("Added order book for symbol: {}", symbol);
+        Ok(())
     }
 
     fn get_book(&self, symbol: &str) -> Option<&OrderBook<T>> {

--- a/tests/unit/book_manager_cross_cancel_tests.rs
+++ b/tests/unit/book_manager_cross_cancel_tests.rs
@@ -12,8 +12,8 @@ mod tests_cross_book_cancel {
     #[test]
     fn std_cancel_all_across_books() {
         let mut mgr: BookManagerStd<()> = BookManagerStd::new();
-        mgr.add_book("BTC/USD");
-        mgr.add_book("ETH/USD");
+        mgr.add_book("BTC/USD").expect("add book");
+        mgr.add_book("ETH/USD").expect("add book");
 
         if let Some(book) = mgr.get_book("BTC/USD") {
             book.add_limit_order(Id::new_uuid(), 100, 10, Side::Buy, TimeInForce::Gtc, None)
@@ -40,8 +40,8 @@ mod tests_cross_book_cancel {
     #[test]
     fn std_cancel_all_across_empty_books() {
         let mut mgr: BookManagerStd<()> = BookManagerStd::new();
-        mgr.add_book("BTC/USD");
-        mgr.add_book("ETH/USD");
+        mgr.add_book("BTC/USD").expect("add book");
+        mgr.add_book("ETH/USD").expect("add book");
 
         let results = mgr.cancel_all_across_books();
         assert_eq!(results.len(), 2);
@@ -60,8 +60,8 @@ mod tests_cross_book_cancel {
     #[test]
     fn std_cancel_by_user_across_books() {
         let mut mgr: BookManagerStd<()> = BookManagerStd::new();
-        mgr.add_book("BTC/USD");
-        mgr.add_book("ETH/USD");
+        mgr.add_book("BTC/USD").expect("add book");
+        mgr.add_book("ETH/USD").expect("add book");
 
         let user_a = Hash32::from([1u8; 32]);
         let user_b = Hash32::from([2u8; 32]);
@@ -114,8 +114,8 @@ mod tests_cross_book_cancel {
     #[test]
     fn std_cancel_by_side_across_books() {
         let mut mgr: BookManagerStd<()> = BookManagerStd::new();
-        mgr.add_book("BTC/USD");
-        mgr.add_book("ETH/USD");
+        mgr.add_book("BTC/USD").expect("add book");
+        mgr.add_book("ETH/USD").expect("add book");
 
         if let Some(book) = mgr.get_book("BTC/USD") {
             book.add_limit_order(Id::new_uuid(), 100, 10, Side::Buy, TimeInForce::Gtc, None)
@@ -152,8 +152,8 @@ mod tests_cross_book_cancel {
     #[test]
     fn tokio_cancel_all_across_books() {
         let mut mgr: BookManagerTokio<()> = BookManagerTokio::new();
-        mgr.add_book("BTC/USD");
-        mgr.add_book("ETH/USD");
+        mgr.add_book("BTC/USD").expect("add book");
+        mgr.add_book("ETH/USD").expect("add book");
 
         if let Some(book) = mgr.get_book("BTC/USD") {
             book.add_limit_order(Id::new_uuid(), 100, 10, Side::Buy, TimeInForce::Gtc, None)
@@ -174,7 +174,7 @@ mod tests_cross_book_cancel {
     #[test]
     fn tokio_cancel_by_user_across_books() {
         let mut mgr: BookManagerTokio<()> = BookManagerTokio::new();
-        mgr.add_book("BTC/USD");
+        mgr.add_book("BTC/USD").expect("add book");
 
         let user = Hash32::from([7u8; 32]);
 
@@ -198,7 +198,7 @@ mod tests_cross_book_cancel {
     #[test]
     fn tokio_cancel_by_side_across_books() {
         let mut mgr: BookManagerTokio<()> = BookManagerTokio::new();
-        mgr.add_book("BTC/USD");
+        mgr.add_book("BTC/USD").expect("add book");
 
         if let Some(book) = mgr.get_book("BTC/USD") {
             book.add_limit_order(Id::new_uuid(), 100, 10, Side::Buy, TimeInForce::Gtc, None)

--- a/tests/unit/integration_workflow_tests.rs
+++ b/tests/unit/integration_workflow_tests.rs
@@ -282,7 +282,7 @@ fn bincode_serializer_trade_result_round_trip() {
 #[test]
 fn book_manager_multi_book_operations() {
     let mut mgr: BookManagerStd<()> = BookManagerStd::new();
-    mgr.add_book("BTC/USD");
+    mgr.add_book("BTC/USD").expect("add book");
 
     // Place a sell order
     let book = mgr.get_book("BTC/USD").expect("BTC/USD book must exist");
@@ -304,8 +304,8 @@ fn book_manager_multi_book_operations() {
 #[test]
 fn book_manager_multi_book_independent_state() {
     let mut mgr: BookManagerStd<()> = BookManagerStd::new();
-    mgr.add_book("BTC/USD");
-    mgr.add_book("ETH/USD");
+    mgr.add_book("BTC/USD").expect("add book");
+    mgr.add_book("ETH/USD").expect("add book");
 
     let btc_book = mgr.get_book("BTC/USD").expect("BTC/USD must exist");
     let _ = btc_book.add_limit_order(Id::new_uuid(), 50000, 1, Side::Buy, TimeInForce::Gtc, None);

--- a/tests/unit/manager_coverage_tests.rs
+++ b/tests/unit/manager_coverage_tests.rs
@@ -19,7 +19,7 @@ fn std_default_creates_empty_manager() {
 #[test]
 fn std_add_and_get_book() {
     let mut mgr: BookManagerStd<()> = BookManagerStd::new();
-    mgr.add_book("BTC/USD");
+    mgr.add_book("BTC/USD").expect("add book");
     assert!(mgr.has_book("BTC/USD"));
     assert!(!mgr.has_book("ETH/USD"));
     assert_eq!(mgr.book_count(), 1);
@@ -44,7 +44,7 @@ fn std_get_book_mut_returns_none_for_unknown() {
 #[test]
 fn std_get_book_returns_valid_ref() {
     let mut mgr: BookManagerStd<()> = BookManagerStd::new();
-    mgr.add_book("ETH/USD");
+    mgr.add_book("ETH/USD").expect("add book");
     let book = mgr.get_book("ETH/USD");
     assert!(book.is_some());
 }
@@ -52,7 +52,7 @@ fn std_get_book_returns_valid_ref() {
 #[test]
 fn std_get_book_mut_allows_modification() {
     let mut mgr: BookManagerStd<()> = BookManagerStd::new();
-    mgr.add_book("ETH/USD");
+    mgr.add_book("ETH/USD").expect("add book");
     let book = mgr.get_book_mut("ETH/USD").expect("book must exist");
     let _ = book.add_limit_order(Id::new_uuid(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
     let snap = book.create_snapshot(usize::MAX);
@@ -62,7 +62,7 @@ fn std_get_book_mut_allows_modification() {
 #[test]
 fn std_remove_book_returns_some_when_exists() {
     let mut mgr: BookManagerStd<()> = BookManagerStd::new();
-    mgr.add_book("BTC/USD");
+    mgr.add_book("BTC/USD").expect("add book");
     let removed = mgr.remove_book("BTC/USD");
     assert!(removed.is_some());
     assert_eq!(mgr.book_count(), 0);
@@ -105,8 +105,8 @@ fn std_start_trade_processor_fails_second_time() {
 #[test]
 fn std_add_order_and_cancel_across_books() {
     let mut mgr: BookManagerStd<()> = BookManagerStd::new();
-    mgr.add_book("BTC/USD");
-    mgr.add_book("ETH/USD");
+    mgr.add_book("BTC/USD").expect("add book");
+    mgr.add_book("ETH/USD").expect("add book");
 
     let btc = mgr.get_book("BTC/USD").expect("BTC book must exist");
     let _ = btc.add_limit_order(Id::new_uuid(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
@@ -133,7 +133,7 @@ fn std_add_order_and_cancel_across_books() {
 #[test]
 fn std_cancel_by_user_across_books() {
     let mut mgr: BookManagerStd<()> = BookManagerStd::new();
-    mgr.add_book("BTC/USD");
+    mgr.add_book("BTC/USD").expect("add book");
 
     let book = mgr.get_book("BTC/USD").expect("book must exist");
     let _ = book.add_limit_order_with_user(
@@ -158,7 +158,7 @@ fn std_cancel_by_user_across_books() {
 #[test]
 fn std_cancel_by_side_across_books() {
     let mut mgr: BookManagerStd<()> = BookManagerStd::new();
-    mgr.add_book("BTC/USD");
+    mgr.add_book("BTC/USD").expect("add book");
 
     let book = mgr.get_book("BTC/USD").expect("book must exist");
     let _ = book.add_limit_order(Id::new_uuid(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
@@ -186,7 +186,7 @@ fn tokio_default_creates_empty_manager() {
 #[test]
 fn tokio_add_and_get_book() {
     let mut mgr: BookManagerTokio<()> = BookManagerTokio::new();
-    mgr.add_book("BTC/USD");
+    mgr.add_book("BTC/USD").expect("add book");
     assert!(mgr.has_book("BTC/USD"));
     assert_eq!(mgr.book_count(), 1);
 }
@@ -206,7 +206,7 @@ fn tokio_get_book_mut_returns_none_for_unknown() {
 #[test]
 fn tokio_remove_book_returns_some_when_exists() {
     let mut mgr: BookManagerTokio<()> = BookManagerTokio::new();
-    mgr.add_book("BTC/USD");
+    mgr.add_book("BTC/USD").expect("add book");
     assert!(mgr.remove_book("BTC/USD").is_some());
     assert_eq!(mgr.book_count(), 0);
 }
@@ -220,8 +220,8 @@ fn tokio_remove_book_returns_none_when_missing() {
 #[test]
 fn tokio_symbols_returns_all_books() {
     let mut mgr: BookManagerTokio<()> = BookManagerTokio::new();
-    mgr.add_book("BTC/USD");
-    mgr.add_book("ETH/USD");
+    mgr.add_book("BTC/USD").expect("add book");
+    mgr.add_book("ETH/USD").expect("add book");
     let mut symbols = mgr.symbols();
     symbols.sort();
     assert_eq!(symbols, vec!["BTC/USD", "ETH/USD"]);
@@ -230,7 +230,7 @@ fn tokio_symbols_returns_all_books() {
 #[test]
 fn tokio_cancel_all_across_books() {
     let mut mgr: BookManagerTokio<()> = BookManagerTokio::new();
-    mgr.add_book("BTC/USD");
+    mgr.add_book("BTC/USD").expect("add book");
     let book = mgr.get_book("BTC/USD").expect("book must exist");
     let _ = book.add_limit_order(Id::new_uuid(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
 
@@ -246,7 +246,7 @@ fn tokio_cancel_all_across_books() {
 #[test]
 fn tokio_cancel_by_user_across_books() {
     let mut mgr: BookManagerTokio<()> = BookManagerTokio::new();
-    mgr.add_book("BTC/USD");
+    mgr.add_book("BTC/USD").expect("add book");
     let book = mgr.get_book("BTC/USD").expect("book must exist");
     let _ = book.add_limit_order_with_user(
         Id::new_uuid(),
@@ -270,7 +270,7 @@ fn tokio_cancel_by_user_across_books() {
 #[test]
 fn tokio_cancel_by_side_across_books() {
     let mut mgr: BookManagerTokio<()> = BookManagerTokio::new();
-    mgr.add_book("BTC/USD");
+    mgr.add_book("BTC/USD").expect("add book");
     let book = mgr.get_book("BTC/USD").expect("book must exist");
     let _ = book.add_limit_order(Id::new_uuid(), 100, 10, Side::Sell, TimeInForce::Gtc, None);
 
@@ -281,4 +281,55 @@ fn tokio_cancel_by_side_across_books() {
         .expect("book")
         .create_snapshot(usize::MAX);
     assert!(snap.asks.is_empty());
+}
+
+// ─── add_book duplicate-symbol rejection (#105) ─────────────────────────────
+
+#[test]
+fn std_add_book_duplicate_symbol_is_rejected_and_preserves_existing_issue_105() {
+    use orderbook_rs::ManagerError;
+
+    let mut mgr: BookManagerStd<()> = BookManagerStd::new();
+    mgr.add_book("BTC/USD").expect("first add");
+    // Seed a resting order into the existing book.
+    if let Some(book) = mgr.get_book("BTC/USD") {
+        let _ = book.add_limit_order(Id::new_uuid(), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+    }
+
+    // A second add_book for the same symbol must NOT overwrite the live book.
+    match mgr.add_book("BTC/USD") {
+        Err(ManagerError::BookAlreadyExists { symbol }) => assert_eq!(symbol, "BTC/USD"),
+        other => panic!("expected BookAlreadyExists, got {other:?}"),
+    }
+    // The original book (and its resting order) survives unchanged.
+    assert_eq!(mgr.book_count(), 1);
+    let book = mgr.get_book("BTC/USD").expect("book still present");
+    assert_eq!(
+        book.best_bid(),
+        Some(100),
+        "existing resting order preserved"
+    );
+}
+
+#[test]
+fn tokio_add_book_duplicate_symbol_is_rejected_and_preserves_existing_issue_105() {
+    use orderbook_rs::ManagerError;
+
+    let mut mgr: BookManagerTokio<()> = BookManagerTokio::new();
+    mgr.add_book("ETH/USD").expect("first add");
+    if let Some(book) = mgr.get_book("ETH/USD") {
+        let _ = book.add_limit_order(Id::new_uuid(), 200, 5, Side::Sell, TimeInForce::Gtc, None);
+    }
+
+    match mgr.add_book("ETH/USD") {
+        Err(ManagerError::BookAlreadyExists { symbol }) => assert_eq!(symbol, "ETH/USD"),
+        other => panic!("expected BookAlreadyExists, got {other:?}"),
+    }
+    assert_eq!(mgr.book_count(), 1);
+    let book = mgr.get_book("ETH/USD").expect("book still present");
+    assert_eq!(
+        book.best_ask(),
+        Some(200),
+        "existing resting order preserved"
+    );
 }


### PR DESCRIPTION
## Summary

Both `BookManagerStd` and `BookManagerTokio` did `self.books.insert(symbol, book)`
and **ignored the returned `Option`**, so calling `add_book` twice for the same
symbol silently replaced the first book — dropping all its resting orders and
order locations with no warning and no error path (`ManagerError` had no such
variant).

## Change (maintainer decision: breaking `Result`)

- Added `ManagerError::BookAlreadyExists { symbol }`.
- `BookManager::add_book` now returns **`Result<(), ManagerError>`** and refuses
  to overwrite an existing symbol (dup check via `books.contains_key` before
  insert). Both managers stay in parity.
- Updated the doc example to the hidden-main `?` pattern and all test callers to
  handle the `Result`.

**Breaking:** the trait method signature changed (`-> Result<(), ManagerError>`);
callers must handle the result. Permitted under the 0.8 → 0.9 window.

## Tests

- `std_add_book_duplicate_symbol_is_rejected_and_preserves_existing_issue_105`
  and the `tokio_…` twin: a second `add_book` for an existing symbol returns
  `BookAlreadyExists`, `book_count` stays `1`, and the existing book's resting
  order survives unchanged.
- `cargo test --all-features` — all pass. clippy `-D warnings` / fmt /
  `--release --all-features` — clean.

Closes #105