### PR TITLE
fix(api): resolve declared-but-unemitted wire/event surfaces (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Resolve declared-but-unemitted wire/event surfaces (#119).** Three public
+  surfaces claimed behavior the engine never implemented; all three are now backed
+  by real engine paths. (a) `RejectReason::DuplicateOrderId` (stable wire code 12)
+  was never emitted and `add_order` performed no duplicate-id check — it silently
+  overwrote the resting order's location, orphaning it. `add_order` now rejects an
+  incoming order whose id already rests on the book with the new
+  `OrderBookError::DuplicateOrderId { order_id }` (mapped to wire code 12); the
+  check lives in `add_order` (not the shared `validate_order_shape`) so the
+  validate-first atomic modify is unaffected, and it does not clobber the live
+  order's tracked state. (b) `TransactionInfo::maker_fee` / `taker_fee` were
+  documented as per-transaction fees but no engine path populated them. The new
+  `TradeInfo::from_trade_result(&TradeResult, Option<&FeeSchedule>)` computes each
+  transaction's maker/taker fee from the schedule; the per-transaction fees sum to
+  the aggregate `TradeResult::total_maker_fees` / `total_taker_fees`, so the
+  detailed and aggregate views agree. (c) `MarketImpact::total_quantity_available`
+  was documented as total available depth but was set to the requested-capped fill
+  quantity, making `can_fill` trivially true and `fill_ratio` capped at `1.0`. It
+  now accumulates the true resting depth across the whole side being hit (the
+  impact metrics still describe only the consumed portion), so `fill_ratio` can
+  exceed `1.0` when the book holds more depth than requested.
 - **Evict zeroed per-account risk counters; self-balancing fill accounting (#115).**
   Two hardening fixes in the opt-in pre-trade risk layer (`risk.rs`). (a) `RiskState`
   kept a per-account `RiskCounters` entry forever — `on_fill`/`on_cancel` decremented

--- a/examples/src/bin/market_trades_demo.rs
+++ b/examples/src/bin/market_trades_demo.rs
@@ -7,7 +7,7 @@
 //! 4. Use TradeListener to capture trades in real-time
 
 use orderbook_rs::prelude::{
-    Id, OrderBook, Side, TimeInForce, TradeInfo, TradeListener, TradeResult, TransactionInfo,
+    Id, OrderBook, Side, TimeInForce, TradeInfo, TradeListener, TradeResult,
 };
 use pricelevel::{Quantity, setup_logger};
 use std::sync::{Arc, Mutex};
@@ -178,37 +178,14 @@ fn execute_market_orders(book: &OrderBook) {
     }
 }
 
-/// Helper function to create TradeInfo from TradeResult
+/// Helper function to create TradeInfo from TradeResult.
+///
+/// Delegates to the engine-provided `TradeInfo::from_trade_result`, which
+/// populates the per-transaction maker/taker fees from the supplied fee
+/// schedule. This demo runs without a fee schedule, so it passes `None`
+/// (per-transaction fees are `0`); pass `Some(&schedule)` to populate them.
 fn create_trade_info_from_result(trade_result: &TradeResult) -> TradeInfo {
-    let match_result = &trade_result.match_result;
-
-    let transactions: Vec<TransactionInfo> = match_result
-        .trades()
-        .as_vec()
-        .iter()
-        .map(|tx| TransactionInfo {
-            price: tx.price().as_u128(),
-            quantity: tx.quantity().as_u64(),
-            transaction_id: tx.trade_id().to_string(),
-            maker_order_id: tx.maker_order_id().to_string(),
-            taker_order_id: tx.taker_order_id().to_string(),
-            maker_fee: 0,
-            taker_fee: 0,
-        })
-        .collect();
-
-    TradeInfo {
-        symbol: trade_result.symbol.clone(),
-        order_id: match_result.order_id().to_string(),
-        executed_quantity: match_result
-            .executed_quantity()
-            .unwrap_or(Quantity::new(0))
-            .as_u64(),
-        remaining_quantity: match_result.remaining_quantity().as_u64(),
-        is_complete: match_result.is_complete(),
-        transaction_count: match_result.trades().len(),
-        transactions,
-    }
+    TradeInfo::from_trade_result(trade_result, None)
 }
 
 /// Display the current state of the order book

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -1657,11 +1657,23 @@ where
     /// - `worst_price`: Furthest price from the best price
     /// - `slippage`: Absolute difference from best price
     /// - `slippage_bps`: Slippage in basis points
-    /// - `levels_consumed`: Number of price levels used
-    /// - `total_quantity_available`: Total liquidity available
+    /// - `levels_consumed`: Number of price levels the order would consume
+    /// - `total_quantity_available`: Total resting depth on the hit side
+    ///   (summed across every level, not capped at `quantity`)
+    ///
+    /// Note the two reference frames in the returned struct: `avg_price`,
+    /// `worst_price`, `slippage`, `slippage_bps`, and `levels_consumed`
+    /// describe only the portion this `quantity` would consume, while
+    /// `total_quantity_available` reports the whole side's resting depth.
+    /// A `quantity == 0` query is a degenerate no-op and returns an
+    /// all-zero [`MarketImpact`] (including `total_quantity_available == 0`),
+    /// so read depth with a positive `quantity`.
     ///
     /// # Performance
-    /// O(M log N) where M is the number of levels needed.
+    /// O(N) over the resting price levels on the side being hit: the impact
+    /// metrics only need the consumed prefix, but `total_quantity_available`
+    /// reports true depth, so the whole side is scanned. This is an
+    /// analytics query, not on the matching hot path.
     ///
     /// # Examples
     /// ```
@@ -1707,20 +1719,23 @@ where
         let mut remaining = quantity;
         let mut total_cost = 0u128;
         let mut total_filled = 0u64;
+        let mut total_available = 0u64;
         let mut worst_price = best_price;
         let mut levels_consumed = 0;
 
-        // Iterate in price-priority order
+        // Iterate in price-priority order. The loop scans the whole side
+        // (not just the levels this order would consume) so
+        // `total_quantity_available` reflects the *true* resting depth — the
+        // `can_fill` / `fill_ratio` helpers are meaningless when it is capped
+        // at the requested quantity. The impact metrics (`avg_price`,
+        // `worst_price`, `slippage`, `levels_consumed`) still describe only
+        // the consumed portion, gated on `remaining > 0`.
         let iter = match side {
             Side::Buy => Either::Left(price_levels.iter()), // Lowest to highest (asks)
             Side::Sell => Either::Right(price_levels.iter().rev()), // Highest to lowest (bids)
         };
 
         for entry in iter {
-            if remaining == 0 {
-                break;
-            }
-
             let price = *entry.key();
             let price_level = entry.value();
             let available = price_level.total_quantity().unwrap_or(0);
@@ -1729,12 +1744,18 @@ where
                 continue;
             }
 
-            levels_consumed += 1;
-            let fill_qty = remaining.min(available);
-            total_cost = total_cost.saturating_add(price * (fill_qty as u128));
-            total_filled = total_filled.saturating_add(fill_qty);
-            worst_price = price;
-            remaining = remaining.saturating_sub(fill_qty);
+            // Accumulate full available depth across every non-empty level.
+            total_available = total_available.saturating_add(available);
+
+            // Cost / slippage only reflect the portion this order consumes.
+            if remaining > 0 {
+                levels_consumed += 1;
+                let fill_qty = remaining.min(available);
+                total_cost = total_cost.saturating_add(price * (fill_qty as u128));
+                total_filled = total_filled.saturating_add(fill_qty);
+                worst_price = price;
+                remaining = remaining.saturating_sub(fill_qty);
+            }
         }
 
         let avg_price = if total_filled > 0 {
@@ -1760,7 +1781,7 @@ where
             slippage,
             slippage_bps,
             levels_consumed,
-            total_quantity_available: total_filled,
+            total_quantity_available: total_available,
         }
     }
 

