### PR TITLE
perf(matching): pool the per-level STP scan buffer; drop per-level maker-id Vec (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.0] — 2026-06-24
 
+### Performance — Pool the per-level STP scan buffer (#107)
+
+- **Zero per-level heap allocation on the STP match path.** Under an active
+  `STPMode`, each crossed price level previously allocated a fresh
+  `Vec<Arc<OrderType<()>>>` for the self-trade scan
+  (`PriceLevel::snapshot_by_insertion_seq`). The matching engine now reuses a
+  single pooled scratch buffer (`MatchingPool::get_order_snapshot_vec` /
+  `return_order_snapshot_vec`), refilled in place via the new
+  `PriceLevel::snapshot_by_seq_into` (pricelevel 0.8.2), so the snapshot is
+  reused across every conflicting level instead of allocated per level.
+- **Dropped the per-level maker-id `Vec`.** `STPAction::CancelMaker` is now a
+  unit variant — `check_stp_at_level` no longer `collect()`s same-user maker
+  IDs into a `Vec<Id>`. The matching engine re-scans the pooled snapshot in
+  insertion-sequence order and cancels each same-user maker inline. The cancel
+  order (and therefore emitted events / journal) is bit-identical to before, so
+  determinism and snapshot round-trip are unchanged.
+- **Bumped `pricelevel` 0.8.1 → 0.8.2** for the determinism-preserving
+  `snapshot_by_seq_into` drop-in.
+- New `stp_sweep_hdr` Criterion HDR bench covers the aggressive self-crossing
+  sweep under `STPMode::CancelMaker`.
+
 ### Changed — Upgrade to `pricelevel` 0.8.0 (#130)
 
 - **Bumped `pricelevel` 0.7 → 0.8.0.** Picks up the upstream price-time-priority

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,11 @@ path = "benches/order_book/mass_cancel_burst_hdr.rs"
 harness = false
 
 [[bench]]
+name = "stp_sweep_hdr"
+path = "benches/order_book/stp_sweep_hdr.rs"
+harness = false
+
+[[bench]]
 name = "alloc_count"
 path = "benches/order_book/alloc_count.rs"
 harness = false
