### PR TITLE
fix(repricing): deterministic special-order reprice + tick-aware non-crossing peg clamp (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Deterministic, non-crossing pegged/trailing-stop repricing (#106).** Two
+  fixes in the `special_orders`-gated repricing path. (a) `pegged_order_ids()` and
+  `trailing_stop_ids()` collected from a `DashSet<Id>` in unspecified order, so the
+  re-pricing sequence — and the events / journal entries it produced — was
+  non-reproducible across runs, breaking replay determinism and price-time
+  tie-breaking on re-insert. `Id` does not implement `Ord`, so both methods now
+  sort by the deterministic `Display`/`to_string` key (`ids.sort_by_key(|id| id.to_string())`)
+  before returning; the `to_string` allocation is acceptable off the matching hot
+  path (operator-triggered maintenance). (b) `calculate_pegged_price` ignored the
+  order `side` and could return a `reference ± offset` price that crossed the
+  spread, so a pegged re-price would aggressively fill during a maintenance
+  operation. It now takes the book `tick_size` and clamps the computed price to
+  the passive side of the market — one tick inside the touch (`best_ask - tick`
+  for a Buy, `best_bid + tick` for a Sell) — then snaps the result onto the tick
+  grid in the passive direction (round down for a Buy, up for a Sell) so the
+  re-priced order is always tick-aligned and restable. This is required because
+  the re-price path swallows `add_order`'s tick-validation error: a `± 1`
+  (off-tick) clamp on a `tick_size > 1` book was silently rejected on re-insert,
+  leaving the peg stuck at its stale price. When no valid passive tick exists
+  (degenerate cases such as `best_ask == tick`), the re-price is skipped (returns
+  `None`) instead of crossing or resting off-book. The order now rests passively,
+  tick-aligned, just inside the spread instead of trading.
 - **`add_book` refuses to overwrite an existing book (#105, breaking).** Both
   `BookManagerStd` and `BookManagerTokio` did `self.books.insert(symbol, book)` and
   ignored the returned `Option`, so a second `add_book` for the same symbol

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -3432,6 +3432,7 @@ where
                         best_ask,
                         mid_price,
                         last_trade,
+                        self.tick_size,
                     )
                     && new_price != current_price.as_u128()
                 {

--- a/src/orderbook/repricing.rs
+++ b/src/orderbook/repricing.rs
@@ -81,14 +81,30 @@ impl SpecialOrderTracker {
         self.trailing_stop_orders.len()
     }
 
-    /// Returns all tracked pegged order IDs
+    /// Returns all tracked pegged order IDs in a deterministic order.
+    ///
+    /// The underlying [`DashSet`] iterates in an unspecified order, which would
+    /// make the re-pricing sequence (and any events / journal entries it
+    /// produces) non-reproducible across runs and break replay determinism and
+    /// price-time tie-breaking on re-insert. `Id` does not implement `Ord`, so
+    /// we sort by the deterministic `Display`/`to_string` key. The per-id
+    /// `to_string` allocation is acceptable here: this is off the matching hot
+    /// path (operator-triggered maintenance, not per-submit).
     pub fn pegged_order_ids(&self) -> Vec<Id> {
-        self.pegged_orders.iter().map(|r| *r).collect()
+        let mut ids: Vec<Id> = self.pegged_orders.iter().map(|r| *r).collect();
+        ids.sort_by_key(|id| id.to_string());
+        ids
     }
 
-    /// Returns all tracked trailing stop order IDs
+    /// Returns all tracked trailing stop order IDs in a deterministic order.
+    ///
+    /// See [`pegged_order_ids`](Self::pegged_order_ids) for why the order is
+    /// sorted by the `Display`/`to_string` key rather than relying on
+    /// [`DashSet`] iteration order.
     pub fn trailing_stop_ids(&self) -> Vec<Id> {
-        self.trailing_stop_orders.iter().map(|r| *r).collect()
+        let mut ids: Vec<Id> = self.trailing_stop_orders.iter().map(|r| *r).collect();
+        ids.sort_by_key(|id| id.to_string());
+        ids
     }
 
     /// Clears all tracked orders
@@ -109,27 +125,61 @@ pub struct RepricingResult {
     pub failed_orders: Vec<(Id, String)>,
 }
 
-/// Calculates the new price for a pegged order based on reference price
+/// Calculates the new price for a pegged order based on reference price.
+///
+/// The computed `reference ± offset` price is **clamped to the passive side of
+/// the market** so a pegged re-price can never cross the spread and trade
+/// aggressively during a maintenance operation:
+/// - A **Buy** peg is capped strictly **below** the best ask (one tick inside,
+///   `best_ask - tick`); a buy resting at/above the best ask would cross.
+/// - A **Sell** peg is floored strictly **above** the best bid (one tick
+///   inside, `best_bid + tick`); a sell resting at/below the best bid would
+///   cross.
+///
+/// After clamping the price is repriced via `UpdatePrice` -> `add_order`, so it
+/// rests passively just inside the spread instead of crossing.
+///
+/// Tick alignment: `best_bid` / `best_ask` are price-level keys and therefore
+/// tick-aligned, but the clamp bound and the raw `reference ± offset` price are
+/// not. When `tick_size > 1` the clamped price is **snapped onto the tick grid
+/// in the passive direction** (round *down* for a Buy, *up* for a Sell) so the
+/// re-priced order is always restable. This matters because `add_order`
+/// validates tick alignment and the re-price path swallows that error, so an
+/// off-tick price would silently abort the re-price and leave the peg at a stale
+/// price. If, after snapping and flooring to the minimum valid price, the price
+/// would still cross the touch (degenerate cases such as `best_ask == tick`),
+/// there is no valid passive resting price this cycle and the function returns
+/// `None` — the re-price is skipped rather than crossing or resting off-book.
 ///
 /// # Arguments
 /// * `reference_type` - The type of reference price to use
 /// * `offset` - The offset from the reference price (can be negative)
-/// * `side` - The side of the order (Buy or Sell)
+/// * `side` - The side of the order (Buy or Sell); drives the passive-side clamp
 /// * `best_bid` - Current best bid price
 /// * `best_ask` - Current best ask price
 /// * `mid_price` - Current mid price in integer units
 /// * `last_trade` - Last trade price
+/// * `tick_size` - Book tick size, if any; drives passive-side snapping and the
+///   minimum valid resting price. `None` (or `<= 1`) preserves non-tick-book
+///   behavior (effective step of 1)
 ///
 /// # Returns
-/// The calculated new price, or None if reference price is not available
+/// The calculated new price, or `None` if the reference price is unavailable or
+/// no valid passive resting price exists this cycle
+// Each argument is a distinct, independently-sourced market input (reference
+// type, offset, side, the four reference prices, tick size); bundling them into
+// a struct would add ceremony without clarifying the pure calculation. Matches
+// the convention used by other multi-input helpers in this crate.
+#[allow(clippy::too_many_arguments)]
 pub fn calculate_pegged_price(
     reference_type: PegReferenceType,
     offset: i64,
-    _side: Side,
+    side: Side,
     best_bid: Option<u128>,
     best_ask: Option<u128>,
     mid_price: Option<u128>,
     last_trade: Option<u128>,
+    tick_size: Option<u128>,
 ) -> Option<u128> {
     let reference_price = match reference_type {
         PegReferenceType::BestBid => best_bid?,
@@ -139,14 +189,58 @@ pub fn calculate_pegged_price(
     };
 
     // Apply offset (can be positive or negative)
-    let new_price = if offset >= 0 {
+    let mut new_price = if offset >= 0 {
         reference_price.saturating_add(offset as u128)
     } else {
         reference_price.saturating_sub((-offset) as u128)
     };
 
-    // Ensure price is at least 1
-    Some(new_price.max(1))
+    // Effective tick step (1 when unset / <= 1 preserves non-tick-book behavior).
+    let step = tick_size.filter(|t| *t > 1).unwrap_or(1);
+
+    // Clamp to the passive side, one *tick* inside the touch so the bound is tick-aligned.
+    match side {
+        Side::Buy => {
+            if let Some(ask) = best_ask {
+                new_price = new_price.min(ask.saturating_sub(step));
+            }
+        }
+        Side::Sell => {
+            if let Some(bid) = best_bid {
+                new_price = new_price.max(bid.saturating_add(step));
+            }
+        }
+    }
+
+    // Snap onto the tick grid in the passive direction. Off-tick prices are rejected
+    // by validate_order_shape on re-insert, which would silently abort the re-price.
+    if step > 1 {
+        new_price = match side {
+            Side::Buy => (new_price / step) * step, // round down = more passive
+            Side::Sell => new_price.div_ceil(step).saturating_mul(step), // round up = more passive
+        };
+    }
+
+    // Floor to the minimum valid (tick-aligned) resting price.
+    let min_price = if step > 1 { step } else { 1 };
+    let priced = new_price.max(min_price);
+
+    // Final non-cross guard: if even the floored price would still cross the touch,
+    // there is no valid passive price this cycle — skip the re-price (None) rather than
+    // cross or rest off-book. (Fixes the best_ask==1 / ask==step degenerate case.)
+    match side {
+        Side::Buy => {
+            if best_ask.is_some_and(|a| priced >= a) {
+                return None;
+            }
+        }
+        Side::Sell => {
+            if best_bid.is_some_and(|b| priced <= b) {
+                return None;
+            }
+        }
+    }
+    Some(priced)
 }
 
 /// Calculates the new price for a trailing stop order
@@ -261,8 +355,12 @@ mod tests {
             Some(105),
             Some(102),
             Some(101),
+            None, // tick_size
         );
-        assert_eq!(price, Some(105)); // 100 + 5
+        // Raw computed price is 100 + 5 = 105, which equals best_ask and would
+        // cross for a Buy. The passive-side clamp caps it at best_ask - 1 = 104
+        // so the re-priced order rests just inside the spread instead of trading.
+        assert_eq!(price, Some(104));
     }
 
     #[test]
@@ -275,6 +373,7 @@ mod tests {
             Some(105),
             Some(102),
             Some(101),
+            None, // tick_size
         );
         assert_eq!(price, Some(102)); // 105 - 3
     }
@@ -289,6 +388,7 @@ mod tests {
             Some(110),
             Some(105),
             Some(103),
+            None, // tick_size
         );
         assert_eq!(price, Some(105)); // mid price (105)
     }
@@ -303,6 +403,7 @@ mod tests {
             Some(105),
             Some(102),
             Some(101),
+            None, // tick_size
         );
         assert_eq!(price, Some(103)); // 101 + 2
     }
@@ -317,6 +418,7 @@ mod tests {
             Some(105),
             Some(102),
             Some(101),
+            None, // tick_size
         );
         assert_eq!(price, None);
     }