--- a/src/orderbook/error.rs
+++ b/src/orderbook/error.rs
@@ -109,6 +109,22 @@ pub enum OrderBookError {
         max: Option<u64>,
     },
 
+    /// Order rejected because its `order_id` duplicates an order that is
+    /// already resting on the book. Admitting it would overwrite the
+    /// existing order's location and orphan it (the prior order could no
+    /// longer be cancelled or modified by id), so the engine rejects the
+    /// duplicate instead of silently replacing the live order. Maps to the
+    /// stable wire code `RejectReason::DuplicateOrderId`.
+    ///
+    /// This guards against sequential reuse of a *live* order's id. It is
+    /// not atomic against two concurrent submissions of the same fresh id
+    /// on the lock-free admission path — serializing order ids is the
+    /// ingress / sequencing layer's responsibility.
+    DuplicateOrderId {
+        /// The duplicate order ID that was rejected
+        order_id: pricelevel::Id,
+    },
+
     /// Order rejected because `user_id` is `Hash32::zero()` while
     /// Self-Trade Prevention is enabled. All orders must carry a non-zero
     /// `user_id` when STP mode is active.
@@ -263,6 +279,12 @@ impl fmt::Display for OrderBookError {
                 write!(
                     f,
                     "order size out of range: quantity {quantity}, min {min:?}, max {max:?}"
+                )
+            }
+            OrderBookError::DuplicateOrderId { order_id } => {
+                write!(
+                    f,
+                    "duplicate order id: order {order_id} is already resting on the book"
                 )
             }
             OrderBookError::MissingUserId { order_id } => {
@@ -456,6 +478,9 @@ impl Clone for OrderBookError {
                     max: *max,
                 }
             }