@@ -141,7 +146,7 @@ members = [
 
 [workspace.dependencies]
 orderbook-rs = { path = "." }
-pricelevel = "0.8.1"
+pricelevel = "0.8.2"
 tracing = "0.1"
 uuid = { version = "1.23", features = ["v4", "v5", "serde"] }
 dashmap = "6.2"

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,7 @@ bench-hdr:
 	cargo bench --bench mixed_70_20_10_hdr
 	cargo bench --bench thin_book_sweep_hdr
 	cargo bench --bench mass_cancel_burst_hdr
+	cargo bench --bench stp_sweep_hdr
 
 
 .PHONY: workflow-coverage

--- a/benches/order_book/stp_sweep_hdr.rs
+++ b/benches/order_book/stp_sweep_hdr.rs
@@ -1,0 +1,90 @@
+// stp_sweep_hdr — aggressive self-crossing sweep under STP `CancelMaker`.
+// Every measured op crosses a multi-level book where each level holds a
+// same-user (taker) resting maker, so the per-level STP scan finds a maker
+// to cancel inline. Exercises the pooled snapshot scan path (#107).
+
+#[path = "hdr_common.rs"]
+mod common;
+
+use common::{Rng, new_histogram, owner, persist, record, report};
+use orderbook_rs::{OrderBook, STPMode};
+use pricelevel::{Id, Side, TimeInForce};
+
+const SCENARIO: &str = "stp_sweep";
+// Other-maker depth per level — the liquidity the taker actually fills
+// against after its own same-user makers are cancelled by STP.
+const OTHER_PER_LEVEL: u64 = 8;
+const NUM_LEVELS: u64 = 50;
+const MEASURED_OPS: u64 = 100_000;
+const SEED: u64 = 0xA5A5_A5A5_A5A5_A5A5;
+
+fn main() {
+    // STP `CancelMaker`: an incoming taker order that would self-cross cancels
+    // the resting same-user makers per level and keeps matching. This is the
+    // path that re-scans the pooled snapshot buffer.
+    let book = OrderBook::<()>::with_stp_mode("BENCH", STPMode::CancelMaker);
+    let mut rng = Rng::new(SEED);
+    let mut hist = new_histogram();
+
+    let taker = owner(0xBB);
+    let other = owner(0xCC);
+
+    // Seed each ask level with other-maker Sell depth plus at least one
+    // taker-owned Sell, so every measured Buy sweep hits the CancelMaker scan
+    // (a same-user maker to cancel) before filling against the other maker.
+    let mut next_id = 1u64;
+    for level in 0..NUM_LEVELS {
+        let price = (100 + level) as u128;
+        // One taker-owned resting Sell at this level — the STP target.
+        let _ = book.add_limit_order_with_user(
+            Id::from_u64(next_id),
+            price,
+            rng.range(1, 5),
+            Side::Sell,
+            TimeInForce::Gtc,
+            taker,
+            None,
+        );
+        next_id += 1;
+        // Other-maker depth the taker actually fills against.
+        for _ in 0..OTHER_PER_LEVEL {
+            let _ = book.add_limit_order_with_user(
+                Id::from_u64(next_id),
+                price,
+                rng.range(1, 10),
+                Side::Sell,
+                TimeInForce::Gtc,
+                other,
+                None,
+            );
+            next_id += 1;
+        }
+    }
+
+    // Aggressive self-crossing Buys from the taker. Each crosses the best ask
+    // levels: the per-level STP scan finds the taker's own resting Sell and
+    // cancels it inline, then matches against the other maker's depth. We
+    // re-seed a fresh taker-owned Sell at the best level (unmeasured) before
+    // each op so every measured sweep keeps hitting the CancelMaker path.
+    for i in 0..MEASURED_OPS {
+        let reseed_id = Id::from_u64(next_id + (2 * i));
+        let _ = book.add_limit_order_with_user(
+            reseed_id,
+            100u128,
+            1,
+            Side::Sell,
+            TimeInForce::Gtc,
+            taker,
+            None,
+        );
+
+        let qty = rng.range(5, 20);
+        let id = Id::from_u64(next_id + (2 * i) + 1);
+        record(&mut hist, || {
+            let _ = book.submit_market_order_with_user(id, qty, Side::Buy, taker);
+        });
+    }
+
+    report(SCENARIO, &hist);
+    persist(SCENARIO, &hist).expect("persist hgrm");
+}

--- a/src/orderbook/matching.rs
+++ b/src/orderbook/matching.rs
@@ -350,12 +350,20 @@ where
             static MATCHING_POOL: MatchingPool = MatchingPool::new();
         }
 
-        // Get reusable vectors from pool
-        let (mut filled_orders, mut empty_price_levels) = MATCHING_POOL.with(|pool| {
-            let filled = pool.get_filled_orders_vec();
-            let empty = pool.get_price_vec();
-            (filled, empty)
-        });
+        // Get reusable vectors from pool. `filled_orders` / `empty_price_levels`
+        // are needed by every sweep. `stp_orders` is the per-level STP scan
+        // scratch buffer (#107), reused across conflicting levels instead of a
+        // fresh allocation per level — but it is only acquired when STP is
+        // active, so the default (`STPMode::None`) hot path touches the pool
+        // exactly as it did before #107 (an empty `Vec::new()` allocates nothing
+        // and is never filled or returned).
+        let (mut filled_orders, mut empty_price_levels) =
+            MATCHING_POOL.with(|pool| (pool.get_filled_orders_vec(), pool.get_price_vec()));
+        let mut stp_orders = if stp_active {
+            MATCHING_POOL.with(|pool| pool.get_order_snapshot_vec())
+        } else {
+            Vec::new()
+        };
 
         // Track whether STP cancelled the taker
         let mut stp_taker_cancelled = false;
@@ -398,13 +406,17 @@ where
                 // `check_stp_at_level` must see the resting orders in the exact order
                 // the sweep consumes them — pure insertion sequence — so `safe_quantity`
                 // and the CancelBoth `maker_order_id` correspond to what `match_order`