@@ -331,6 +433,7 @@ mod tests {
             Some(105),
             Some(102),
             Some(101),
+            None, // tick_size
         );
         assert_eq!(price, Some(1)); // Minimum price is 1
     }
@@ -415,5 +518,302 @@ mod tests {
         tracker.clear();
         assert_eq!(tracker.pegged_order_count(), 0);
         assert_eq!(tracker.trailing_stop_count(), 0);
+    }
+
+    /// Computes the deterministic order the tracker is expected to return:
+    /// sorted by the `Display`/`to_string` key (same key the tracker uses).
+    fn expected_sorted(ids: &[Id]) -> Vec<Id> {
+        let mut sorted = ids.to_vec();
+        sorted.sort_by_key(|id| id.to_string());
+        sorted
+    }
+
+    #[test]
+    fn test_pegged_order_ids_deterministic_order_issue_106() {
+        // Use sequential ids so to_string() order is unambiguous and the
+        // registration order deliberately differs from the sorted order.
+        let id10 = Id::sequential(10);
+        let id2 = Id::sequential(2);
+        let id33 = Id::sequential(33);
+        let id1 = Id::sequential(1);
+
+        let tracker = SpecialOrderTracker::new();
+        // Register in a non-sorted order.
+        tracker.register_pegged_order(id10);
+        tracker.register_pegged_order(id2);
+        tracker.register_pegged_order(id33);
+        tracker.register_pegged_order(id1);
+
+        let expected = expected_sorted(&[id10, id2, id33, id1]);
+        let got = tracker.pegged_order_ids();
+        assert_eq!(got, expected, "pegged_order_ids must be to_string-sorted");
+
+        // Stable across repeated calls.
+        assert_eq!(tracker.pegged_order_ids(), got);
+
+        // Order does not depend on insertion order: a fresh tracker built with a
+        // different insertion sequence yields the same result.
+        let tracker2 = SpecialOrderTracker::new();
+        tracker2.register_pegged_order(id1);
+        tracker2.register_pegged_order(id33);
+        tracker2.register_pegged_order(id2);
+        tracker2.register_pegged_order(id10);
+        assert_eq!(tracker2.pegged_order_ids(), expected);
+    }
+
+    #[test]
+    fn test_trailing_stop_ids_deterministic_order_issue_106() {
+        let id10 = Id::sequential(10);
+        let id2 = Id::sequential(2);
+        let id33 = Id::sequential(33);
+        let id1 = Id::sequential(1);
+
+        let tracker = SpecialOrderTracker::new();
+        tracker.register_trailing_stop(id10);
+        tracker.register_trailing_stop(id2);
+        tracker.register_trailing_stop(id33);
+        tracker.register_trailing_stop(id1);
+
+        let expected = expected_sorted(&[id10, id2, id33, id1]);
+        let got = tracker.trailing_stop_ids();
+        assert_eq!(got, expected, "trailing_stop_ids must be to_string-sorted");
+        assert_eq!(tracker.trailing_stop_ids(), got);
+
+        let tracker2 = SpecialOrderTracker::new();
+        tracker2.register_trailing_stop(id1);
+        tracker2.register_trailing_stop(id33);
+        tracker2.register_trailing_stop(id2);
+        tracker2.register_trailing_stop(id10);
+        assert_eq!(tracker2.trailing_stop_ids(), expected);
+    }
+
+    #[test]
+    fn test_calculate_pegged_price_buy_clamped_below_best_ask_issue_106() {
+        // Buy peg whose reference + offset lands above the best ask must be
+        // capped strictly below the best ask so it never crosses.
+        let best_bid = Some(100_u128);
+        let best_ask = Some(105_u128);
+
+        // BestBid + 20 = 120, well above the ask -> clamp to best_ask - 1 = 104.
+        let price = calculate_pegged_price(
+            PegReferenceType::BestBid,
+            20,
+            Side::Buy,
+            best_bid,
+            best_ask,
+            Some(102),
+            Some(101),
+            None, // tick_size
+        );
+        assert_eq!(price, Some(104));
+        // Strictly below the best ask (105) so it cannot cross.
+        assert!(price < best_ask, "must rest below best ask");
+    }
+
+    #[test]
+    fn test_calculate_pegged_price_sell_clamped_above_best_bid_issue_106() {
+        // Sell peg whose reference - offset lands below the best bid must be
+        // floored strictly above the best bid so it never crosses.
+        let best_bid = Some(100_u128);
+        let best_ask = Some(105_u128);
+
+        // BestAsk - 20 = 85, below the bid -> clamp to best_bid + 1 = 101.
+        let price = calculate_pegged_price(
+            PegReferenceType::BestAsk,
+            -20,
+            Side::Sell,
+            best_bid,
+            best_ask,
+            Some(102),
+            Some(101),
+            None, // tick_size
+        );
+        assert_eq!(price, Some(101));
+        // Strictly above the best bid (100) so it cannot cross.
+        assert!(price > best_bid, "must rest above best bid");
+    }
+
+    #[test]
+    fn test_calculate_pegged_price_no_clamp_when_passive_issue_106() {
+        // When the computed price already rests passively, the clamp is a no-op.
+        // Buy at 102 with ask 105 -> stays 102.
+        let price = calculate_pegged_price(
+            PegReferenceType::BestBid,
+            2,
+            Side::Buy,
+            Some(100),
+            Some(105),
+            Some(102),
+            Some(101),
+            None, // tick_size
+        );
+        assert_eq!(price, Some(102));
+
+        // Sell at 104 with bid 100 -> stays 104.
+        let price = calculate_pegged_price(
+            PegReferenceType::BestAsk,
+            -1,
+            Side::Sell,
+            Some(100),
+            Some(105),
+            Some(102),
+            Some(101),
+            None, // tick_size
+        );
+        assert_eq!(price, Some(104));
+    }
+
+    #[test]
+    fn test_calculate_pegged_price_buy_tick_aware_clamp_snaps_to_ask_step_issue_106() {
+        // tick_size = 5, best_ask = 105, raw = 107 (BestBid 100 + 7) crosses the
+        // ask. Clamp to ask - step = 100 (already tick-aligned, strictly below
+        // ask). Without the tick-aware bound this would be best_ask - 1 = 104,
+        // which is OFF-TICK and silently rejected on re-insert.
+        let price = calculate_pegged_price(
+            PegReferenceType::BestBid,
+            7,
+            Side::Buy,
+            Some(100),
+            Some(105),
+            Some(102),
+            Some(101),
+            Some(5),
+        );
+        assert_eq!(price, Some(100));
+        let p = price.expect("price present");
+        assert!(p.is_multiple_of(5), "must be tick-aligned");
+        assert!(p < 105, "must rest below best ask");
+    }
+
+    #[test]
+    fn test_calculate_pegged_price_buy_tick_aware_snaps_offtick_raw_down_issue_106() {
+        // tick_size = 5, best_ask = 105, raw = 97 (BestBid 100 - 3) is passive
+        // but off-tick. It must snap DOWN (passive direction) to 95.
+        let price = calculate_pegged_price(
+            PegReferenceType::BestBid,
+            -3,
+            Side::Buy,
+            Some(100),
+            Some(105),
+            Some(102),
+            Some(101),
+            Some(5),
+        );
+        assert_eq!(price, Some(95));
+        assert!(price.expect("price present").is_multiple_of(5));
+    }
+
+    #[test]
+    fn test_calculate_pegged_price_sell_tick_aware_clamp_snaps_to_bid_step_issue_106() {
+        // tick_size = 5, best_bid = 100, raw = 112 (BestAsk 105 + 7) would not
+        // cross (it's above the bid) but is off-tick; passive snap rounds UP to
+        // 115. The bid+step floor (105) does not bind here.
+        let price = calculate_pegged_price(
+            PegReferenceType::BestAsk,
+            7,
+            Side::Sell,
+            Some(100),
+            Some(105),
+            Some(102),
+            Some(101),
+            Some(5),
+        );
+        assert_eq!(price, Some(115));
+        let p = price.expect("price present");
+        assert!(p.is_multiple_of(5), "must be tick-aligned");
+        assert!(p > 100, "must rest above best bid");
+    }
+
+    #[test]
+    fn test_calculate_pegged_price_sell_tick_aware_clamp_below_bid_snaps_up_issue_106() {
+        // tick_size = 5, best_bid = 100, best_ask = 120, raw = 85 (BestAsk 120
+        // - 35) is below the bid. Clamp to bid + step = 105 (tick-aligned, above
+        // bid).
+        let price = calculate_pegged_price(
+            PegReferenceType::BestAsk,
+            -35,
+            Side::Sell,
+            Some(100),
+            Some(120),
+            Some(110),
+            Some(101),
+            Some(5),
+        );
+        assert_eq!(price, Some(105));
+        let p = price.expect("price present");
+        assert!(p.is_multiple_of(5));
+        assert!(p > 100, "must rest above best bid");
+    }
+
+    #[test]
+    fn test_calculate_pegged_price_buy_no_passive_tick_returns_none_issue_106() {
+        // Degenerate: best_ask == step. There is no tick-aligned price strictly
+        // below the ask (ask - step = 0, floored to step = 5 == ask, still
+        // crosses), so the re-price must be skipped (None) rather than crossing.
+        let price = calculate_pegged_price(
+            PegReferenceType::BestBid,
+            10,
+            Side::Buy,
+            Some(3),
+            Some(5),
+            Some(4),
+            None,
+            Some(5),
+        );
+        assert_eq!(price, None);
+
+        // Degenerate non-tick book: best_ask == 1. Floor 1 with ask 1 crosses
+        // (buy at 1 >= ask 1), so no valid passive price -> None.
+        let price = calculate_pegged_price(
+            PegReferenceType::BestAsk,
+            0,
+            Side::Buy,
+            None,
+            Some(1),
+            None,
+            None,
+            None, // tick_size
+        );
+        assert_eq!(price, None);
+    }
+
+    #[test]
+    fn test_calculate_pegged_price_sell_floor_stays_passive_issue_106() {
+        // Sell counterpart to the degenerate Buy case: the bid+step clamp always
+        // lifts the price strictly above the bid, so a Sell can find a passive
+        // resting price even in a 1-wide market. best_bid == 1 on a non-tick
+        // book: clamp to bid + 1 = 2, which is above the bid and does not cross.
+        let price = calculate_pegged_price(
+            PegReferenceType::BestBid,
+            -10,
+            Side::Sell,
+            Some(1),
+            None,
+            None,
+            None,
+            None, // tick_size
+        );
+        assert_eq!(price, Some(2));
+    }
+
+    #[test]
+    fn test_calculate_pegged_price_sell_no_passive_tick_returns_none_issue_106() {
+        // The Sell-side non-cross guard is load-bearing, not dead code: when
+        // best_bid is at the top of the range there is no representable tick
+        // strictly above it, so bid + step saturates to bid and the guard must
+        // skip the re-price (None) rather than rest at/through the bid. This test
+        // pins that path so a future "the Sell None branch is unreachable"
+        // simplification cannot delete the guard.
+        let price = calculate_pegged_price(
+            PegReferenceType::BestBid,
+            10,
+            Side::Sell,
+            Some(u128::MAX),
+            None,
+            None,
+            None,
+            None, // tick_size
+        );
+        assert_eq!(price, None);
     }
 }