+            OrderBookError::DuplicateOrderId { order_id } => OrderBookError::DuplicateOrderId {
+                order_id: *order_id,
+            },
             OrderBookError::MissingUserId { order_id } => OrderBookError::MissingUserId {
                 order_id: *order_id,
             },

--- a/src/orderbook/market_impact.rs
+++ b/src/orderbook/market_impact.rs
@@ -13,6 +13,13 @@ use serde::{Deserialize, Serialize};
 ///
 /// Provides detailed metrics about how an order would affect the market,
 /// including price impact, slippage, and liquidity consumption.
+///
+/// The fields use two reference frames: `avg_price`, `worst_price`,
+/// `slippage`, `slippage_bps`, and `levels_consumed` describe only the
+/// portion the analyzed order would **consume**, whereas
+/// [`total_quantity_available`](Self::total_quantity_available) reports the
+/// **whole side's** resting depth (so [`fill_ratio`](Self::fill_ratio) can
+/// exceed `1.0`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MarketImpact {
     /// Average execution price across all fills (in price units)
@@ -30,7 +37,11 @@ pub struct MarketImpact {
     /// Number of price levels that would be consumed
     pub levels_consumed: usize,
 
-    /// Total quantity available to fill the order (in units)
+    /// Total resting depth available on the side being hit (in units),
+    /// summed across **every** non-empty level — not capped at the
+    /// requested quantity. This is what makes [`Self::can_fill`] and
+    /// [`Self::fill_ratio`] meaningful: a value greater than the requested
+    /// quantity means the order would fully fill with depth to spare.
     pub total_quantity_available: u64,
 }
 
@@ -82,13 +93,19 @@ impl MarketImpact {
         self.total_quantity_available >= requested_quantity
     }
 
-    /// Returns the fill ratio (0.0 to 1.0)
+    /// Returns the fill ratio of available depth to requested quantity.
+    ///
+    /// Because [`Self::total_quantity_available`] now reflects the true
+    /// resting depth (not the capped fill quantity), this ratio **can
+    /// exceed 1.0** when the book holds more depth than requested — a value
+    /// of `2.0` means twice the requested quantity is resting. Returns
+    /// `0.0` for a zero `requested_quantity`.
     ///
     /// # Arguments
     /// - `requested_quantity`: The quantity originally requested (in units)
     ///
     /// # Returns