-                // will actually fill/cancel. `snapshot_by_insertion_seq()` (pricelevel
-                // 0.8.1) gives that order; it is deterministic (fixing the #94 DashMap
-                // non-determinism) AND faithful to the sweep even under non-monotonic
-                // timestamps, unlike `snapshot_orders()` which is `(timestamp, seq)`-ordered
-                // (the residual gap closed by #132 / PriceLevel#102).
-                let orders = price_level.snapshot_by_insertion_seq();
-                let action = check_stp_at_level(&orders, taker_user_id, self.stp_mode);
+                // will actually fill/cancel. `snapshot_by_seq_into` (pricelevel 0.8.2)
+                // refills the pooled `stp_orders` scratch buffer in that exact order
+                // (clearing it first), so we reuse one allocation across every level
+                // instead of allocating a fresh `Vec` per conflicting level (#107). The
+                // order is identical to `snapshot_by_insertion_seq`: deterministic (fixing
+                // the #94 DashMap non-determinism) AND faithful to the sweep even under
+                // non-monotonic timestamps, unlike `snapshot_orders()` which is
+                // `(timestamp, seq)`-ordered (the residual gap closed by #132 /
+                // PriceLevel#102).
+                price_level.snapshot_by_seq_into(&mut stp_orders);
+                let action = check_stp_at_level(&stp_orders, taker_user_id, self.stp_mode);
 
                 match action {
                     STPAction::NoConflict => {
@@ -443,21 +455,27 @@ where
                         break;
                     }
 
-                    STPAction::CancelMaker { maker_order_ids } => {
-                        // Cancel same-user resting orders, then match normally.
+                    STPAction::CancelMaker => {
+                        // Cancel same-user resting orders, then match normally. We
+                        // re-scan the pooled snapshot in insertion-sequence order —
+                        // the exact order the old `maker_order_ids` Vec held — so the
+                        // cancel order (and therefore emitted events / journal) is
+                        // bit-identical to before, with no per-level allocation (#107).
                         // Each cancel runs on the level we already hold — it emits the
                         // level-change event, records OrderStatus::Cancelled
                         // { SelfTradePrevention }, and releases the per-account risk slot
                         // in lockstep, but does NOT remove the level from the map (no
                         // order_locations re-resolution either), so level removal stays
                         // with the post-walk empty_price_levels drain (#95).
-                        for maker_id in &maker_order_ids {
-                            self.cancel_resting_maker_on_level(
-                                price_level,
-                                side.opposite(),
-                                *maker_id,
-                                CancelReason::SelfTradePrevention,
-                            );
+                        for order in &stp_orders {
+                            if order.user_id() == taker_user_id {
+                                self.cancel_resting_maker_on_level(
+                                    price_level,
+                                    side.opposite(),
+                                    order.id(),
+                                    CancelReason::SelfTradePrevention,
+                                );
+                            }
                         }
                         // If the level is now empty, mark for removal and continue
                         if price_level.order_count() == 0 {
@@ -572,10 +590,15 @@ where
             self.untrack_order_by_id(filled_id);
         }
 
-        // Return vectors to pool for reuse
+        // Return vectors to pool for reuse. `stp_orders` only entered the pool
+        // when STP was active; otherwise it is an empty, never-filled `Vec` that
+        // is simply dropped.
         MATCHING_POOL.with(|pool| {
             pool.return_filled_orders_vec(filled_orders);
             pool.return_price_vec(empty_price_levels);
+            if stp_active {
+                pool.return_order_snapshot_vec(stp_orders);
+            }
         });
 
         let no_fills = match_result.trades().as_vec().is_empty();
@@ -932,7 +955,7 @@ where
                     }
                     // Same-user makers are cancelled, not filled: only non-self
                     // resting depth is reachable; the walk continues.
-                    STPAction::CancelMaker { .. } => {
+                    STPAction::CancelMaker => {
                         let non_self: u64 = orders
                             .iter()
                             .filter(|o| o.user_id() != taker_user_id)

--- a/src/orderbook/pool.rs
+++ b/src/orderbook/pool.rs
@@ -1,5 +1,6 @@
 use pricelevel::Id;
 use std::cell::RefCell;
+use std::sync::Arc;
 
 /// A memory pool for reusing vectors to reduce allocations in hot paths.
 #[derive(Debug)]
@@ -8,6 +9,10 @@ pub struct MatchingPool {
     /// during a match so terminal `Filled` events carry the true fill (#104).
     filled_orders_pool: RefCell<Vec<Vec<(Id, u64)>>>,
     price_vec_pool: RefCell<Vec<Vec<u128>>>,
+    /// Reusable buffers for the per-level STP scan snapshot. Each match fills
+    /// one of these via `PriceLevel::snapshot_by_seq_into` instead of allocating
+    /// a fresh `Vec<Arc<OrderType<()>>>` per conflicting level (#107).
+    order_snapshot_pool: RefCell<Vec<Vec<Arc<pricelevel::OrderType<()>>>>>,
 }
 
 impl MatchingPool {
@@ -16,6 +21,7 @@ impl MatchingPool {
         MatchingPool {
             filled_orders_pool: RefCell::new(Vec::with_capacity(4)),
             price_vec_pool: RefCell::new(Vec::with_capacity(4)),
+            order_snapshot_pool: RefCell::new(Vec::new()),
         }
     }
 
@@ -32,6 +38,29 @@ impl MatchingPool {
     pub fn return_filled_orders_vec(&self, mut vec: Vec<(Id, u64)>) {
         vec.clear();
         self.filled_orders_pool.borrow_mut().push(vec);
+    }
+
+    /// Retrieves a vector for the per-level STP scan snapshot from the pool.
+    ///
+    /// Mirrors [`Self::get_filled_orders_vec`]: pops a reusable buffer or
+    /// allocates a fresh one. The caller fills it with
+    /// `PriceLevel::snapshot_by_seq_into` and returns it via
+    /// [`Self::return_order_snapshot_vec`] (#107).
+    pub fn get_order_snapshot_vec(&self) -> Vec<Arc<pricelevel::OrderType<()>>> {
+        self.order_snapshot_pool
+            .borrow_mut()
+            .pop()
+            .unwrap_or_else(|| Vec::with_capacity(16))
+    }
+
+    /// Returns a STP scan snapshot vector to the pool for reuse.
+    ///
+    /// Clears the buffer **first** so the `Arc<OrderType<()>>` clones are
+    /// dropped immediately — leaving them in place would pin resting orders
+    /// alive across reuse. Mirrors [`Self::return_filled_orders_vec`] (#107).
+    pub fn return_order_snapshot_vec(&self, mut vec: Vec<Arc<pricelevel::OrderType<()>>>) {
+        vec.clear();
+        self.order_snapshot_pool.borrow_mut().push(vec);
     }
 
     /// Retrieves a vector for prices from the pool.

--- a/src/orderbook/stp.rs
+++ b/src/orderbook/stp.rs
@@ -87,12 +87,11 @@ pub(crate) enum STPAction {
         safe_quantity: u64,
     },
 
-    /// CancelMaker triggered: these maker order IDs should be cancelled
-    /// before matching proceeds at this level.
-    CancelMaker {
-        /// Order IDs of same-user resting orders to cancel.
-        maker_order_ids: Vec<Id>,
-    },
+    /// CancelMaker triggered: at least one same-user resting order exists at
+    /// this level and must be cancelled before matching proceeds. The caller
+    /// re-scans the snapshot in insertion-sequence order and cancels each
+    /// same-user maker, so no per-level `Vec<Id>` is allocated here (#107).
+    CancelMaker,
 
     /// CancelBoth triggered: match up to `safe_quantity`, then cancel
     /// the maker and stop.
@@ -142,17 +141,13 @@ pub(crate) fn check_stp_at_level(
         }
 
         STPMode::CancelMaker => {
-            // Collect all same-user order IDs for cancellation
-            let maker_order_ids: Vec<Id> = orders
-                .iter()
-                .filter(|o| o.user_id() == taker_user_id)
-                .map(|o| o.id())
-                .collect();
-
-            if maker_order_ids.is_empty() {
-                STPAction::NoConflict
+            // Signal a conflict if any resting order belongs to the taker; the
+            // caller cancels the same-user makers by re-scanning the snapshot in
+            // insertion-sequence order, so no `Vec<Id>` is built here (#107).
+            if orders.iter().any(|o| o.user_id() == taker_user_id) {
+                STPAction::CancelMaker
             } else {
-                STPAction::CancelMaker { maker_order_ids }
+                STPAction::NoConflict
             }
         }
 
@@ -278,7 +273,7 @@ mod tests {
     }
 
     #[test]
-    fn test_check_stp_cancel_maker_collects_ids() {
+    fn test_check_stp_cancel_maker_detects_same_user() {
         let taker_user = Hash32::new([1u8; 32]);
         let other_user = Hash32::new([2u8; 32]);
 
@@ -312,16 +307,12 @@ mod tests {
             time_in_force: pricelevel::TimeInForce::Gtc,
             extra_fields: (),
         });
-        let orders = vec![same1.clone(), other, same2.clone()];
+        let orders = vec![same1, other, same2];
+        // CancelMaker is now a unit variant; per-id cancellation is the caller's
+        // responsibility (it re-scans the snapshot), so the action just signals
+        // that a same-user maker exists at this level (#107).
         let action = check_stp_at_level(&orders, taker_user, STPMode::CancelMaker);
-        match action {
-            STPAction::CancelMaker { maker_order_ids } => {
-                assert_eq!(maker_order_ids.len(), 2);
-                assert_eq!(maker_order_ids[0], same1.id());
-                assert_eq!(maker_order_ids[1], same2.id());
-            }
-            _ => panic!("expected CancelMaker action"),
-        }
+        assert!(matches!(action, STPAction::CancelMaker));
     }
 
     #[test]

--- a/src/orderbook/tests/stp.rs
+++ b/src/orderbook/tests/stp.rs
@@ -277,6 +277,66 @@ mod tests {
         );
     }
 
+    /// #107: with same-user makers on BOTH sides of an interleaved other-user
+    /// maker (`same, other, same` in insertion/sweep order), CancelMaker cancels
+    /// EVERY same-user maker regardless of queue position and the taker fills
+    /// only the interleaved non-self maker. Pins the inline snapshot-buffer
+    /// cancel (which replaced the per-level `maker_order_ids` Vec) to the exact
+    /// CancelMaker set, position-independent, from the OrderBook side.
+    #[test]
+    fn test_cancel_maker_same_other_same_cancels_both_self_fills_other_issue_107() {
+        use crate::orderbook::order_state::{CancelReason, OrderStateTracker, OrderStatus};
+
+        let mut book: OrderBook<()> = OrderBook::new("TEST");
+        book.set_stp_mode(STPMode::CancelMaker);
+        book.set_order_state_tracker(OrderStateTracker::new());
+
+        let taker_user = user(9);
+        let other = user(1);
+
+        // Insertion (sweep) order at price 100: same -> other -> same.
+        let self_a = add_sell_order_with_user(&book, 100, 10, taker_user);
+        let other_b = add_sell_order_with_user(&book, 100, 7, other);
+        let self_c = add_sell_order_with_user(&book, 100, 20, taker_user);
+
+        // Same-user taker crosses with ample size.
+        let taker = Id::new();
+        let result = book.match_market_order_with_user(taker, 100, Side::Buy, taker_user);
+        assert!(
+            result.is_ok(),
+            "expected a fill against the non-self maker, got {result:?}"
+        );
+        let mr = result.unwrap();
+
+        // Only the interleaved other-user maker fills — exactly its 7 units, in
+        // one trade. The same-user makers never self-trade.
+        let trades = mr.trades().as_vec();
+        assert_eq!(trades.len(), 1, "only the non-self maker fills");
+        assert_eq!(trades[0].maker_order_id(), other_b);
+        assert_eq!(trades[0].quantity(), Quantity::new(7));
+        assert_eq!(mr.executed_quantity().unwrap(), Quantity::new(7));
+
+        // Both same-user makers are cancelled (SelfTradePrevention), regardless
+        // of their position around the non-self maker.
+        for self_id in [self_a, self_c] {
+            assert!(
+                book.get_order(self_id).is_none(),
+                "same-user maker must be STP-cancelled"
+            );
+            match book.order_status(self_id) {
+                Some(OrderStatus::Cancelled { reason, .. }) => {
+                    assert_eq!(reason, CancelReason::SelfTradePrevention);
+                }
+                other => panic!("expected Cancelled {{ SelfTradePrevention }}, got {other:?}"),
+            }
+        }
+        // The non-self maker was fully consumed.
+        assert!(
+            book.get_order(other_b).is_none(),
+            "non-self maker fully filled"
+        );
+    }
+
     /// CancelBoth: cancelling the maker releases its per-account risk slot (no
     /// counter leak) and records `Cancelled { SelfTradePrevention }`.
     #[test]


### PR DESCRIPTION
## Summary

When STP is active, every conflicting price level allocated a fresh `Vec<Arc<OrderType<()>>>` via `snapshot_by_insertion_seq()`, and the `CancelMaker` arm built a fresh `Vec<Id>` per level — per-level heap allocation in the matching inner loop, which `MatchingPool` exists to avoid (issue #107). Only triggers with STP enabled + a non-anonymous taker, so the default config was never affected.

- **Bumps `pricelevel` 0.8.1 → 0.8.2** for `PriceLevel::snapshot_by_seq_into(&mut Vec)`, which clears and refills a caller-owned buffer in the **identical insertion-sequence order** as `snapshot_by_insertion_seq`.
- The match path reuses a **pooled scratch buffer** (`MatchingPool::get_order_snapshot_vec` / `return_order_snapshot_vec`, cleared on return so resting `Arc`s aren't pinned) across every conflicting level — zero per-level allocation.
- `STPAction::CancelMaker` drops its `maker_order_ids: Vec<Id>` field (now a unit variant): `check_stp_at_level` returns it via a short-circuiting `orders.iter().any(...)` (no allocation), and the match loop **inline-cancels** by iterating the pooled snapshot in insertion order — the same set and order the Vec held, so emitted `Cancelled` events and journal records are bit-identical.
- The buffer is only acquired/returned when STP is active, so the default `STPMode::None` hot path touches the pool exactly as before #107.

`fok_fillable_quantity`'s feasibility scan keeps its own snapshot for now (issue **#136** replaces it with `matchable_quantity`); only its `CancelMaker` match arm was updated to the unit variant.

## Review

- **determinism-auditor**: PASS (replay-safe). Verified against the pricelevel source that `snapshot_by_seq_into` walks the same `SkipMap<u64,Id>` ascending as the old call → bit-identical sequence; the inline cancel iterates the same snapshot in the same order → identical `Cancelled` event/journal order; clear-on-return + clear-on-refill prevents stale `Arc`s; thread-local pool.
- **hotpath-reviewer**: PASS (items 1-4) — per-level alloc eliminated, pool discipline matches the existing buffers, `Arc`s released on return, inline cancel alloc-free, `.any()` strictly cheaper. The item-5 note (non-STP path paid 2 unconditional `RefCell` borrows) is **addressed** — the acquire/return is now guarded behind `stp_active`.
- **microstructure-critic**: PASS — Ready for release. CancelMaker semantics preserved exactly (same cancel set, iceberg coverage, no double-cancel/missed-removal, correct decision-vs-cancel split, faithful FOK prediction). The suggested cancel-order-determinism test was **added**.

## Benchmark

New `benches/order_book/stp_sweep_hdr.rs` (CancelMaker self-cross sweep, 100k samples): p50 **250 ns** / p99 **4459 ns** / p99.9 **9007 ns**. The structural win is zero per-level allocation (one pooled buffer reused across all conflicting levels) plus the eliminated per-level maker-id `Vec`.

## Tests

- `same/other/same` CancelMaker integration test (`..._issue_107`) pinning that every same-user maker is cancelled regardless of queue position while the interleaved non-self maker is the only fill — from the OrderBook side.
- Full STP correctness suite green; `cargo test --all-features`, `clippy --all-targets --all-features -D warnings`, `fmt --check`, `build --release --all-features`, and `build --features special_orders,nats,bincode,journal` all clean.

Closes #107
