### PR TITLE
fix(robustness): reject zero quantity and zero price at the NewOrder wire boundary (#125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Reject zero quantity and zero price at the `NewOrder` wire boundary (#125).**
+  `TryFrom<&NewOrderWire> for OrderType<()>` validated padding, negative price,
+  side, time-in-force, and order type but never checked `qty`, so a wire `qty == 0`
+  became a degenerate `OrderType::Standard { quantity: 0 }` that slipped past the
+  default-config lot check (passes for 0) and `min_order_size` (defaults to `None`)
+  and reached the insert/match path. The boundary now rejects `qty == 0` with
+  `WireError::InvalidPayload("NewOrder: zero quantity")`. **Decision (price 0):**
+  also reject `price == 0` (`"NewOrder: zero price"`) — price 0 is the cache's
+  "no best price" sentinel and a zero-priced limit order is structurally
+  meaningless, so only `price > 0` is admissible. `CancelReplaceWire` carries a
+  `new_qty` field but has no domain conversion yet, so there is nothing to mirror;
+  the same guard should be added when it gains one.
 - **Resolve declared-but-unemitted wire/event surfaces (#119).** Three public
   surfaces claimed behavior the engine never implemented; all three are now backed
   by real engine paths. (a) `RejectReason::DuplicateOrderId` (stable wire code 12)

--- a/src/wire/inbound/new_order.rs
+++ b/src/wire/inbound/new_order.rs
@@ -101,6 +101,9 @@ impl TryFrom<&NewOrderWire> for OrderType<()> {
     /// Returns [`WireError::InvalidPayload`] when the wire message is malformed:
     /// - non-zero reserved padding (`_pad`),
     /// - a negative `price`,
+    /// - `price == 0` (the cache "no best price" sentinel; only `price > 0`
+    ///   is admissible),
+    /// - `qty == 0` (a zero-quantity order is structurally meaningless),
     /// - `account_id == 0` (reserved — it would collide with the
     ///   `Hash32::zero()` "no STP" sentinel),
     /// - an unknown `side` byte (not `SIDE_BUY` / `SIDE_SELL`),
@@ -127,6 +130,19 @@ impl TryFrom<&NewOrderWire> for OrderType<()> {
         }
         if price_raw < 0 {
             return Err(WireError::InvalidPayload("NewOrder: negative price"));
+        }
+        // Reject `price == 0` at the trust boundary: price 0 is the cache's
+        // "no best price" sentinel and a zero-priced limit order is
+        // structurally meaningless. Only `price > 0` is admissible.
+        if price_raw == 0 {
+            return Err(WireError::InvalidPayload("NewOrder: zero price"));
+        }
+        // Reject `qty == 0`: a zero-quantity order is structurally meaningless
+        // and otherwise slips through (the lot check passes for 0 and
+        // `min_order_size` defaults to `None`), reaching the insert/match path
+        // as a degenerate order. Reject it close to the source.
+        if qty == 0 {
+            return Err(WireError::InvalidPayload("NewOrder: zero quantity"));
         }
         // `account_id == 0` is reserved: it encodes to an all-zero `Hash32`,
         // which equals `Hash32::zero()` — the "no STP" sentinel — so an order
@@ -312,6 +328,50 @@ mod tests {
             pricelevel::Hash32::zero(),
             "a valid account must never produce the no-STP sentinel"
         );
+    }
+
+    #[test]
+    fn try_from_rejects_zero_quantity_issue_125() {
+        // A zero-quantity order is structurally meaningless and otherwise slips
+        // past the default-config lot / min-size checks. Reject it precisely.
+        let wire = NewOrderWire {
+            client_ts: 0,
+            order_id: 1,
+            account_id: 2,
+            price: 100,
+            qty: 0,
+            side: SIDE_BUY,
+            time_in_force: TIF_GTC,
+            order_type: ORDER_TYPE_STANDARD,
+            _pad: [0u8; 5],
+        };
+        let res: Result<OrderType<()>, _> = (&wire).try_into();
+        assert!(matches!(
+            res,
+            Err(WireError::InvalidPayload("NewOrder: zero quantity"))
+        ));
+    }
+
+    #[test]
+    fn try_from_rejects_zero_price_issue_125() {
+        // price 0 is the cache "no best price" sentinel; only price > 0 is
+        // admissible at the wire boundary.
+        let wire = NewOrderWire {
+            client_ts: 0,
+            order_id: 1,
+            account_id: 2,
+            price: 0,
+            qty: 5,
+            side: SIDE_BUY,
+            time_in_force: TIF_GTC,
+            order_type: ORDER_TYPE_STANDARD,
+            _pad: [0u8; 5],
+        };
+        let res: Result<OrderType<()>, _> = (&wire).try_into();
+        assert!(matches!(
+            res,
+            Err(WireError::InvalidPayload("NewOrder: zero price"))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`TryFrom<&NewOrderWire> for OrderType<()>` validated padding, negative price, side, time-in-force, and order type but never checked `qty` (issue #125). A wire `qty == 0` became a degenerate `OrderType::Standard { quantity: 0 }` that slipped past the default-config lot check (passes for `0`) and `min_order_size` (defaults to `None`), reaching the insert/match path. The wire layer is the trust boundary for an untrusted gateway peer, so a structurally-meaningless order is now rejected here, close to the source, with a precise `WireError`.

- `qty == 0` → `WireError::InvalidPayload("NewOrder: zero quantity")`
- **Decision on price 0 (rejected):** `price == 0` → `WireError::InvalidPayload("NewOrder: zero price")`. Price 0 is the cache's "no best price" sentinel and a zero-priced limit order is structurally meaningless, so only `price > 0` is admissible. (Previously only negative price was rejected.)

`CancelReplaceWire` carries a `new_qty` field but has **no** domain conversion yet (only byte decode + roundtrip), so there is nothing to mirror; the same guard should be added when it gains one.

## Scope

Pure additive validation at the wire ingress boundary — no matching, sequencer, serialization, or NATS surface touched, and not on the matching hot path (two integer comparisons in `TryFrom`). No public API change.

## Tests

- `try_from_rejects_zero_quantity_issue_125` and `try_from_rejects_zero_price_issue_125` assert each rejection with its exact `WireError::InvalidPayload` message.
- The existing byte-roundtrip proptest is unaffected (it exercises `decode_new_order`, not the domain `TryFrom`).
- `cargo test --all-features`, `clippy --all-targets --all-features -D warnings`, `fmt --check`, release build all clean.

Closes #125