-    /// The ratio of available quantity to requested quantity
+    /// `total_quantity_available / requested_quantity`
     #[must_use]
     pub fn fill_ratio(&self, requested_quantity: u64) -> f64 {
         if requested_quantity == 0 {

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -936,6 +936,32 @@ where
             return Err(err);
         }
 
+        // Reject a duplicate order id: an order with this id is already
+        // resting on the book. Admitting it would overwrite the existing
+        // order's entry in `order_locations` and orphan the live order (it
+        // could no longer be cancelled or modified by id). This is an
+        // `add_order`-specific structural check and deliberately does NOT
+        // live in `validate_order_shape`: the validate-first atomic modify
+        // (#98) runs that shared validator while the original, same-id
+        // order is still resting, so a check there would false-reject every
+        // modify. We also do NOT record an `OrderStatus::Rejected`
+        // transition — the id belongs to a different, still-live order
+        // whose tracked state must not be clobbered. The metric plus the
+        // typed error (which the wire layer maps to
+        // `RejectReason::DuplicateOrderId`) are sufficient.
+        //
+        // This is a sequential guard, not a concurrency guard: the check
+        // and the eventual `order_locations.insert` straddle the match
+        // walk, so two concurrent `add_order` calls with the same *fresh*
+        // id can both pass here and both rest (last-writer-wins on insert).
+        // Serializing order ids is the ingress / sequencing layer's job.
+        if self.order_locations.contains_key(&order.id()) {
+            crate::orderbook::metrics::record_reject(RejectReason::DuplicateOrderId);
+            return Err(OrderBookError::DuplicateOrderId {
+                order_id: order.id(),
+            });
+        }
+
         trace!(
             "Order book {}: Adding order {} at price {}",
             self.symbol,

--- a/src/orderbook/reject_reason.rs
+++ b/src/orderbook/reject_reason.rs
@@ -222,6 +222,7 @@ impl From<&OrderBookError> for RejectReason {
             OrderBookError::InvalidTickSize { .. } => Self::InvalidPrice,
             OrderBookError::InvalidLotSize { .. } => Self::InvalidQuantity,
             OrderBookError::OrderSizeOutOfRange { .. } => Self::OrderSizeOutOfRange,
+            OrderBookError::DuplicateOrderId { .. } => Self::DuplicateOrderId,
             OrderBookError::MissingUserId { .. } => Self::MissingUserId,
             OrderBookError::PriceLevelError(_) => Self::Other(0),
             OrderBookError::OrderNotFound(_) => Self::Other(0),
@@ -361,6 +362,14 @@ mod tests {
             order_id: Id::new_uuid(),
         };
         assert_eq!(RejectReason::from(&err), RejectReason::MissingUserId);
+    }
+
+    #[test]
+    fn test_from_order_book_error_duplicate_order_id() {
+        let err = OrderBookError::DuplicateOrderId {
+            order_id: Id::new_uuid(),
+        };
+        assert_eq!(RejectReason::from(&err), RejectReason::DuplicateOrderId);
     }
 
     #[test]

--- a/src/orderbook/tests/market_impact_tests.rs
+++ b/src/orderbook/tests/market_impact_tests.rs
@@ -17,7 +17,8 @@ mod tests {
         // Buy 20 units (will consume 2 levels)
         let impact = book.market_impact(20, Side::Buy);
 
-        assert_eq!(impact.total_quantity_available, 20);
+        // Full ask-side depth (10 + 15 + 20), not capped at the requested 20.
+        assert_eq!(impact.total_quantity_available, 45);
         assert_eq!(impact.levels_consumed, 2);
         assert_eq!(impact.worst_price, 105);
         assert_eq!(impact.slippage, 5);
@@ -39,6 +40,31 @@ mod tests {
         assert_eq!(impact.levels_consumed, 1);
         assert!(!impact.can_fill(50));
         assert_eq!(impact.fill_ratio(50), 0.2);
+    }
+
+    #[test]
+    fn test_market_impact_reports_true_depth_beyond_request_issue_119() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+        // 45 units resting on the ask side across 3 levels.
+        let _ = book.add_limit_order(Id::new(), 100, 10, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(Id::new(), 105, 15, Side::Sell, TimeInForce::Gtc, None);
+        let _ = book.add_limit_order(Id::new(), 110, 20, Side::Sell, TimeInForce::Gtc, None);
+
+        // Request only 12, which the first two levels cover.
+        let impact = book.market_impact(12, Side::Buy);
+
+        // total_quantity_available reports the *true* resting depth (45), not
+        // the capped fill quantity (12), so can_fill / fill_ratio are
+        // meaningful: there is depth to spare and the ratio exceeds 1.0.
+        assert_eq!(impact.total_quantity_available, 45);
+        assert!(impact.can_fill(12));
+        assert!(impact.can_fill(45));
+        assert!(!impact.can_fill(46));
+        assert_eq!(impact.fill_ratio(12), 45.0 / 12.0);
+        assert!(impact.fill_ratio(12) > 1.0);
+        // Impact metrics still describe only the consumed portion.
+        assert_eq!(impact.levels_consumed, 2);
+        assert_eq!(impact.worst_price, 105);
     }
 
     #[test]
@@ -77,7 +103,8 @@ mod tests {
         // Sell 20 units (will consume 2 levels)
         let impact = book.market_impact(20, Side::Sell);
 
-        assert_eq!(impact.total_quantity_available, 20);
+        // Full bid-side depth (10 + 15 + 20), not capped at the requested 20.
+        assert_eq!(impact.total_quantity_available, 45);
         assert_eq!(impact.levels_consumed, 2);
         assert_eq!(impact.worst_price, 95);
         assert_eq!(impact.slippage, 5); // 100 - 95
@@ -253,7 +280,8 @@ mod tests {
 
         // Test market impact
         let impact = book.market_impact(50, Side::Buy);
-        assert_eq!(impact.total_quantity_available, 50);
+        // Full ask-side depth (25 + 35), not capped at the requested 50.
+        assert_eq!(impact.total_quantity_available, 60);
         assert!(impact.can_fill(50));
 
         // Test simulation

--- a/src/orderbook/trade.rs
+++ b/src/orderbook/trade.rs
@@ -205,6 +205,75 @@ pub struct TransactionInfo {
     pub taker_fee: i128,
 }
 
+impl TradeInfo {
+    /// Build a display-oriented [`TradeInfo`] from a [`TradeResult`],
+    /// populating each [`TransactionInfo`]'s per-transaction maker/taker
+    /// fees from `fee_schedule`.
+    ///
+    /// For every transaction the fee is what the configured [`FeeSchedule`]
+    /// charges on that transaction's notional (`price × quantity`):
+    /// `maker_fee = calculate_fee(notional, true)` (negative for a rebate)
+    /// and `taker_fee = calculate_fee(notional, false)`. When `fee_schedule`
+    /// is `None` (or a zero-fee schedule) every per-transaction fee is `0`.
+    ///
+    /// The per-transaction fees sum to the aggregate
+    /// [`TradeResult::total_maker_fees`] / [`TradeResult::total_taker_fees`]
+    /// produced by [`TradeResult::with_fees`] for the same schedule, so the
+    /// detailed and aggregate views are consistent. This is the
+    /// authoritative engine-side population path for the `TransactionInfo`
+    /// fee fields; consumers should prefer it to constructing
+    /// `TransactionInfo` by hand (which historically left the fees at `0`).
+    #[must_use]
+    pub fn from_trade_result(
+        trade_result: &TradeResult,
+        fee_schedule: Option<&FeeSchedule>,
+    ) -> Self {
+        let match_result = &trade_result.match_result;
+        let schedule = fee_schedule.filter(|s| !s.is_zero_fee());
+
+        let transactions: Vec<TransactionInfo> = match_result
+            .trades()
+            .as_vec()
+            .iter()
+            .map(|tx| {
+                let notional = tx
+                    .price()
+                    .as_u128()
+                    .saturating_mul(u128::from(tx.quantity().as_u64()));
+                let (maker_fee, taker_fee) = match schedule {
+                    Some(s) => (
+                        s.calculate_fee(notional, true),
+                        s.calculate_fee(notional, false),
+                    ),
+                    None => (0, 0),
+                };
+                TransactionInfo {
+                    price: tx.price().as_u128(),
+                    quantity: tx.quantity().as_u64(),
+                    transaction_id: tx.trade_id().to_string(),
+                    maker_order_id: tx.maker_order_id().to_string(),
+                    taker_order_id: tx.taker_order_id().to_string(),
+                    maker_fee,
+                    taker_fee,
+                }
+            })
+            .collect();
+
+        Self {
+            symbol: trade_result.symbol.clone(),
+            order_id: match_result.order_id().to_string(),
+            executed_quantity: match_result
+                .executed_quantity()
+                .map(|q| q.as_u64())
+                .unwrap_or(0),
+            remaining_quantity: match_result.remaining_quantity().as_u64(),
+            is_complete: match_result.is_complete(),
+            transaction_count: match_result.trades().len(),
+            transactions,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -319,6 +388,55 @@ mod tests {
         assert_eq!(tr.total_taker_fees, 5_000);
         assert_eq!(tr.total_fees(), 2_500);
         assert!(tr.total_maker_fees < 0); // rebate
+    }
+
+    #[test]
+    fn test_trade_info_from_result_populates_per_transaction_fees_issue_119() {
+        let schedule = FeeSchedule::new(-2, 5); // -2 bps maker rebate, 5 bps taker
+        let mr = make_match_result_with_trades(vec![
+            make_trade(1000, 10), // notional 10_000 → maker -2, taker 5
+            make_trade(2000, 20), // notional 40_000 → maker -8, taker 20
+        ]);
+        let tr = TradeResult::with_fees("BTC/USD".to_string(), mr, Some(schedule));
+
+        let info = TradeInfo::from_trade_result(&tr, Some(&schedule));
+
+        assert_eq!(info.symbol, "BTC/USD");
+        assert_eq!(info.transaction_count, 2);
+        assert_eq!(info.transactions.len(), 2);
+
+        // Per-transaction fees are populated (no longer hard-zero).
+        assert_eq!(info.transactions[0].maker_fee, -2);
+        assert_eq!(info.transactions[0].taker_fee, 5);
+        assert_eq!(info.transactions[1].maker_fee, -8);
+        assert_eq!(info.transactions[1].taker_fee, 20);
+
+        // The detailed view sums to the aggregate TradeResult fees.
+        let maker_sum: i128 = info.transactions.iter().map(|t| t.maker_fee).sum();
+        let taker_sum: i128 = info.transactions.iter().map(|t| t.taker_fee).sum();
+        assert_eq!(maker_sum, tr.total_maker_fees);
+        assert_eq!(taker_sum, tr.total_taker_fees);
+    }
+
+    #[test]
+    fn test_trade_info_from_result_none_schedule_zero_fees_issue_119() {
+        let mr = make_match_result_with_trades(vec![make_trade(1000, 10)]);
+        let tr = TradeResult::new("ETH/USD".to_string(), mr);
+
+        // No schedule → per-transaction fees are zero, metadata still populated.
+        let info = TradeInfo::from_trade_result(&tr, None);
+        assert_eq!(info.transaction_count, 1);
+        assert_eq!(info.transactions.len(), 1);
+        assert_eq!(info.transactions[0].maker_fee, 0);
+        assert_eq!(info.transactions[0].taker_fee, 0);
+        assert_eq!(info.transactions[0].price, 1000);
+        assert_eq!(info.transactions[0].quantity, 10);
+
+        // A zero-fee schedule is treated the same as no schedule.
+        let zero = FeeSchedule::zero_fee();
+        let info_zero = TradeInfo::from_trade_result(&tr, Some(&zero));
+        assert_eq!(info_zero.transactions[0].maker_fee, 0);
+        assert_eq!(info_zero.transactions[0].taker_fee, 0);
     }
 
     #[test]

--- a/tests/unit/validation_tests.rs
+++ b/tests/unit/validation_tests.rs
@@ -1,4 +1,4 @@
-use orderbook_rs::OrderBook;
+use orderbook_rs::{OrderBook, OrderBookError};
 use pricelevel::{Hash32, Id, OrderType, Price, Quantity, Side, TimeInForce, TimestampMs};
 
 #[cfg(test)]
@@ -783,5 +783,42 @@ mod tests {
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
         assert!(msg.contains("lot size"), "Should fail on lot: {msg}");
+    }
+
+    #[test]
+    fn test_add_order_rejects_duplicate_order_id_issue_119() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+        let id = Id::new_uuid();
+
+        // First order rests on the book.
+        let first = book.add_limit_order(id, 100, 10, Side::Sell, TimeInForce::Gtc, None);
+        assert!(first.is_ok());
+
+        // A second order reusing the same id is rejected with the typed error,
+        // not silently overwritten (which would orphan the resting order).
+        let dup = book.add_limit_order(id, 105, 5, Side::Sell, TimeInForce::Gtc, None);
+        assert!(
+            matches!(&dup, Err(OrderBookError::DuplicateOrderId { order_id }) if *order_id == id),
+            "duplicate id must be rejected: {dup:?}"
+        );
+
+        // The original order is untouched: still resting at its original price,
+        // and cancellable by its id.
+        let cancelled = book
+            .cancel_order(id)
+            .expect("cancel succeeds")
+            .expect("original order still resting");
+        assert_eq!(
+            cancelled.price().as_u128(),
+            100,
+            "the rejected duplicate must not have relocated the original order"
+        );
+
+        // After the original is gone the id is free to reuse.
+        let reused = book.add_limit_order(id, 110, 7, Side::Sell, TimeInForce::Gtc, None);
+        assert!(
+            reused.is_ok(),
+            "id is reusable once the original is removed"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Three public surfaces claimed behavior the engine never implemented (issue #119). All three are now backed by real engine paths.

### 1. `DuplicateOrderId` (wire code 12)
The stable reject code was never emitted and `add_order` performed no duplicate-id check — it silently overwrote the resting order's `order_locations` entry, orphaning it (the prior order could no longer be cancelled or modified by id). `add_order` now rejects an incoming order whose id already rests on the book with the new `OrderBookError::DuplicateOrderId { order_id }`, mapped to `RejectReason::DuplicateOrderId`.

- The check lives in `add_order`, **not** the shared `validate_order_shape`: the validate-first atomic modify (#98) runs that validator while the original same-id order is still resting, so a check there would false-reject every modify. Modify routes `cancel(old) → add(new)`, so the id is absent at re-add time.
- It does **not** record an `OrderStatus::Rejected` transition — the id belongs to a *different* live order whose tracked state must not be clobbered. The typed error (synchronous return) + the wire reject code are the surface.
- It is a **sequential** guard, not a concurrency guard: serializing order ids across concurrent submissions is the ingress/sequencing layer's job (documented on the variant and at the check site).

### 2. `TransactionInfo` per-transaction fees
`maker_fee` / `taker_fee` were documented as per-transaction fees but no engine path populated them (consumers set them to `0`). The new `TradeInfo::from_trade_result(&TradeResult, Option<&FeeSchedule>)` computes each transaction's fee from the schedule. Both this and `TradeResult::with_fees` truncate **per-trade** (never on an aggregated notional), so the per-transaction fees sum **exactly** to `total_maker_fees` / `total_taker_fees`. The `market_trades_demo` example now delegates to it.

### 3. `MarketImpact.total_quantity_available` = true depth
It was set to the requested-capped fill quantity, making `can_fill` trivially true and `fill_ratio` capped at `1.0`. It now accumulates the **true resting depth** across the whole side being hit; the impact metrics (`avg_price`/`worst_price`/`slippage`/`levels_consumed`) still describe only the consumed portion, so `fill_ratio` can exceed `1.0`. The two reference frames and the degenerate `quantity == 0` no-op are documented. This is a read-only analytics query (now O(N) over the side), not on the matching hot path.

## Review

- **determinism-auditor**: PASS — replay-safe. Dup-id is a pure point lookup; `market_impact` iterates key-ordered SkipMaps and writes only to a returned value struct (never journaled/emitted); `from_trade_result` is pure over an insertion-ordered Vec.
- **hotpath-reviewer**: PASS — one extra `DashMap` point lookup per admission (no alloc/clone, `Id` is `Copy`); `market_impact` confirmed query-only, not reachable from matching.
- **microstructure-critic**: dup-id policy and fee self-consistency PASS (per-trade truncation means no rounding drift; `order_locations` is the exact liveness predicate). Two non-blocking contract-accuracy notes addressed in docs: the dup-id check guards sequential reuse not concurrent submission, and `market_impact(0)`'s zero-depth degenerate result is now documented (plus the struct's two reference frames).

## Tests

- Duplicate-id rejection: second add with the same id returns `DuplicateOrderId`, the original stays resting at its price, and the id is reusable after the original is removed.
- Per-transaction fees populated and summing to the aggregate `TradeResult` fees (multi-trade + rebate); zero/none schedule → zero fees.
- True-depth market impact: `total_quantity_available` reports full side depth, `can_fill` honest, `fill_ratio > 1.0`; existing impact assertions updated to true depth.
- `cargo test --all-features`, `clippy --all-targets --all-features -D warnings`, `fmt --check`, release build all clean.

Closes #119
