### PR TITLE
fix(modifications): extend modify atomicity to STP self-cross taker-cancellation (#168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.0] — 2026-06-24
 
+### Fixed
+
+- **Extend modify atomicity to the STP self-cross taker-cancellation edge (#168).**
+  #98 made `UpdatePrice` / `UpdatePriceAndQuantity` / `Replace` validate-first for
+  every *pre-match* admission rejection, but one *post-match* case slipped
+  through: under `STPMode::CancelTaker` / `CancelBoth`, re-pricing an order so it
+  crosses into the **same user's** resting liquidity on the opposite side made
+  `add_order` match post-cancel and cancel the taker (the re-added order) — *after*
+  the original was already removed, destroying it. The modify guard now runs a
+  `check_modify_stp_self_cross` pre-check (after the risk check, before
+  `cancel_order`): it dry-runs the crossable opposite side in the sweep's
+  price-time order, consuming each non-self level's authoritative
+  `matchable_quantity`, and if it reaches a same-user maker while the taker still
+  has unfilled quantity — the exact condition under which the engine sets
+  `stp_taker_cancelled` — returns `OrderBookError::SelfTradePrevented` so the
+  original survives unchanged. No-op for STP `None` / `CancelMaker` (the taker
+  rests, never destroyed) and anonymous takers; lot-aligned by construction
+  (`validate_order_shape` runs first), so the verdict matches the engine exactly.
+
 ### Changed
 
 - **Delegate FOK matchable-depth to `PriceLevel::matchable_quantity` (#136).**

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -5,6 +5,7 @@ use crate::orderbook::matching::MatchOutcome;
 use crate::orderbook::order_state::{CancelReason, OrderStatus};
 use crate::orderbook::reject_reason::RejectReason;
 use crate::orderbook::trade::TradeResult;
+use either::Either;
 use pricelevel::{Id, OrderType, OrderUpdate, PriceLevel, Quantity, Side};
 use std::sync::Arc;
 use tracing::trace;
@@ -204,6 +205,11 @@ where
                         new_order.total_quantity(),
                     )?;
 
+                    // #168: reject a re-price that would self-cross the same
+                    // user's opposite-side liquidity under CancelTaker/CancelBoth
+                    // BEFORE cancelling the original, so the original survives.
+                    self.check_modify_stp_self_cross(&new_order)?;
+
                     // Both checks passed: cancel the original and add the
                     // updated order. `add_order` re-runs its own checks;
                     // post-cancel the account count is restored so its risk
@@ -325,6 +331,11 @@ where
                         new_order.price().as_u128(),
                         new_order.total_quantity(),
                     )?;
+
+                    // #168: reject a re-price that would self-cross the same
+                    // user's opposite-side liquidity under CancelTaker/CancelBoth
+                    // BEFORE cancelling the original, so the original survives.
+                    self.check_modify_stp_self_cross(&new_order)?;
 
                     // Both checks passed: cancel the original and add the
                     // updated order.
@@ -506,6 +517,11 @@ where
                         new_order.price().as_u128(),
                         new_order.total_quantity(),
                     )?;
+
+                    // #168: reject a re-price that would self-cross the same
+                    // user's opposite-side liquidity under CancelTaker/CancelBoth
+                    // BEFORE cancelling the original, so the original survives.
+                    self.check_modify_stp_self_cross(&new_order)?;
 
                     // Both checks passed: cancel the original and add the
                     // new order.
@@ -842,6 +858,92 @@ where
             }
         }
 
