### PR TITLE
fix(repricing): surface swallowed re-price failures + clamp telemetry (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Surface swallowed re-price failures + clamp telemetry (#174).** The special-order
+  re-price loops used `if self.update_order(update).is_ok()` and discarded the
+  `Err`, and `reprice_special_orders` hardcoded `failed_orders: Vec::new()`, so a
+  re-price rejected by admission (e.g. a risk `RiskMaxNotional`) silently left the
+  order at its stale price with nothing recorded. The loops now capture each
+  rejected `update_order` and `RepricingResult::failed_orders` is populated with a
+  `(order_id, reason)` pair for every failure (a rejected re-price keeps the
+  order's prior price — validate-first modify, #98/#168). The public
+  `RepricingOperations` trait signatures are unchanged: `reprice_pegged_orders` /
+  `reprice_trailing_stops` still return the repriced count; the failure detail is
+  reported through `reprice_special_orders`. Separately, `calculate_pegged_price`
+  now emits a `trace!` when a peg is price-slid off its requested
+  `reference ± offset` to the passive side (or skipped because no valid passive
+  tick exists), so a consumer can distinguish a peg that tracked its reference
+  from one that was clamped.
 - **Extend modify atomicity to the STP self-cross taker-cancellation edge (#168).**
   #98 made `UpdatePrice` / `UpdatePriceAndQuantity` / `Replace` validate-first for
   every *pre-match* admission rejection, but one *post-match* case slipped

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -3414,15 +3414,22 @@ use crate::orderbook::repricing::{
 };
 
 #[cfg(feature = "special_orders")]
-impl<T> RepricingOperations<T> for OrderBook<T>
+impl<T> OrderBook<T>
 where
     T: Clone + Default + Send + Sync + 'static,
 {
-    /// Re-prices all pegged orders based on current market conditions
-    fn reprice_pegged_orders(&self) -> Result<usize, OrderBookError> {
+    /// Re-price every pegged order, returning the count repriced and pushing a
+    /// `(order_id, reason)` pair onto `failures` for each one whose
+    /// `update_order` is **rejected** (e.g. a risk-admission rejection). The
+    /// validate-first modify (#98/#168) means a rejected re-price leaves the
+    /// order at its old price — but it was previously swallowed by
+    /// `if ...is_ok()`; now it is surfaced (#174). A peg that simply has no
+    /// reference / no valid passive tick this cycle is a no-op, not a failure,
+    /// and is not recorded.
+    fn reprice_pegged_collecting(&self, failures: &mut Vec<(Id, String)>) -> usize {
         let pegged_ids = self.special_order_tracker.pegged_order_ids();
         if pegged_ids.is_empty() {
-            return Ok(0);
+            return 0;
         }
 
         let best_bid = self.best_bid();
@@ -3461,12 +3468,24 @@ where
                         order_id,
                         new_price: pricelevel::Price::new(new_price),
                     };
-                    if self.update_order(update).is_ok() {
-                        repriced_count += 1;
-                        trace!(
-                            "Re-priced pegged order {} from {} to {}",
-                            order_id, current_price, new_price
-                        );
+                    match self.update_order(update) {
+                        Ok(_) => {
+                            repriced_count += 1;
+                            trace!(
+                                "Re-priced pegged order {} from {} to {}",
+                                order_id, current_price, new_price
+                            );
+                        }
+                        Err(e) => {
+                            trace!(
+                                "Pegged re-price of {} to {} rejected: {}",
+                                order_id, new_price, e
+                            );
+                            failures.push((
+                                order_id,
+                                format!("pegged re-price to {new_price} rejected: {e}"),
+                            ));
+                        }
                     }
                 }
             } else {
@@ -3476,14 +3495,16 @@ where
             }
         }
 
-        Ok(repriced_count)
+        repriced_count
     }
 
-    /// Re-prices all trailing stop orders based on current market conditions
-    fn reprice_trailing_stops(&self) -> Result<usize, OrderBookError> {
+    /// Re-price every trailing stop, returning the count repriced and pushing a
+    /// `(order_id, reason)` pair onto `failures` for each rejected
+    /// `update_order` (mirrors [`Self::reprice_pegged_collecting`], #174).
+    fn reprice_trailing_collecting(&self, failures: &mut Vec<(Id, String)>) -> usize {
         let trailing_ids = self.special_order_tracker.trailing_stop_ids();
         if trailing_ids.is_empty() {
-            return Ok(0);
+            return 0;
         }
 
         let mut repriced_count = 0;
@@ -3521,16 +3542,30 @@ where
                             order_id,
                             new_price: pricelevel::Price::new(new_stop_price),
                         };
-                        if self.update_order(update).is_ok() {
-                            repriced_count += 1;
-                            trace!(
-                                "Re-priced trailing stop {} from {} to {} (ref: {} -> {})",
-                                order_id,
-                                current_stop_price,
-                                new_stop_price,
-                                last_reference_price,
-                                new_reference
-                            );
+                        match self.update_order(update) {
+                            Ok(_) => {
+                                repriced_count += 1;
+                                trace!(
+                                    "Re-priced trailing stop {} from {} to {} (ref: {} -> {})",
+                                    order_id,
+                                    current_stop_price,
+                                    new_stop_price,
+                                    last_reference_price,
+                                    new_reference
+                                );
+                            }
+                            Err(e) => {
+                                trace!(
+                                    "Trailing-stop re-price of {} to {} rejected: {}",
+                                    order_id, new_stop_price, e
+                                );
+                                failures.push((
+                                    order_id,
+                                    format!(
+                                        "trailing-stop re-price to {new_stop_price} rejected: {e}"
+                                    ),
+                                ));
+                            }
                         }
                     }
                 }
@@ -3541,18 +3576,51 @@ where
             }
         }
 
-        Ok(repriced_count)
+        repriced_count
+    }
+}
+
+#[cfg(feature = "special_orders")]
+impl<T> RepricingOperations<T> for OrderBook<T>
+where
+    T: Clone + Default + Send + Sync + 'static,
+{
+    /// Re-prices all pegged orders based on current market conditions.
+    ///
+    /// Returns the number repriced. Per-order re-price *failures* are not
+    /// surfaced through this count-only entry point — use
+    /// [`reprice_special_orders`](Self::reprice_special_orders), whose
+    /// [`RepricingResult::failed_orders`] records every rejected re-price.
+    fn reprice_pegged_orders(&self) -> Result<usize, OrderBookError> {
+        Ok(self.reprice_pegged_collecting(&mut Vec::new()))
     }
 
-    /// Re-prices all special orders (both pegged and trailing stops)
+    /// Re-prices all trailing stop orders based on current market conditions.
+    ///
+    /// Returns the number repriced. See
+    /// [`reprice_special_orders`](Self::reprice_special_orders) for the
+    /// failure-reporting variant.
+    fn reprice_trailing_stops(&self) -> Result<usize, OrderBookError> {
+        Ok(self.reprice_trailing_collecting(&mut Vec::new()))
+    }
+
+    /// Re-prices all special orders (both pegged and trailing stops) and reports
+    /// per-order failures.
+    ///
+    /// [`RepricingResult::failed_orders`] is populated with a `(order_id,
+    /// reason)` pair for every re-price whose `update_order` was rejected (e.g.
+    /// a risk-admission rejection). These were previously swallowed (#174); a
+    /// rejected re-price leaves the order at its prior price (validate-first
+    /// modify, #98/#168).
     fn reprice_special_orders(&self) -> Result<RepricingResult, OrderBookError> {
-        let pegged_count = self.reprice_pegged_orders()?;
-        let trailing_count = self.reprice_trailing_stops()?;
+        let mut failed_orders = Vec::new();
+        let pegged_count = self.reprice_pegged_collecting(&mut failed_orders);
+        let trailing_count = self.reprice_trailing_collecting(&mut failed_orders);
 
         Ok(RepricingResult {
             pegged_orders_repriced: pegged_count,
             trailing_stops_repriced: trailing_count,
-            failed_orders: Vec::new(),
+            failed_orders,
         })
     }
 

--- a/src/orderbook/repricing.rs
+++ b/src/orderbook/repricing.rs
@@ -194,6 +194,10 @@ pub fn calculate_pegged_price(
     } else {
         reference_price.saturating_sub((-offset) as u128)
     };
+    // The raw target the user requested (`reference ± offset`), before any
+    // passive-side clamp / tick snap. Used only for the price-sliding telemetry
+    // below — the returned value is unaffected (#174).
+    let raw_target = new_price;
 
     // Effective tick step (1 when unset / <= 1 preserves non-tick-book behavior).
     let step = tick_size.filter(|t| *t > 1).unwrap_or(1);
@@ -231,14 +235,30 @@ pub fn calculate_pegged_price(
     match side {
         Side::Buy => {
             if best_ask.is_some_and(|a| priced >= a) {
+                trace!(
+                    "pegged re-price skipped (Buy): no valid passive tick below best_ask; raw target {raw_target} would cross"
+                );
                 return None;
             }
         }
         Side::Sell => {
             if best_bid.is_some_and(|b| priced <= b) {
+                trace!(
+                    "pegged re-price skipped (Sell): no valid passive tick above best_bid; raw target {raw_target} would cross"
+                );
                 return None;
             }
         }
+    }
+
+    // Price-sliding telemetry (#174): signal when the order was clamped/snapped
+    // off its requested `reference ± offset` to the passive side, so a consumer
+    // can distinguish a peg that tracked its reference from one that was
+    // price-slid to avoid a cross. Does not affect the returned value.
+    if priced != raw_target {
+        trace!(
+            "pegged price clamped to passive side ({side:?}): requested reference+offset {raw_target} -> resting at {priced}"
+        );
     }
     Some(priced)
 }

--- a/tests/unit/repricing_determinism_tests.rs
+++ b/tests/unit/repricing_determinism_tests.rs
@@ -338,3 +338,67 @@ fn sell_pegged_reprice_tick_aligned_and_moves_issue_106() {
     let best_bid = book.best_bid().expect("best bid present");
     assert!(new_price > best_bid, "must rest above best bid");
 }
+
+/// #174: a re-price whose `update_order` is rejected by the risk layer is no
+/// longer silently swallowed — it is recorded in `RepricingResult.failed_orders`
+/// with a reason, and (validate-first) the order keeps its prior price.
+#[test]
+fn reprice_records_risk_rejected_peg_in_failed_orders_issue_174() {
+    use orderbook_rs::RiskConfig;
+
+    let mut book: OrderBook<()> = OrderBook::new("TEST");
+    book.set_risk_config(RiskConfig::new().with_max_notional_per_account(600));
+
+    // Market maker (anonymous account) provides best bid 100, best ask 105.
+    book.add_limit_order(Id::from_u64(1), 100, 1, Side::Buy, TimeInForce::Gtc, None)
+        .expect("bid admitted");
+    book.add_limit_order(Id::from_u64(2), 105, 1, Side::Sell, TimeInForce::Gtc, None)
+        .expect("ask admitted");
+
+    // A pegged buy on its OWN account, resting passively at 90 (notional 540 <= 600).
+    let pegger = Hash32::new([7u8; 32]);
+    let peg_id = Id::from_u64(100);
+    book.add_order(OrderType::PeggedOrder {
+        id: peg_id,
+        price: Price::new(90),
+        quantity: Quantity::new(6),
+        side: Side::Buy,
+        user_id: pegger,
+        timestamp: TimestampMs::new(1),
+        time_in_force: TimeInForce::Gtc,
+        reference_price_offset: 20,
+        reference_price_type: PegReferenceType::BestBid,
+        extra_fields: (),
+    })
+    .expect("peg admitted (540 <= 600)");
+
+    // Re-price target = BestBid(100)+20 = 120, clamped to best_ask-1 = 104.
+    // 6 * 104 = 624 > 600 -> the modify-aware risk check rejects the re-price,
+    // which is now recorded (previously swallowed by `if ...is_ok()`).
+    let result = book.reprice_special_orders().expect("reprice runs");
+    assert_eq!(
+        result.pegged_orders_repriced, 0,
+        "the risk-rejected peg did not re-price"
+    );
+    assert_eq!(
+        result.failed_orders.len(),
+        1,
+        "the rejection is recorded in failed_orders"
+    );
+    assert_eq!(result.failed_orders[0].0, peg_id);
+    let reason = &result.failed_orders[0].1;
+    assert!(
+        reason.contains("rejected"),
+        "the reason explains the failure: {reason}"
+    );
+
+    // Validate-first: the rejected re-price left the peg at its original price.
+    let peg = book
+        .get_order(peg_id)
+        .expect("peg survives the rejected re-price");
+    assert_eq!(
+        peg.price().as_u128(),
+        90,
+        "a rejected re-price leaves the peg at its old price"
+    );
+}


### PR DESCRIPTION
## Summary

The special-order re-price loops used `if self.update_order(update).is_ok()` and discarded the `Err`, and `reprice_special_orders` hardcoded `failed_orders: Vec::new()` — so a re-price rejected by admission (e.g. a risk `RiskMaxNotional`) silently left the order at its stale price with nothing recorded (issue #174, from the #106 / PR #173 review).

- The per-order loops are refactored into two **private** inherent methods (`reprice_pegged_collecting` / `reprice_trailing_collecting`) that capture every rejected `update_order` and push a `(order_id, reason)` pair onto a `failures` Vec. `reprice_special_orders` threads one shared Vec through both and returns it in `RepricingResult::failed_orders`. A rejected re-price keeps the order's prior price (validate-first modify, #98/#168).
- **No public API break:** the `RepricingOperations` trait signatures are unchanged — `reprice_pegged_orders` / `reprice_trailing_stops` still return the repriced count (delegating to the collecting helpers); the failure detail is reported through `reprice_special_orders` only.
- `calculate_pegged_price` now emits a `trace!` when a peg is **price-slid** off its requested `reference ± offset` to the passive side (or skipped because no valid passive tick exists), so a consumer can distinguish a peg that tracked its reference from one that was clamped. A `raw_target` local was added solely for this telemetry; the returned value is unchanged.

## Review (multi-agent workflow: panel → adversarial verify)

- **determinism-auditor**: PASS — the `trace!` calls are value-neutral logging side effects (no clock/rand/state, returned `Option` unchanged); `failed_orders` is pushed in the deterministic `pegged_order_ids` / `trailing_stop_ids` order (sorted by `Id::to_string`, #106); the refactor preserves the exact repriced count and per-order `update_order` calls.
- **architect**: PASS — public trait signatures unchanged (no breaking API change), happy-path behavior + `trace!` messages + missing-order unregistration preserved, `RepricingResult` struct unchanged, `#![deny(unsafe_code)]` intact, no new deps/flags, no module-boundary violation, and the `&mut Vec::new()` delegate allocates lazily (zero heap on the no-failure path). The single raised finding was refuted on verification.

## Tests

- `reprice_records_risk_rejected_peg_in_failed_orders_issue_174`: a pegged order re-prices to a notional that trips `max_notional_per_account`; asserts the rejection is recorded in `RepricingResult.failed_orders` with a reason and the peg keeps its old price.
- `cargo test --all-features`, `clippy --all-targets --all-features -D warnings`, `fmt --check`, `build --release --all-features`, `test --features special_orders`, `build --features special_orders,nats,bincode,journal` all clean.

Closes #174