--- a/src/orderbook/tests/repricing.rs
+++ b/src/orderbook/tests/repricing.rs
@@ -258,6 +258,7 @@ mod tests {
             Some(120), // best_ask
             Some(110), // mid_price
             None,
+            None, // tick_size
         );
         assert_eq!(pegged_price, Some(102));
 
@@ -337,6 +338,7 @@ mod tests {
             Some(120), // best_ask
             Some(110), // mid_price
             None,
+            None, // tick_size
         );
 
         // Calculated price is 105 (100 + 5)

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -24,6 +24,8 @@ mod replay_config_tests;
 mod replay_coverage_tests;
 #[cfg(feature = "journal")]
 mod replay_determinism;
+#[cfg(feature = "special_orders")]
+mod repricing_determinism_tests;
 mod risk_layer_tests;
 mod sequencer_types_tests;
 mod snapshot_restore_tests;

--- a/tests/unit/repricing_determinism_tests.rs
+++ b/tests/unit/repricing_determinism_tests.rs
@@ -1,0 +1,340 @@
+//! Integration tests for issue #106: repricing determinism and the
+//! passive-side clamp that prevents a pegged re-price from crossing and
+//! trading aggressively during a maintenance operation.
+//!
+//! These tests are gated on the `special_orders` feature, which is the only
+//! configuration in which the repricing path exists.
+
+#![cfg(feature = "special_orders")]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use orderbook_rs::OrderBook;
+use orderbook_rs::orderbook::repricing::RepricingOperations;
+use pricelevel::{
+    Hash32, Id, OrderType, PegReferenceType, Price, Quantity, Side, TimeInForce, TimestampMs,
+};
+
+/// Builds a two-sided book with a clear spread: best bid 100, best ask 105.
+fn two_sided_book(trade_count: Arc<AtomicUsize>) -> OrderBook<()> {
+    let counter = trade_count.clone();
+    let book = OrderBook::<()>::with_trade_listener(
+        "TEST/USD",
+        Arc::new(move |_trade| {
+            counter.fetch_add(1, Ordering::SeqCst);
+        }),
+    );
+
+    // Bids below the spread.
+    let _ = book.add_limit_order(Id::from_u64(1), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+    let _ = book.add_limit_order(Id::from_u64(2), 99, 10, Side::Buy, TimeInForce::Gtc, None);
+    // Asks above the spread.
+    let _ = book.add_limit_order(Id::from_u64(3), 105, 10, Side::Sell, TimeInForce::Gtc, None);
+    let _ = book.add_limit_order(Id::from_u64(4), 106, 10, Side::Sell, TimeInForce::Gtc, None);
+
+    book
+}
+
+#[test]
+fn buy_pegged_reprice_does_not_cross_or_trade_issue_106() {
+    let trade_count = Arc::new(AtomicUsize::new(0));
+    let book = two_sided_book(trade_count.clone());
+
+    assert_eq!(book.best_bid(), Some(100));
+    assert_eq!(book.best_ask(), Some(105));
+
+    // Buy peg tracking best bid with a +20 offset would land at 120, well above
+    // the best ask (105). Without the clamp this would cross and fill.
+    let pegged_id = Id::from_u64(1000);
+    let pegged = OrderType::PeggedOrder {
+        id: pegged_id,
+        price: Price::new(90), // resting, passive initial price
+        quantity: Quantity::new(5),
+        side: Side::Buy,
+        user_id: Hash32::zero(),
+        timestamp: TimestampMs::new(1),
+        time_in_force: TimeInForce::Gtc,
+        reference_price_offset: 20,
+        reference_price_type: PegReferenceType::BestBid,
+        extra_fields: (),
+    };
+    book.add_order(pegged)
+        .expect("pegged order added passively");
+
+    // Adding the resting peg must not have traded.
+    assert_eq!(
+        trade_count.load(Ordering::SeqCst),
+        0,
+        "passive pegged add must not trade"
+    );
+
+    let repriced = book.reprice_pegged_orders().expect("reprice succeeds");
+    assert_eq!(repriced, 1, "the pegged order should have been re-priced");
+
+    // (i) No trade was emitted by the reprice.
+    assert_eq!(
+        trade_count.load(Ordering::SeqCst),
+        0,
+        "reprice must not aggressively trade"
+    );
+
+    // (ii) The order rests passively strictly below the best ask.
+    let order = book
+        .get_order(pegged_id)
+        .expect("pegged order still resting");
+    let best_ask = book.best_ask().expect("best ask present");
+    assert!(
+        order.price().as_u128() < best_ask,
+        "buy peg must rest below best ask: price={} best_ask={}",
+        order.price(),
+        best_ask
+    );
+    // Clamp lands exactly at best_ask - 1.
+    assert_eq!(order.price().as_u128(), best_ask - 1);
+}
+
+#[test]
+fn sell_pegged_reprice_does_not_cross_or_trade_issue_106() {
+    let trade_count = Arc::new(AtomicUsize::new(0));
+    let book = two_sided_book(trade_count.clone());
+
+    assert_eq!(book.best_bid(), Some(100));
+    assert_eq!(book.best_ask(), Some(105));
+
+    // Sell peg tracking best ask with a -20 offset would land at 85, below the
+    // best bid (100). Without the clamp this would cross and fill.
+    let pegged_id = Id::from_u64(2000);
+    let pegged = OrderType::PeggedOrder {
+        id: pegged_id,
+        price: Price::new(115), // resting, passive initial price
+        quantity: Quantity::new(5),
+        side: Side::Sell,
+        user_id: Hash32::zero(),
+        timestamp: TimestampMs::new(1),
+        time_in_force: TimeInForce::Gtc,
+        reference_price_offset: -20,
+        reference_price_type: PegReferenceType::BestAsk,
+        extra_fields: (),
+    };
+    book.add_order(pegged)
+        .expect("pegged order added passively");
+
+    assert_eq!(
+        trade_count.load(Ordering::SeqCst),
+        0,
+        "passive pegged add must not trade"
+    );
+
+    let repriced = book.reprice_pegged_orders().expect("reprice succeeds");
+    assert_eq!(repriced, 1, "the pegged order should have been re-priced");
+
+    // (i) No trade was emitted by the reprice.
+    assert_eq!(
+        trade_count.load(Ordering::SeqCst),
+        0,
+        "reprice must not aggressively trade"
+    );
+
+    // (ii) The order rests passively strictly above the best bid.
+    let order = book
+        .get_order(pegged_id)
+        .expect("pegged order still resting");
+    let best_bid = book.best_bid().expect("best bid present");
+    assert!(
+        order.price().as_u128() > best_bid,
+        "sell peg must rest above best bid: price={} best_bid={}",
+        order.price(),
+        best_bid
+    );
+    // Clamp lands exactly at best_bid + 1.
+    assert_eq!(order.price().as_u128(), best_bid + 1);
+}
+
+/// Re-pricing visits pegged orders in the deterministic `to_string`-sorted
+/// order regardless of registration order. We register several pegged orders
+/// whose insertion order differs from the sorted order and assert the book's
+/// `pegged_order_ids()` view (the same source the reprice loop consumes) is
+/// stable and sorted.
+#[test]
+fn reprice_visits_pegged_ids_in_deterministic_order_issue_106() {
+    let book = OrderBook::<()>::new("TEST/USD");
+
+    // Liquidity so reference prices exist.
+    let _ = book.add_limit_order(Id::from_u64(1), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+    let _ = book.add_limit_order(Id::from_u64(2), 105, 10, Side::Sell, TimeInForce::Gtc, None);
+
+    // Register pegged orders with ids whose insertion order != sorted order.
+    let ids = [
+        Id::sequential(10),
+        Id::sequential(2),
+        Id::sequential(33),
+        Id::sequential(1),
+    ];
+    for (i, id) in ids.iter().enumerate() {
+        let pegged = OrderType::PeggedOrder {
+            id: *id,
+            price: Price::new(80 + i as u128),
+            quantity: Quantity::new(1),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1),
+            time_in_force: TimeInForce::Gtc,
+            reference_price_offset: -5,
+            reference_price_type: PegReferenceType::BestBid,
+            extra_fields: (),
+        };
+        book.add_order(pegged).expect("pegged order added");
+    }
+
+    let mut expected = ids.to_vec();
+    expected.sort_by_key(|id| id.to_string());
+
+    let got = book.pegged_order_ids();
+    assert_eq!(got, expected, "pegged ids must be to_string-sorted");
+    // Stable across repeated reads.
+    assert_eq!(book.pegged_order_ids(), got);
+}
+
+/// BLOCKER regression for issue #106: on a `tick_size > 1` book, a clamped peg
+/// price must be tick-aligned so the re-insert actually succeeds.
+///
+/// The old `±1` clamp produced `best_ask - 1`, which is off-tick on a tick=5
+/// book. `add_order` rejects off-tick prices with `InvalidTickSize`, and the
+/// re-price path swallows that error (`if self.update_order(..).is_ok()`), so
+/// the order would be silently left at its stale price — defeating #106. With
+/// the tick-aware clamp the order moves to `best_ask - tick` (tick-aligned,
+/// strictly below the ask) and never trades.
+///
+/// This test FAILS against the old `±1` code (the order stays at 90) and passes
+/// with the tick-aware snap (the order moves to 100).
+#[test]
+fn buy_pegged_reprice_tick_aligned_and_moves_issue_106() {
+    let trade_count = Arc::new(AtomicUsize::new(0));
+    let counter = trade_count.clone();
+
+    let mut book = OrderBook::<()>::with_tick_size("TICK/USD", 5);
+    book.set_trade_listener(Arc::new(move |_trade| {
+        counter.fetch_add(1, Ordering::SeqCst);
+    }));
+
+    // Tick-aligned (multiples of 5) two-sided liquidity: best bid 100, ask 105.
+    let _ = book.add_limit_order(Id::from_u64(1), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+    let _ = book.add_limit_order(Id::from_u64(2), 95, 10, Side::Buy, TimeInForce::Gtc, None);
+    let _ = book.add_limit_order(Id::from_u64(3), 105, 10, Side::Sell, TimeInForce::Gtc, None);
+    let _ = book.add_limit_order(Id::from_u64(4), 110, 10, Side::Sell, TimeInForce::Gtc, None);
+
+    assert_eq!(book.best_bid(), Some(100));
+    assert_eq!(book.best_ask(), Some(105));
+
+    // Buy peg tracking best bid + 7 = 107 -> would cross ask 105. Initial resting
+    // price 90 (tick-aligned, passive).
+    let pegged_id = Id::from_u64(1000);
+    let pegged = OrderType::PeggedOrder {
+        id: pegged_id,
+        price: Price::new(90),
+        quantity: Quantity::new(5),
+        side: Side::Buy,
+        user_id: Hash32::zero(),
+        timestamp: TimestampMs::new(1),
+        time_in_force: TimeInForce::Gtc,
+        reference_price_offset: 7,
+        reference_price_type: PegReferenceType::BestBid,
+        extra_fields: (),
+    };
+    book.add_order(pegged)
+        .expect("pegged order added passively");
+    assert_eq!(
+        trade_count.load(Ordering::SeqCst),
+        0,
+        "passive add must not trade"
+    );
+
+    let repriced = book.reprice_pegged_orders().expect("reprice succeeds");
+    assert_eq!(repriced, 1, "the pegged order must actually re-price");
+
+    // No trade emitted by the reprice.
+    assert_eq!(
+        trade_count.load(Ordering::SeqCst),
+        0,
+        "reprice must not aggressively trade"
+    );
+
+    // The order actually MOVED to a tick-aligned passive price: best_ask - tick.
+    let order = book
+        .get_order(pegged_id)
+        .expect("pegged order still resting");
+    let new_price = order.price().as_u128();
+    assert_eq!(
+        new_price, 100,
+        "must snap to best_ask - tick (tick-aligned), not stay at stale 90"
+    );
+    assert!(new_price.is_multiple_of(5), "must be tick-aligned");
+    let best_ask = book.best_ask().expect("best ask present");
+    assert!(new_price < best_ask, "must rest below best ask");
+}
+
+/// Symmetric Sell case on a `tick_size = 5` book: a sell peg whose raw price
+/// lands below the bid must snap UP to a tick-aligned price strictly above the
+/// bid (`best_bid + tick`) and must not trade.
+#[test]
+fn sell_pegged_reprice_tick_aligned_and_moves_issue_106() {
+    let trade_count = Arc::new(AtomicUsize::new(0));
+    let counter = trade_count.clone();
+
+    let mut book = OrderBook::<()>::with_tick_size("TICK/USD", 5);
+    book.set_trade_listener(Arc::new(move |_trade| {
+        counter.fetch_add(1, Ordering::SeqCst);
+    }));
+
+    let _ = book.add_limit_order(Id::from_u64(1), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+    let _ = book.add_limit_order(Id::from_u64(2), 95, 10, Side::Buy, TimeInForce::Gtc, None);
+    let _ = book.add_limit_order(Id::from_u64(3), 120, 10, Side::Sell, TimeInForce::Gtc, None);
+    let _ = book.add_limit_order(Id::from_u64(4), 125, 10, Side::Sell, TimeInForce::Gtc, None);
+
+    assert_eq!(book.best_bid(), Some(100));
+    assert_eq!(book.best_ask(), Some(120));
+
+    // Sell peg tracking best ask (120) - 35 = 85 -> below bid 100. Initial
+    // resting price 130 (tick-aligned, passive).
+    let pegged_id = Id::from_u64(2000);
+    let pegged = OrderType::PeggedOrder {
+        id: pegged_id,
+        price: Price::new(130),
+        quantity: Quantity::new(5),
+        side: Side::Sell,
+        user_id: Hash32::zero(),
+        timestamp: TimestampMs::new(1),
+        time_in_force: TimeInForce::Gtc,
+        reference_price_offset: -35,
+        reference_price_type: PegReferenceType::BestAsk,
+        extra_fields: (),
+    };
+    book.add_order(pegged)
+        .expect("pegged order added passively");
+    assert_eq!(
+        trade_count.load(Ordering::SeqCst),
+        0,
+        "passive add must not trade"
+    );
+
+    let repriced = book.reprice_pegged_orders().expect("reprice succeeds");
+    assert_eq!(repriced, 1, "the pegged order must actually re-price");
+    assert_eq!(
+        trade_count.load(Ordering::SeqCst),
+        0,
+        "reprice must not aggressively trade"
+    );
+
+    let order = book
+        .get_order(pegged_id)
+        .expect("pegged order still resting");
+    let new_price = order.price().as_u128();
+    assert_eq!(
+        new_price, 105,
+        "must snap to best_bid + tick (tick-aligned), not stay at stale 130"
+    );
+    assert!(new_price.is_multiple_of(5), "must be tick-aligned");
+    let best_bid = book.best_bid().expect("best bid present");
+    assert!(new_price > best_bid, "must rest above best bid");
+}


### PR DESCRIPTION
## Summary

Two repricing-determinism fixes for pegged and trailing-stop maintenance (issue #106).

### 1. Deterministic re-price order
`pegged_order_ids()` and `trailing_stop_ids()` collected from a `DashSet<Id>` in unspecified order, which leaked into the re-price sequence and any events / journal entries it produced — breaking replay determinism and price-time tie-breaking on re-insert. `Id` does not implement `Ord`, so both methods now sort by the stable `Display`/`to_string` key before returning. This runs off the matching hot path (operator-triggered maintenance), so the per-id `to_string` allocation is acceptable.

### 2. Non-crossing, tick-aware peg clamp
`calculate_pegged_price` now clamps the computed `reference ± offset` to the **passive side** of the market so a peg re-price can never cross the spread and trade aggressively during maintenance:

- **Buy** peg is capped one tick **below** the best ask; **Sell** peg floored one tick **above** the best bid.
- The clamp is **tick-aware**: it snaps to the nearest passive tick (Buy rounds down, Sell rounds up) so the repriced order is always tick-aligned and accepted by the re-insert tick validation. Without this, on a `tick_size > 1` book the bound would be off-tick → `validate_order_shape` rejects it → the reprice loop silently discards the error and the peg stays stuck at a stale price.
- A final **non-cross guard** returns `None` to skip the re-price when no valid passive tick exists (e.g. `best_ask == tick_size`, or `best_ask == 1` on a non-tick book), rather than resting at or through the touch.

## Review

- **determinism-auditor**: PASS — `id.to_string()` is injective (variant string-lengths are mutually exclusive), so the sort is a total, stable, replay-safe order; the clamp is a pure function; no clock/rand/env introduced.
- **microstructure-critic** (two passes): first pass flagged a BLOCKER — the original `±1` clamp produced an off-tick bound that the re-insert path silently rejected on `tick_size > 1` books, and the `.max(1)` floor could re-introduce a cross at `best_ask == 1`. Second pass on the tick-aware fix: **PASS — ready for release**; both issues resolved, no new crossing/alignment hazard, and the Sell-side non-cross guard is correctly load-bearing (reachable when `best_bid == u128::MAX`).

## Tests

- Unit: deterministic id order; tick-aware clamp/snap in both directions; degenerate no-passive-tick skip on both sides (including the `best_bid == u128::MAX → None` guard).
- Integration (`tests/unit/repricing_determinism_tests.rs`) on a `with_tick_size(5)` book: pegged re-price moves to a tick-aligned passive price with **zero trades**; verified to fail against the old `±1` code (`repriced == 0`).
- `cargo test --all-features` and `cargo test --features special_orders` green; `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt` clean; release build clean.

## Follow-up (deferred, not in scope)

The reprice loop still uses `if self.update_order(update).is_ok()` and does not populate `RepricingResult.failed_orders`, so a non-tick re-price failure (e.g. risk-admission rejection) is unobservable. There is also no explicit telemetry when a peg is clamped away from its requested offset. Tracking these separately.

Closes #106