+        Ok(())
+    }
+
+    /// STP self-cross pre-check for the validate-first atomic modify (#168).
+    ///
+    /// Closes the one post-match modify-atomicity gap #98 left open. Under
+    /// [`STPMode::CancelTaker`](crate::orderbook::stp::STPMode::CancelTaker) /
+    /// [`CancelBoth`](crate::orderbook::stp::STPMode::CancelBoth), if a
+    /// re-priced order would cross into the **same user's** resting liquidity on
+    /// the opposite side, `add_order` matches post-cancel and cancels the taker
+    /// (the re-added order) — *after* the original was already removed,
+    /// destroying it. This dry-runs the crossable opposite side and, if the
+    /// sweep would reach a same-user maker while the taker still has unfilled
+    /// quantity (the exact condition under which the engine sets
+    /// `stp_taker_cancelled`), returns [`OrderBookError::SelfTradePrevented`]
+    /// **before** the original is cancelled, so it survives unchanged.
+    ///
+    /// No-op when STP is off, the taker is anonymous, or the mode is
+    /// [`CancelMaker`](crate::orderbook::stp::STPMode::CancelMaker) (which
+    /// cancels the maker and rests the taker — it never destroys the re-added
+    /// order). Like the other validate-first checks (#98) it is a pure function
+    /// of the new order plus the *opposite* book side, so evaluating it while
+    /// the same-side original still rests yields the same verdict as after
+    /// cancel.
+    pub(super) fn check_modify_stp_self_cross(
+        &self,
+        new_order: &OrderType<T>,
+    ) -> Result<(), OrderBookError> {
+        use crate::orderbook::stp::STPMode;
+
+        let taker_user_id = new_order.user_id();
+        // Only CancelTaker / CancelBoth cancel the taker; None / CancelMaker
+        // rest it, so the re-added order is never destroyed.
+        match self.stp_mode {
+            STPMode::CancelTaker | STPMode::CancelBoth => {}
+            _ => return Ok(()),
+        }
+        if taker_user_id == pricelevel::Hash32::zero() {
+            return Ok(());
+        }
+
+        let side = new_order.side();
+        let new_price = new_order.price().as_u128();
+        let opposite = match side {
+            Side::Buy => &self.asks,
+            Side::Sell => &self.bids,
+        };
+        // Walk the crossable opposite side in price-time priority — asks
+        // ascending for a Buy, bids descending for a Sell — exactly the sweep's
+        // visit order.
+        let iter = match side {
+            Side::Buy => Either::Left(opposite.iter()),
+            Side::Sell => Either::Right(opposite.iter().rev()),
+        };
+
+        let mut remaining = new_order.total_quantity();
+        for entry in iter {
+            if remaining == 0 {
+                // The taker fully fills against non-self depth before reaching
+                // any same-user maker → the engine never cancels it.
+                return Ok(());
+            }
+            let price = *entry.key();
+            let crosses = match side {
+                Side::Buy => new_price >= price,
+                Side::Sell => new_price <= price,
+            };
+            if !crosses {
+                // Price-sorted levels: no further level can cross.
+                break;
+            }
+            let level = entry.value();
+            if level.iter_orders().any(|o| o.user_id() == taker_user_id) {
+                // The sweep reaches a level holding a same-user maker while the
+                // taker still has unfilled quantity: the engine would cancel the
+                // taker here. Reject the modify before the original is cancelled.
+                return Err(OrderBookError::SelfTradePrevented {
+                    mode: self.stp_mode,
+                    taker_order_id: new_order.id(),
+                    user_id: taker_user_id,
+                });
+            }
+            // No same-user maker at this level: the taker consumes its full
+            // matchable depth (the authoritative upstream dry run), then walks on.
+            remaining = remaining.saturating_sub(level.matchable_quantity(remaining));
+        }
         Ok(())
     }
 

