### PR TITLE
refactor(matching): delegate FOK matchable-depth to PriceLevel::matchable_quantity (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.0] — 2026-06-24
 
+### Changed
+
+- **Delegate FOK matchable-depth to `PriceLevel::matchable_quantity` (#136).**
+  `fok_fillable_quantity` (#96) computed per-level reachable depth with a
+  hand-rolled `order_matchable_qty` sum (`visible + drawable_hidden`), a
+  re-implementation of pricelevel's authoritative dry-run that could silently
+  drift from `OrderType::match_against` if upstream replenishment/order-kind
+  semantics changed. The non-STP and STP-`NoConflict` paths now delegate to
+  `PriceLevel::matchable_quantity` (made `pub` in pricelevel 0.8.2) — the single
+  upstream source of truth for what `match_order` would consume — so the FOK
+  all-or-nothing verdict can no longer diverge from the real sweep. The
+  hand-rolled helper remains only for the STP `CancelMaker` case, which must sum
+  the *non-self* makers' depth (a per-user filter the upstream primitive cannot
+  express). Behavior is unchanged; the #96 reserve/iceberg FOK regression tests
+  still pass, plus a new iceberg-replenishable-hidden FOK fill test.
+
 ### Performance — Pool the per-level STP scan buffer (#107)
 
 - **Zero per-level heap allocation on the STP match path.** Under an active

--- a/src/orderbook/matching.rs
+++ b/src/orderbook/matching.rs
@@ -17,8 +17,18 @@ use std::sync::atomic::Ordering;
 /// hidden quantity the sweep can actually draw. An iceberg always replenishes
 /// its hidden tranche; a reserve only when `auto_replenish` is set — a
 /// non-auto-replenish reserve drops its hidden unfilled, so that hidden is NOT
-/// reachable depth. Used by FOK feasibility (#96) so undrawable hidden is never
-/// counted as fillable.
+/// reachable depth.
+///
+/// As of #136 the non-STP and STP-NoConflict FOK feasibility paths delegate to
+/// `PriceLevel::matchable_quantity` (the authoritative upstream dry run). This
+/// helper remains only for the STP `CancelMaker` case, which must sum the
+/// matchable depth of the *non-self* makers — a per-user filter the upstream
+/// primitive cannot express. It is therefore the one FOK-feasibility path that
+/// no longer rides on pricelevel's authoritative dry run, so its per-order total
+/// MUST stay equal to `OrderType::match_against`'s for every resting kind: if a
+/// new `OrderType` variant is added whose sweep total differs from
+/// `visible + drawable_hidden`, update this helper or the CancelMaker FOK path
+/// will silently mis-predict while the delegated paths stay correct.
 #[inline]
 fn order_matchable_qty(order: &OrderType<()>) -> u64 {
     let visible = order.visible_quantity().as_u64();
@@ -941,20 +951,26 @@ where
             let price_level = entry.value();
 
             // Reachable depth at this level — the quantity the real sweep could
-            // actually fill — using per-order *matchable* depth (visible + drawable
-            // hidden), not the level's raw total, so a non-auto-replenish reserve's
-            // undrawable hidden tranche is not counted (#96).
+            // actually fill. The non-STP and STP-NoConflict cases delegate to
+            // pricelevel's authoritative dry-run `PriceLevel::matchable_quantity`
+            // (pricelevel 0.8.2), the single upstream source of truth for what
+            // `match_order` would consume — including iceberg/reserve replenishment
+            // and the removal of a non-auto-replenish reserve's undrawable hidden —
+            // instead of re-deriving it from a hand-rolled per-order estimate that
+            // could silently drift from `match_against` (#136, follow-up to #96).
             let (reachable, stop_after) = if stp_active {
                 // Insertion-sequence order = the sweep's consumption order, so the
                 // feasibility STP decision matches the real match even under
                 // non-monotonic timestamps (#132).
                 let orders = price_level.snapshot_by_insertion_seq();
                 match check_stp_at_level(&orders, taker_user_id, self.stp_mode) {
-                    STPAction::NoConflict => {
-                        (orders.iter().map(|o| order_matchable_qty(o)).sum(), false)
-                    }
+                    // No self-trade: the whole level is reachable — delegate to the
+                    // upstream dry run.
+                    STPAction::NoConflict => (price_level.matchable_quantity(cap), false),
                     // Same-user makers are cancelled, not filled: only non-self
-                    // resting depth is reachable; the walk continues.
+                    // resting depth is reachable; the walk continues. The upstream
+                    // primitive cannot filter by user, so the non-self matchable
+                    // depth is still summed per order here.
                     STPAction::CancelMaker => {
                         let non_self: u64 = orders
                             .iter()
@@ -970,11 +986,7 @@ where
                     | STPAction::CancelBoth { safe_quantity, .. } => (safe_quantity, true),
                 }
             } else {
-                let reachable = price_level
-                    .iter_orders()
-                    .map(|o| order_matchable_qty(&o))
-                    .sum();
-                (reachable, false)
+                (price_level.matchable_quantity(cap), false)
             };
 
             matched = matched.saturating_add(cap.min(reachable));

--- a/src/orderbook/tests/matching.rs
+++ b/src/orderbook/tests/matching.rs
@@ -186,6 +186,49 @@ mod tests {
         );
     }
 
+    /// #136: the non-STP FOK feasibility path now delegates to the upstream
+    /// `PriceLevel::matchable_quantity`, which counts an iceberg's replenishable
+    /// hidden depth as drawable. A FOK whose size is covered only by visible +
+    /// replenished hidden must fill (not be killed) — the positive complement to
+    /// the non-replenish-reserve case above.
+    #[test]
+    fn test_fok_fills_against_iceberg_replenishable_hidden_issue_136() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+        book.add_order(OrderType::IcebergOrder {
+            id: Id::new(),
+            price: Price::new(100),
+            visible_quantity: Quantity::new(2),
+            hidden_quantity: Quantity::new(8),
+            side: Side::Sell,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(0),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        })
+        .expect("iceberg admitted");
+
+        // FOK buy 10 at price 100. Visible is only 2, but the iceberg replenishes
+        // its 8 hidden, so `matchable_quantity` reports 10 drawable → the FOK
+        // fills fully and consumes the level.
+        let fok = OrderType::Standard {
+            id: Id::new(),
+            price: Price::new(100),
+            quantity: Quantity::new(10),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            time_in_force: TimeInForce::Fok,
+            timestamp: TimestampMs::new(0),
+            extra_fields: (),
+        };
+        let result = book.add_order(fok);
+        assert!(
+            result.is_ok(),
+            "FOK must fill against an iceberg's replenishable depth, got {result:?}"
+        );
+        assert!(book.has_traded.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(book.asks.is_empty(), "the iceberg is fully consumed");
+    }
+
     #[test]
     fn test_market_buy_full_match() {
         let book = setup_book();


### PR DESCRIPTION
## Summary

`fok_fillable_quantity` (#96) computed per-level FOK reachable depth with a hand-rolled `order_matchable_qty` sum (`visible + drawable_hidden`) — a re-implementation of pricelevel's authoritative FIFO dry run that could silently drift from `OrderType::match_against` if upstream replenishment / order-kind semantics changed. The #96 microstructure review flagged this as a maintainability follow-up (issue #136).

pricelevel 0.8.2 makes `PriceLevel::matchable_quantity` **public** — the single upstream source of truth for what `match_order` would actually consume at a level (including iceberg/reserve replenishment and the removal of a non-auto-replenish reserve's undrawable hidden). The **non-STP** and **STP-`NoConflict`** feasibility paths now delegate to it, so the FOK all-or-nothing verdict can no longer diverge from the real sweep.

- `matchable_quantity(cap)` is bounded by the passed `cap` (so the surrounding `cap.min(..)` stays a no-op there) and is a documented cold-path-only dry run — the lot-rounding budget and price-limit break on the OrderBook side are unchanged.
- The hand-rolled `order_matchable_qty` remains **only** for the STP `CancelMaker` case, which must sum the *non-self* makers' depth — a per-user filter the upstream primitive cannot express. Its rustdoc now flags that it must track `match_against` for any future `OrderType` variant, since it is the one feasibility path no longer riding the upstream dry run.

## Review

- **determinism-auditor**: PASS (replay-safe). The feasibility total is additive across independent makers, so it is order-independent — `matchable_quantity`'s internal `(timestamp,seq)` snapshot ordering can change visit order but never the returned total, so the FOK admit/kill verdict stays deterministic. `matchable_quantity` is pure (no clock/rand). The change only affects the admit/kill decision, never the order of any emitted record.
- **microstructure-critic**: PASS — ready for release. `matchable_quantity` is the *same algorithm* as `match_order` (shared `match_against` decision, identical no-progress guard and replenish-to-tail routing), so verdict parity is exact for plain / iceberg / non-replenish-reserve resting kinds. `cap`-boundedness holds (`consumed ≤ remaining` per step). The CancelMaker non-self sum is the correct and only available model for the survivor set with no single-level total divergence. On untested edges (e.g. a zero-visible iceberg) the new delegation is *strictly more* faithful than the old sum.

## Tests

- The #96 reserve/iceberg FOK regression tests still pass (`test_fok_excludes_non_replenish_reserve_hidden_issue_96`, `test_fok_with_lot_size_fills_when_depth_suffices_issue_96`, `test_fok_under_stp_cancel_maker_kills_without_touching_makers`).
- New `test_fok_fills_against_iceberg_replenishable_hidden_issue_136`: a FOK fills fully against an iceberg whose hidden is replenishable, exercising the delegated `matchable_quantity` path (positive complement to the non-replenish-reserve kill case).
- `cargo test --all-features`, `clippy --all-targets --all-features -D warnings`, `fmt --check`, `build --release --all-features`, `build --features special_orders,nats,bincode,journal` all clean.

Closes #136