--- a/src/orderbook/tests/stp.rs
+++ b/src/orderbook/tests/stp.rs
@@ -5,7 +5,9 @@ mod tests {
     use crate::orderbook::book::OrderBook;
     use crate::orderbook::error::OrderBookError;
     use crate::orderbook::stp::STPMode;
-    use pricelevel::{Hash32, Id, OrderType, Price, Quantity, Side, TimeInForce, TimestampMs};
+    use pricelevel::{
+        Hash32, Id, OrderType, OrderUpdate, Price, Quantity, Side, TimeInForce, TimestampMs,
+    };
 
     /// Helper: create a non-zero user hash from a single byte value.
     fn user(byte: u8) -> Hash32 {
@@ -1264,5 +1266,214 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("missing user_id"));
         assert!(msg.contains("STP"));
+    }
+
+    // -----------------------------------------------------------------------
+    // #168 — STP self-cross modify atomicity: a re-price that would self-cross
+    // the same user's opposite-side liquidity under CancelTaker / CancelBoth is
+    // rejected BEFORE the original is cancelled, so the original survives.
+    // -----------------------------------------------------------------------
+
+    /// CancelTaker: re-pricing a buy up into the same user's own resting sell is
+    /// rejected pre-cancel with `SelfTradePrevented`; the original buy survives
+    /// unchanged and the opposite-side maker is untouched.
+    #[test]
+    fn test_modify_self_cross_under_cancel_taker_rejected_preserves_original_issue_168() {
+        let mut book: OrderBook<()> = OrderBook::new("TEST");
+        book.set_stp_mode(STPMode::CancelTaker);
+        let u = user(7);
+
+        let buy_id = add_buy_order_with_user(&book, 100, 10, u);
+        let sell_id = add_sell_order_with_user(&book, 110, 10, u);
+
+        // Re-price the buy up to 110 — it would cross the user's own sell.
+        let res = book.update_order(OrderUpdate::UpdatePrice {
+            order_id: buy_id,
+            new_price: Price::new(110),
+        });
+        assert!(
+            matches!(
+                res,
+                Err(OrderBookError::SelfTradePrevented { taker_order_id, .. }) if taker_order_id == buy_id
+            ),
+            "self-crossing modify must be STP-rejected pre-cancel, got {res:?}"
+        );
+
+        // The original buy survives at its ORIGINAL price, and the sell is intact.
+        let buy = book.get_order(buy_id).expect("original buy must survive");
+        assert_eq!(
+            buy.price().as_u128(),
+            100,
+            "original price must be unchanged"
+        );
+        assert!(
+            book.get_order(sell_id).is_some(),
+            "the maker must be untouched"
+        );
+        assert!(
+            !book.has_traded.load(std::sync::atomic::Ordering::SeqCst),
+            "a rejected modify must emit no trades"
+        );
+    }
+
+    /// CancelBoth: same self-cross scenario is rejected pre-cancel (the taker is
+    /// cancelled under CancelBoth too), preserving the original.
+    #[test]
+    fn test_modify_self_cross_under_cancel_both_rejected_preserves_original_issue_168() {
+        let mut book: OrderBook<()> = OrderBook::new("TEST");
+        book.set_stp_mode(STPMode::CancelBoth);
+        let u = user(8);
+
+        let sell_id = add_sell_order_with_user(&book, 110, 10, u);
+        let bid_maker = add_buy_order_with_user(&book, 90, 10, u);
+
+        // Re-price the sell down to 90 — it would cross the user's own bid.
+        let res = book.update_order(OrderUpdate::UpdatePrice {
+            order_id: sell_id,
+            new_price: Price::new(90),
+        });
+        assert!(
+            matches!(res, Err(OrderBookError::SelfTradePrevented { .. })),
+            "self-crossing modify under CancelBoth must be rejected pre-cancel, got {res:?}"
+        );
+        let sell = book.get_order(sell_id).expect("original sell must survive");
+        assert_eq!(sell.price().as_u128(), 110, "original price unchanged");
+        assert!(
+            book.get_order(bid_maker).is_some(),
+            "the bid maker untouched"
+        );
+    }
+
+    /// CancelMaker: the taker is rested (the maker is cancelled), so the modify
+    /// must NOT be pre-rejected — it succeeds, re-pricing the order and letting
+    /// STP cancel the same-user maker. Confirms no spurious pre-rejection.
+    #[test]
+    fn test_modify_self_cross_under_cancel_maker_not_prerejected_issue_168() {
+        let mut book: OrderBook<()> = OrderBook::new("TEST");
+        book.set_stp_mode(STPMode::CancelMaker);
+        let u = user(9);
+
+        let buy_id = add_buy_order_with_user(&book, 100, 10, u);
+        let sell_id = add_sell_order_with_user(&book, 110, 10, u);
+
+        let res = book.update_order(OrderUpdate::UpdatePrice {
+            order_id: buy_id,
+            new_price: Price::new(110),
+        });
+        assert!(
+            res.is_ok(),
+            "CancelMaker modify must not be pre-rejected, got {res:?}"
+        );
+        // The re-priced buy rests; the same-user sell maker is STP-cancelled.
+        assert!(
+            book.get_order(buy_id).is_some(),
+            "the re-priced taker rests"
+        );
+        assert!(
+            book.get_order(sell_id).is_none(),
+            "the same-user maker is cancelled by CancelMaker"
+        );
+    }
+
+    /// CancelTaker, different user: re-pricing into ANOTHER user's resting order
+    /// is a normal cross, not a self-cross, so it must NOT be pre-rejected.
+    #[test]
+    fn test_modify_cross_other_user_under_cancel_taker_allowed_issue_168() {
+        let mut book: OrderBook<()> = OrderBook::new("TEST");
+        book.set_stp_mode(STPMode::CancelTaker);
+        let u = user(1);
+        let other = user(2);
+
+        let buy_id = add_buy_order_with_user(&book, 100, 10, u);
+        let _other_sell = add_sell_order_with_user(&book, 110, 10, other);
+
+        let res = book.update_order(OrderUpdate::UpdatePrice {
+            order_id: buy_id,
+            new_price: Price::new(110),
+        });
+        assert!(
+            res.is_ok(),
+            "crossing another user's order is not a self-cross, must succeed, got {res:?}"
+        );
+        assert!(
+            book.has_traded.load(std::sync::atomic::Ordering::SeqCst),
+            "the re-priced buy fills against the other user's sell"
+        );
+    }
+
+    /// CancelTaker, precise quantity accounting: if the taker fully fills against
+    /// strictly-higher-priority NON-self depth before the sweep reaches the
+    /// same-user maker, the engine never cancels it — so the modify must NOT be
+    /// pre-rejected. Pins that the check accounts for fillable depth, not just
+    /// the existence of a same-user maker in range.
+    #[test]
+    fn test_modify_self_cross_taker_fills_before_self_maker_allowed_issue_168() {
+        let mut book: OrderBook<()> = OrderBook::new("TEST");
+        book.set_stp_mode(STPMode::CancelTaker);
+        let u = user(3);
+        let other = user(4);
+
+        // Buy 5 at 100. Opposite asks: other-user 10 @ 105 (better), same-user 10 @ 110.
+        let buy_id = add_buy_order_with_user(&book, 100, 5, u);
+        let _other_sell = add_sell_order_with_user(&book, 105, 10, other);
+        let self_sell = add_sell_order_with_user(&book, 110, 10, u);
+
+        // Re-price to 110: the buy (qty 5) fully fills against the other-user
+        // 105 ask and never reaches the same-user 110 ask, so no STP cancel.
+        let res = book.update_order(OrderUpdate::UpdatePrice {
+            order_id: buy_id,
+            new_price: Price::new(110),
+        });
+        assert!(
+            res.is_ok(),
+            "taker satisfied before the same-user maker must not be rejected, got {res:?}"
+        );
+        assert!(book.has_traded.load(std::sync::atomic::Ordering::SeqCst));
+        // The same-user sell at 110 is untouched (never reached).
+        assert!(
+            book.get_order(self_sell).is_some(),
+            "the same-user maker beyond the fill point is untouched"
+        );
+    }
+
+    /// CancelTaker with `lot_size` set: the self-cross verdict still matches the
+    /// engine. `validate_order_shape` (which enforces lot-alignment) runs before
+    /// the pre-check, so every quantity is a lot multiple and the engine's
+    /// per-level `level_qty_cap` lot-rounding is a no-op — the helper's
+    /// `matchable_quantity` consumption and the engine's sweep agree, leaving no
+    /// sub-lot dust that could strand a same-user maker. Pins that invariant.
+    #[test]
+    fn test_modify_self_cross_under_cancel_taker_with_lot_size_rejected_issue_168() {
+        let mut book: OrderBook<()> = OrderBook::with_lot_size("TEST", 5);
+        book.set_stp_mode(STPMode::CancelTaker);
+        let u = user(5);
+        let other = user(6);
+
+        // Buy 10 (lot-aligned) at 100. Opposite asks: other-user 5 @ 105,
+        // same-user 10 @ 110. Re-pricing to 110 fills 5 against the other-user
+        // ask (remaining 5) then reaches the same-user 110 ask with remaining>0
+        // → the engine cancels the taker, so the pre-check must reject.
+        let buy_id = add_buy_order_with_user(&book, 100, 10, u);
+        let _other_sell = add_sell_order_with_user(&book, 105, 5, other);
+        let self_sell = add_sell_order_with_user(&book, 110, 10, u);
+
+        let res = book.update_order(OrderUpdate::UpdatePrice {
+            order_id: buy_id,
+            new_price: Price::new(110),
+        });
+        assert!(
+            matches!(res, Err(OrderBookError::SelfTradePrevented { .. })),
+            "lot-sized self-cross must be rejected pre-cancel, got {res:?}"
+        );
+        let buy = book.get_order(buy_id).expect("original buy survives");
+        assert_eq!(buy.price().as_u128(), 100, "original price unchanged");
+        assert!(
+            book.get_order(self_sell).is_some(),
+            "same-user maker untouched"
+        );
+        assert!(
+            !book.has_traded.load(std::sync::atomic::Ordering::SeqCst),
+            "a rejected modify emits no trades"
+        );
     }
 }


### PR DESCRIPTION
## Summary

#98 made `UpdatePrice` / `UpdatePriceAndQuantity` / `Replace` validate-first for every *pre-match* admission rejection, but one *post-match* case slipped through (issue #168, filed from the #98 review): under `STPMode::CancelTaker` / `CancelBoth`, re-pricing an order so it crosses into the **same user's** resting liquidity on the opposite side made `add_order` match post-cancel and cancel the taker (the re-added order) — **after** the original was already removed, destroying it.

The modify guard now runs `check_modify_stp_self_cross` **after** the risk check and **before** `cancel_order` in all three branches. It dry-runs the crossable opposite side in the sweep's price-time order (asks-ascending for a Buy, bids-descending for a Sell), consuming each non-self level's authoritative `matchable_quantity`, and if it reaches a level holding a same-user maker while the taker still has unfilled quantity — the **exact** condition under which the engine sets `stp_taker_cancelled` — returns `OrderBookError::SelfTradePrevented` so the original survives unchanged.

- No-op for STP `None` / `CancelMaker` (the taker rests, never destroyed) and anonymous takers.
- Pure function of the new order + the opposite book side, like the other validate-first checks (#98).
- **Verdict matches the engine exactly.** `validate_order_shape` (lot validation) runs before the pre-check, so `remaining` stays lot-aligned and the engine's per-level `level_qty_cap` lot-rounding is a no-op that consumes identically to `matchable_quantity` — no sub-lot dust can strand a same-user maker.

## Review (multi-agent workflow: review panel → adversarial verify)

- **determinism-auditor**: pure `Result` before any mutation; no clock/rand/env; `iter_orders().any()` is an order-invariant membership test. A hypothesised "over-reject" was **refuted on verification** (the engine sets `stp_taker_cancelled` *unconditionally* once it reaches a same-user level with remaining > 0, so the helper agrees).
- **microstructure-critic**: confirmed exact parity for taker-fills-first, same-user-at-touch, CancelTaker≡CancelBoth, crossable-range break, no same-side leakage, iceberg/reserve depth. A hypothesised `lot_size` "under-reject" was **refuted on verification**: lot-alignment (enforced before the pre-check) makes `remaining` a lot multiple throughout, so `level_qty_cap` and `matchable_quantity` consume identically — no divergence. Pinned with a dedicated `lot_size` test.
- **hotpath-reviewer**: PASS. Common no-cross path is O(1) (immediate break), nothing runs under `None`/`CancelMaker`/anonymous. One awareness-only note: `matchable_quantity` allocates a snapshot per non-self level on a *deep* self-cross (cold MODIFY path only) — acceptable; a future micro-opt could thread the pooled `snapshot_by_seq_into` buffer.

## Tests

Six `_issue_168` tests: self-cross rejected + original preserved under CancelTaker and CancelBoth; CancelMaker not pre-rejected; different-user cross allowed; **taker-fills-before-self-maker allowed** (precise quantity accounting, not a naive "any same-user maker" scan); and a **`lot_size` self-cross** pinning the lot-alignment invariant. `cargo test --all-features`, `clippy --all-targets --all-features -D warnings`, `fmt --check`, `build --release --all-features`, `build --features special_orders,nats,bincode,journal` all clean.

Closes #168
