### PR TITLE
chore(examples,docs): clippy-clean examples + refresh 0.9.0 performance docs

### DIFF
--- a/BENCH.md
+++ b/BENCH.md
@@ -4,9 +4,9 @@ This document covers the **HDR-histogram** bench suite added in 0.7.0
 under `benches/order_book/*_hdr.rs`. The default Criterion benches in
 the same directory remain — they publish HTML reports to
 `target/criterion/` and report a mean-centric statistical comparison
-that Criterion does well. The HDR benches are the source of truth for
-the **tail** numbers (`p50` / `p99` / `p99.9` / `p99.99`) that tier-one
-electronic exchanges quote in SLOs.
+that Criterion does well (see `BENCHMARKS.md`). The HDR benches are the
+source of truth for the **tail** numbers (`p50` / `p99` / `p99.9` /
+`p99.99`) that tier-one electronic exchanges quote in SLOs.
 
 ## Allocation profile (feature `alloc-counters`)
 
@@ -26,23 +26,37 @@ static A: CountingAllocator<System> = CountingAllocator::new(System);
 `benches/order_book/alloc_count.rs` runs the same mixed 70 / 20 / 10
 workload as `mixed_70_20_10_hdr` but reports `allocs_per_op` and
 `bytes_alloc/op` over the measurement window (200 000 warmup +
-1 000 000 measured). A reference run on the same M4 Max host:
+1 000 000 measured). A reference run on the M4 Max host (orderbook-rs
+0.9.0):
 
-| counter        | value         |
-|----------------|---------------|
-| allocs         | 17 757 222    |
-| deallocs       | 17 690 635    |
-| bytes_alloc    | 4 926 064 834 |
-| bytes_dealloc  | 4 897 062 482 |
-| **allocs/op**  | **17.76**     |
-| bytes_alloc/op | 4 926         |
+| counter        | value           |
+|----------------|-----------------|
+| allocs         | 14 945 144      |
+| deallocs       | 14 834 805      |
+| bytes_alloc    | 790 864 668 474 |
+| bytes_dealloc  | 790 836 738 974 |
+| **allocs/op**  | **14.95**       |
+| bytes_alloc/op | 790 865         |
 
-This is the headline number for "what does the matching engine cost
-in alloc pressure on a realistic workload" — useful as a regression
-signal much more than as an absolute target. The integration test
-`tests/unit/alloc_budget_tests.rs` runs a smaller 10 000-op slice and
-asserts `allocs/op < 10` to catch order-of-magnitude regressions in
-CI.
+`allocs/op` is the headline number for "what does the matching engine
+cost in alloc pressure on a realistic workload" — useful as a
+regression signal much more than as an absolute target. It is balanced
+(allocs ≈ deallocs, no leak) and is in the same ballpark as the 0.7.0
+reference (`~17.76`). Note `allocs/op` is workload-randomness-sensitive
+on this synthetic stream — repeat runs land in the `~15–19` range.
+
+> **Note (`bytes_alloc/op`).** On this monotonically-growing
+> deep-book workload the per-op *bytes* allocated is large and much
+> higher than the historical 0.7.0 reference (`~4 926`). It is dominated
+> by the few large transient buffers a market sweep allocates against a
+> very deep price level (the workload concentrates ~700 k resting orders
+> into a narrow band, so individual levels get thousands of orders deep).
+> Treat `bytes_alloc/op` as a coarse signal only; `allocs/op` is the
+> stable regression metric and is what CI guards.
+
+The integration test `tests/alloc_budget.rs` runs a smaller 10 000-op
+slice and asserts `allocs/op` stays under a fixed ceiling to catch
+order-of-magnitude regressions in CI.
 
 Run yourself:
 
@@ -56,7 +70,7 @@ Per-run summaries land in `target/alloc-counters/<scenario>.md`.
 ## How to run
 
 ```bash
-make bench-hdr                 # all six scenarios
+make bench-hdr                 # all seven scenarios
 cargo bench --bench mixed_70_20_10_hdr   # single scenario
 ```
 
@@ -79,7 +93,8 @@ plotters; the directory lives under `target/` and is gitignored.
 - **Warmup.** Long-running scenarios (`add_only`, `mixed_70_20_10`)
   discard 200 000 ops before the measurement window starts.
   Pre-loading scenarios (`cancel_only`, `aggressive_walk`,
-  `mass_cancel_burst`) seed the book in a non-measured loop instead.
+  `mass_cancel_burst`, `stp_sweep`) seed the book in a non-measured loop
+  instead.
 - **Workload determinism.** All scenarios drive a self-contained
   xorshift PRNG seeded with `0xA5A5_A5A5_A5A5_A5A5`. Reproducing a run
   with the same code produces the same op stream, modulo concurrent
@@ -103,14 +118,14 @@ plotters; the directory lives under `target/` and is gitignored.
 
 | Item | Value |
 |---|---|
-| Host | Apple M4 Max, macOS 25.4 (Darwin 25.4.0, `arm64`) |
+| Host | Apple M4 Max, macOS (Darwin 25.5.0, `arm64`) |
 | Pinning | None |
-| Toolchain | `rustc 1.95.0` (stable) |
+| Toolchain | `rustc 1.96.0` (stable) |
 | Profile | `--release` (Cargo `bench` profile = `release` clone) |
 | `RUSTFLAGS` | unset |
 | Allocator | system allocator |
-| Date | 2026-04-25 |
-| Crate version | `0.7.0-unreleased` (commit on `issue-56-hdr-bench`) |
+| Date | 2026-06-25 |
+| Crate version | `0.9.0` |
 
 ## Headline numbers
 
@@ -123,11 +138,11 @@ All values in nanoseconds. **Closed-loop service time** — see
 
 | Quantile | Latency (ns) |
 |---|---|
-| p50    | 791 |
-| p99    | 78 847 |
-| p99.9  | 146 303 |
-| p99.99 | 401 663 |
-| max    | 528 895 |
+| p50    | 959 |
+| p99    | 64 383 |
+| p99.9  | 99 711 |
+| p99.99 | 130 751 |
+| max    | 196 863 |
 
 **Where the tail comes from.** The book grows monotonically across the
 measurement window, so each insert must walk the `SkipMap` to the
@@ -142,15 +157,15 @@ working set outgrows L1.
 
 | Quantile | Latency (ns) |
 |---|---|
-| p50    | 42 |
-| p99    | 25 167 |
-| p99.9  | 34 047 |
-| p99.99 | 172 031 |
-| max    | 1 271 807 |
+| p50    | 41 |
+| p99    | 19 631 |
+| p99.9  | 24 751 |
+| p99.99 | 26 847 |
+| max    | 1 081 343 |
 
 **Where the tail comes from.** `DashMap::remove` on the order index is
 a shard-local lock acquisition; the median is dominated by that
-single-cycle CAS path. The very long p99.99 / max tails reflect
+single-cycle CAS path. The very long max tail reflects
 shard-contention windows when multiple removals land on the same
 shard back to back, plus rare allocator returns of large
 `PriceLevel` linked-list nodes.
@@ -162,11 +177,11 @@ buys with qty `5..=20`.
 
 | Quantile | Latency (ns) |
 |---|---|
-| p50    | 41 |
-| p99    | 7 083 |
-| p99.9  | 16 959 |
-| p99.99 | 33 823 |
-| max    | 203 263 |
+| p50    | 42 |
+| p99    | 3 001 |
+| p99.9  | 6 167 |
+| p99.99 | 8 503 |
+| max    | 41 375 |
 
 **Where the tail comes from.** The fill loop iterates per-order at
 each level until the requested quantity is consumed. Median is fast
@@ -180,11 +195,11 @@ at once.
 
 | Quantile | Latency (ns) |
 |---|---|
-| p50    | 667 |
-| p99    | 39 487 |
-| p99.9  | 71 999 |
-| p99.99 | 298 239 |
-| max    | 644 607 |
+| p50    | 833 |
+| p99    | 33 375 |
+| p99.9  | 53 215 |
+| p99.99 | 73 599 |
+| max    | 127 423 |
 
 **Where the tail comes from.** Mix of all three previous tails. The
 median tracks `add_only` (because submits are 70 % of the workload).
@@ -199,10 +214,10 @@ Refills 3 resting asks every 5 ops; 200 000 IOC buy probes with qty
 | Quantile | Latency (ns) |
 |---|---|
 | p50    | 42 |
-| p99    | 5 711 |
-| p99.9  | 15 127 |
-| p99.99 | 50 431 |
-| max    | 418 303 |
+| p99    | 4 251 |
+| p99.9  | 5 083 |
+| p99.99 | 5 459 |
+| max    | 38 527 |
 
 **Where the tail comes from.** Most probes either fully fill the
 small resting depth or partial-fill and short-circuit. The p99 is
@@ -217,17 +232,38 @@ wall-clock guard rather than a per-op tail.
 
 | Quantile | Latency (ns) |
 |---|---|
-| p50    | 25 711 |
-| p99    | 48 447 |
-| p99.9  | 312 575 |
-| p99.99 | 312 575 |
-| max    | 312 575 |
+| p50    | 18 799 |
+| p99    | 26 751 |
+| p99.9  | 36 031 |
+| p99.99 | 36 031 |
+| max    | 36 031 |
 
 **Where the tail comes from.** Burst latency scales linearly with the
-book depth; on a tight host the median is ~26 µs to drain 10 000
-orders, ~0.5 ns per order amortised. The p99.9 / p99.99 / max all
+book depth; on a tight host the median is ~19 µs to drain 10 000
+orders, ~1.9 ns per order amortised. The p99.9 / p99.99 / max all
 collapse to the same value because only 500 samples were taken — the
 single worst-case observation dominates.
+
+### `stp_sweep` — self-trade-prevention CancelMaker self-cross (added 0.9.0)
+
+`OrderBook::with_stp_mode(.., CancelMaker)` seeded with 50 ask levels
+(each one taker-owned sell + 8 other-maker sells); 100 000 measured
+aggressive self-crossing market buys from the taker, each one hitting
+the per-level STP scan + inline maker cancel (#107).
+
+| Quantile | Latency (ns) |
+|---|---|
+| p50    | 291 |
+| p99    | 3 917 |
+| p99.9  | 4 127 |
+| p99.99 | 5 167 |
+| max    | 45 087 |
+
+**Where the tail comes from.** Every measured op runs the per-level
+self-trade scan and cancels the same-user maker inline over the pooled
+snapshot buffer (#107, no per-level `Vec` allocation). The median is
+the scan + single cancel; the tail is the rare sweep that touches
+several levels plus allocator jitter re-seeding the taker order.
 
 ## Limitations
 
@@ -245,7 +281,7 @@ single worst-case observation dominates.
 ## Reproducing
 
 ```bash
-git checkout issue-56-hdr-bench  # or main once merged
+git checkout main
 make bench-hdr
 cat target/bench-hdr/*.hgrm     # raw histograms
 ```

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,6 +1,9 @@
 # Benchmark Results
 
-Measured on Apple M4 Max, Rust 1.85 stable, `--release` profile.
+Measured on Apple M4 Max (Darwin 25.5.0, `arm64`), Rust 1.96.0 stable,
+`--release` profile, orderbook-rs **0.9.0**. Criterion reports the
+median of 100 samples; absolute numbers are machine- and run-dependent.
+Tail-latency (`p50`/`p99`/`p99.9`) numbers live in `BENCH.md`.
 
 Run benchmarks locally:
 
@@ -12,44 +15,63 @@ cargo bench --all-features
 
 | Operation | 100 orders | 1,000 orders | 10,000 orders |
 |---|---|---|---|
-| `create_snapshot` | 127 µs | 147 µs | 329 µs |
-| `restore_from_snapshot` | 189 µs | 308 µs | 1.43 ms |
-| `enriched_snapshot (ALL)` | 129 µs | 148 µs | 334 µs |
-| `enriched_snapshot (MID_PRICE)` | 128 µs | 148 µs | 333 µs |
-| `snapshot_json_roundtrip` | 202 µs | 1.76 ms | — |
+| `create_snapshot` | 94 µs | 113 µs | 302 µs |
+| `restore_from_snapshot` | 151 µs | 292 µs | 1.62 ms |
+| `enriched_snapshot (ALL)` | 92 µs | 113 µs | 318 µs |
+| `enriched_snapshot (MID_PRICE)` | 96 µs | 112 µs | 297 µs |
+| `snapshot_json_roundtrip` | 190 µs | 1.45 ms | — |
 
 ## Journal & Replay
 
 | Operation | 100 events | 1,000 events | 10,000 events |
 |---|---|---|---|
-| `journal_append` | 3.7 µs | 22.6 µs | 562 µs |
-| `replay_from_journal` | 84 µs | 722 µs | 7.88 ms |
-| `replay_verify` | 219 µs | 889 µs | — |
+| `journal_append` | 2.85 µs | 20.1 µs | 408 µs |
+| `replay_from_journal` | 84 µs | 766 µs | 7.77 ms |
+| `replay_verify` | 179 µs | 886 µs | — |
 
-## Order Operations (existing)
+## Order Operations
 
 | Operation | Time |
 |---|---|
-| Add limit order (single) | ~2.1 µs |
-| Match market order (deep book) | ~34.6 ns |
-| Mixed operations (1,000) | ~172 µs |
+| Add limit order (single, cold book) | ~4.1 µs |
+| Add 1,000 limit orders | ~1.55 ms |
+| Match market vs. populated book (batch) | ~158 µs |
+| Realistic mixed scenario | ~251 µs |
+| High-frequency mixed scenario | ~665 µs |
+| Match market order (per-fill p50, deep book) | ~42 ns (`BENCH.md` `aggressive_walk`) |
 
 ## Serialization
 
-| Format | Serialize Trade | Deserialize Trade |
+Single-message encode/decode (nanoseconds).
+
+| Format | Serialize Trade | Deserialize Trade | Serialize BookChange | Deserialize BookChange |
+|---|---|---|---|---|
+| JSON | ~262 ns | ~335 ns | ~55 ns | ~81 ns |
+| Bincode | ~122 ns | ~97 ns | ~31 ns | ~10 ns |
+
+## Concurrent Operations
+
+Per-op latency under N concurrent threads (`add_limit` / `mixed`):
+
+| Threads | `concurrent_add_limit` | `concurrent_mixed` |
 |---|---|---|
-| JSON | ~80 µs | ~84 µs |
-| Bincode | ~89 µs | ~98 µs |
+| 2  | ~1.74 µs | ~1.71 µs |
+| 4  | ~2.02 µs | ~2.77 µs |
+| 8  | ~3.69 µs | ~7.13 µs |
+| 16 | ~10.3 µs | ~16.2 µs |
 
 ## Observations
 
-- **Snapshot creation scales sub-linearly**: 10,000 orders only ~2.6x
-  slower than 100 orders due to efficient SkipMap iteration.
+- **Snapshot creation scales sub-linearly**: 10,000 orders is only ~3.2x
+  slower than 100 orders due to efficient `SkipMap` iteration.
 - **Enriched snapshots add negligible overhead**: metric calculation is
   fast compared to snapshot creation itself.
-- **Journal append is very fast**: ~3.7 µs for 100 events (37 ns/event)
+- **Journal append is very fast**: ~2.85 µs for 100 events (~28 ns/event)
   thanks to the in-memory journal implementation.
-- **Replay throughput**: ~1.27M events/sec at 10,000 events, suitable for
+- **Replay throughput**: ~1.29M events/sec at 10,000 events, suitable for
   fast disaster recovery.
-- **Matching is sub-microsecond**: market order matching on a deep book
-  takes ~35 ns — well within HFT latency requirements.
+- **Matching is sub-microsecond**: per-fill market-order matching on a deep
+  book is ~42 ns at the median (`BENCH.md` `aggressive_walk`) — well within
+  HFT latency requirements.
+- **Bincode is ~2x faster than JSON** on the wire path and an order of
+  magnitude cheaper on small messages (`BookChange` deserialize ~10 ns).

--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ Pre-calculated metrics in snapshots for high-frequency trading:
 
 ## Performance Analysis of the OrderBook System
 
-This analyzes the performance of the OrderBook system based on tests conducted on an Apple M4 Max processor. The data comes from a High-Frequency Trading (HFT) simulation and price level distribution performance tests.
+This analyzes the performance of the OrderBook system based on tests conducted on an Apple M4 Max processor. The data comes from a High-Frequency Trading (HFT) simulation and price level distribution performance tests. The figures below are representative single-run numbers measured on **orderbook-rs 0.9.0** with the bundled examples `orderbook_hft_simulation` and `orderbook_contention_test` (`cargo run --release -p examples --bin <name>`); absolute throughput is workload-, machine-, and run-dependent.
 
 ### 1. High-Frequency Trading (HFT) Simulation
 
@@ -474,50 +474,74 @@ This analyzes the performance of the OrderBook system based on tests conducted o
 
 | Metric | Total Operations | Operations/Second |
 |---------|---------------------|---------------------|
-| Orders Added | 506,105 | 101,152.80 |
-| Orders Matched | 314,245 | 62,806.66 |
-| Orders Cancelled | 204,047 | 40,781.91 |
-| **Total Operations** | **1,024,397** | **204,741.37** |
+| Orders Added | 465,314 | 93,040.99 |
+| Orders Matched | 191,555 | 38,302.02 |
+| Orders Cancelled | 183,700 | 36,731.39 |
+| **Total Operations** | **840,569** | **168,074.41** |
 
 #### Initial vs. Final OrderBook State
 
 | Metric | Initial State | Final State |
 |---------|----------------|---------------|
-| Best Bid | 9,900 | 9,900 |
-| Best Ask | 10,000 | 10,070 |
+| Best Bid | 9,900 | 9,840 |
+| Best Ask | 10,000 | 10,010 |
 | Spread | 100 | 170 |
-| Mid Price | 9,950.00 | 9,985.00 |
-| Total Orders | 1,020 | 34,850 |
+| Mid Price | 9,950.00 | 9,925.00 |
+| Total Orders | 1,020 | 44,987 |
 | Bid Price Levels | 21 | 11 |
-| Ask Price Levels | 21 | 10 |
-| Total Bid Quantity | 7,750 | 274,504 |
-| Total Ask Quantity | 7,750 | 360,477 |
+| Ask Price Levels | 21 | 12 |
+| Total Bid Quantity | 7,750 | 346,031 |
+| Total Ask Quantity | 7,750 | 473,092 |
 
-### 2. Price Level Distribution Performance Tests
+### 2. Contention Pattern Performance Tests
 
 #### Configuration
-- **Test Duration:** 5000 ms (5 seconds)
+- **Threads:** 12
+- **Test Duration:** 3000 ms per sub-test
 - **Concurrent Operations:** Multi-threaded lock-free architecture
 
-#### Price Level Distribution Performance
+#### Read / Write Operation Ratio
+
+Mixed read/write workload over 500 resting orders across 40 price levels;
+the `Read %` is the fraction of operations that are read-only (snapshot /
+best-price / depth queries) versus mutating (add / cancel / match).
 
 | Read % | Operations/Second |
 |------------|---------------------|
-| 0%         | 430,081.91          |
-| 25%        | 17,031.12           |
-| 50%        | 15,965.15           |
-| 75%        | 20,590.32           |
-| 95%        | 42,451.24           |
+| 0%         | 305,435.88          |
+| 25%        | 63,103.90           |
+| 50%        | 51,933.72           |
+| 75%        | 54,960.34           |
+| 95%        | 100,379.54          |
+
+#### Price Level Distribution
+
+Throughput as the resting depth is spread across a varying number of price
+levels (100 orders per level, except the 5- and 1-level cases which pack the
+same orders into fewer levels).
+
+| Price Levels | Operations/Second |
+|--------------|---------------------|
+| 100          | 184,986.35          |
+| 50           | 188,085.24          |
+| 10           | 70,338.52           |
+| 5            | 68,610.25           |
+| 1            | 61,302.26           |
 
 #### Hot Spot Contention Test
 
+All threads hammer a single shared price level (20 hot-spot orders + 480
+regular); higher hot-spot percentages concentrate more operations on that one
+lock-free level, where the `crossbeam-skiplist` + `dashmap` + atomics design
+shines.
+
 | % Operations on Hot Spot | Operations/Second   |
 |--------------------------|---------------------|
-| 0%                       | 2,742,810.37        |
-| 25%                      | 3,414,940.27        |
-| 50%                      | 4,542,931.02        |
-| 75%                      | 8,834,677.82        |
-| 100%                     | 19,403,341.34       |
+| 0%                       | 14,978,484.36       |
+| 25%                      | 19,191,927.99       |
+| 50%                      | 25,890,620.87       |
+| 75%                      | 31,529,898.64       |
+| 100%                     | 31,607,744.24       |
 
 #### Performance Improvements and Deadlock Resolution
 
@@ -527,35 +551,35 @@ The significant performance gains, especially in the "Hot Spot Contention Test,"
 
 - **New Implementation:** The `OrderQueue` was re-designed to use a combination of:
   1. A `dashmap::DashMap` for storing orders, allowing for highly concurrent, O(1) average-case time complexity for insertions, lookups, and removals by `Id`.
-  2. A `crossbeam::queue::SegQueue` that now only stores `Id`s to maintain the crucial First-In-First-Out (FIFO) order for matching.
+  2. A sequence-keyed index (a `crossbeam_skiplist::SkipMap<sequence, Id>`) that maintains the crucial First-In-First-Out (FIFO) order for matching while still allowing O(log n) ordered iteration and deterministic snapshots.
 
 This hybrid approach eliminates the previous bottleneck, allowing threads to operate on the order collection with minimal contention, which is reflected in the massive throughput increase in the hot spot tests.
 
 ### 3. Analysis and Conclusions
 
 #### Overall Performance
-The system demonstrates excellent capability to handle over **200,000 operations per second** in the high-frequency trading simulation, distributed across order creations, matches, and cancellations.
+The system demonstrates excellent capability to handle over **165,000 operations per second** in the high-frequency trading simulation, distributed across order creations, matches, and cancellations.
 
 #### Price Level Distribution Behavior
-- **Optimal Performance Range:** The system performs best with 50-100 price levels, achieving 66,000-67,000 operations per second.
-- **Performance Degradation:** Performance decreases significantly with fewer price levels, dropping to around 23,000-29,000 operations per second with 1-10 levels.
+- **Optimal Performance Range:** The system performs best with 50-100 price levels, achieving roughly 185,000-188,000 operations per second.
+- **Performance Degradation:** Performance decreases with fewer price levels (more per-level contention), dropping to around 61,000-70,000 operations per second with 1-10 levels.
 - **Scalability:** The lock-free architecture demonstrates excellent scalability characteristics across different price level distributions.
 
 #### Hot Spot Contention
-- Surprisingly, performance **increases** as more operations concentrate on a hot spot, reaching its maximum with 100% concentration (19,403,341 ops/s).
+- Surprisingly, performance **increases** as more operations concentrate on a hot spot, reaching its maximum with 100% concentration (31,607,744 ops/s).
 - This counter-intuitive behavior might indicate:
   1. Very efficient cache effects when operations are concentrated in one memory area
   2. Internal optimizations to handle high-contention cases
   3. Benefits of the system's lock-free architecture
 
 #### OrderBook State Behavior
-- During the HFT simulation, the order book handled a significant increase in order volume (from 1,020 to 34,850).
+- During the HFT simulation, the order book handled a significant increase in order volume (from 1,020 to 44,987).
 - The spread increased from 100 to 170, reflecting realistic market behavior under pressure.
-- The final state shows substantial liquidity with over 274,000 bid quantity and 360,000 ask quantity.
+- The final state shows substantial liquidity with over 346,000 bid quantity and 473,000 ask quantity.
 
 ### 4. Practical Implications
 
-- The system is suitable for high-frequency trading environments with the capacity to process over 200,000 operations per second.
+- The system is suitable for high-frequency trading environments with the capacity to process over 165,000 mixed operations per second (and tens of millions of operations per second on a single hot price level).
 - The lock-free architecture proves to be extremely effective at handling contention, especially at hot spots.
 - Optimal performance is achieved with moderate price level distribution (50-100 levels).
 - For real-world use cases, the system demonstrates excellent scalability and maintains performance under concurrent load.

--- a/examples/src/bin/helpers.rs
+++ b/examples/src/bin/helpers.rs
@@ -48,7 +48,7 @@ pub fn setup_orders_for_hot_spot_test(order_book: &crate::OrderBook) {
         let is_buy = i % 2 == 0;
         let side = if is_buy { Side::Buy } else { Side::Sell };
         let price_base: u128 = if is_buy { 9900 } else { 10000 };
-        let price_offset: u128 = (i % 100) * 1;
+        let price_offset: u128 = i % 100;
         let price: u128 = if is_buy {
             price_base - price_offset
         } else {

--- a/examples/src/bin/market_impact_simulation.rs
+++ b/examples/src/bin/market_impact_simulation.rs
@@ -184,7 +184,7 @@ fn demo_order_simulation(book: &OrderBook) {
             i + 1,
             qty,
             price,
-            (*price as u128) * (*qty as u128)
+            *price * (*qty as u128)
         );
     }
 
@@ -214,7 +214,7 @@ fn demo_order_simulation(book: &OrderBook) {
             i + 1,
             qty,
             price,
-            (*price as u128) * (*qty as u128)
+            *price * (*qty as u128)
         );
     }
 
@@ -319,7 +319,7 @@ fn demo_pretrade_risk_assessment(book: &OrderBook) {
     info!("   Average price: {:.2}", simulation.avg_price);
 
     if let Some(best_ask) = book.best_ask() {
-        let best_cost = (best_ask as u128) * (order_size as u128);
+        let best_cost = best_ask * (order_size as u128);
         let additional_cost = total_cost.saturating_sub(best_cost);
         info!("   Cost at best price: {} units", best_cost);
         info!("   Additional cost (slippage): {} units", additional_cost);

--- a/examples/src/bin/market_trades_demo.rs
+++ b/examples/src/bin/market_trades_demo.rs
@@ -66,7 +66,7 @@ fn main() {
 
 /// Add bid orders (buy side) to the order book
 fn add_bid_orders(book: &OrderBook) {
-    let bid_levels = vec![
+    let bid_levels = [
         (49900, 100), // price, quantity
         (49850, 150),
         (49800, 200),
@@ -99,7 +99,7 @@ fn add_bid_orders(book: &OrderBook) {
 
 /// Add ask orders (sell side) to the order book
 fn add_ask_orders(book: &OrderBook) {
-    let ask_levels = vec![
+    let ask_levels = [
         (50100, 100), // price, quantity
         (50150, 150),
         (50200, 200),

--- a/examples/src/bin/multi_threaded_orderbook.rs
+++ b/examples/src/bin/multi_threaded_orderbook.rs
@@ -30,7 +30,7 @@ fn run_performance_test() {
     populate_orderbook(&book, 1000);
 
     // Create thread performance counters
-    let mut operation_counters = vec![0; THREAD_COUNT];
+    let mut operation_counters = [0; THREAD_COUNT];
 
     // Synchronization barrier to ensure all threads start at the same time
     let barrier = Arc::new(Barrier::new(THREAD_COUNT + 1)); // +1 for main thread
@@ -58,7 +58,7 @@ fn run_performance_test() {
                 match thread_id % 4 {
                     0 => {
                         // This thread adds limit orders
-                        let buy_side = local_counter % 2 == 0;
+                        let buy_side = local_counter.is_multiple_of(2);
                         let side = if buy_side { Side::Buy } else { Side::Sell };
                         let price_base: u128 = if buy_side { 9900 } else { 10100 };
                         let price_offset: u128 = (local_counter as u128 % 10) * 10;
@@ -76,7 +76,7 @@ fn run_performance_test() {
                     }
                     1 => {
                         // This thread submits market orders
-                        let side = if local_counter % 2 == 0 {
+                        let side = if local_counter.is_multiple_of(2) {
                             Side::Buy
                         } else {
                             Side::Sell

--- a/examples/src/bin/orderbook_contention_test.rs
+++ b/examples/src/bin/orderbook_contention_test.rs
@@ -177,10 +177,10 @@ fn test_read_write_ratio() -> Result<(), String> {
                 }
 
                 // Update the operation counter
-                if let Ok(mut counters) = thread_counters.lock() {
-                    if thread_id < counters.len() {
-                        counters[thread_id] = local_counter;
-                    }
+                if let Ok(mut counters) = thread_counters.lock()
+                    && thread_id < counters.len()
+                {
+                    counters[thread_id] = local_counter;
                 }
 
                 local_counter
@@ -333,10 +333,10 @@ fn test_hot_spot_contention() -> Result<(), String> {
                 }
 
                 // Update the operation counter
-                if let Ok(mut counters) = thread_counters.lock() {
-                    if thread_id < counters.len() {
-                        counters[thread_id] = local_counter;
-                    }
+                if let Ok(mut counters) = thread_counters.lock()
+                    && thread_id < counters.len()
+                {
+                    counters[thread_id] = local_counter;
                 }
 
                 local_counter
@@ -541,10 +541,10 @@ fn test_price_level_distribution() -> Result<(), String> {
                 }
 
                 // Update the operation counter
-                if let Ok(mut counters) = thread_counters.lock() {
-                    if thread_id < counters.len() {
-                        counters[thread_id] = local_counter as usize;
-                    }
+                if let Ok(mut counters) = thread_counters.lock()
+                    && thread_id < counters.len()
+                {
+                    counters[thread_id] = local_counter as usize;
                 }
 
                 info!(

--- a/examples/src/bin/orderbook_hft_simulation.rs
+++ b/examples/src/bin/orderbook_hft_simulation.rs
@@ -373,41 +373,50 @@ fn spawn_maker_thread(
             match local_count % 5 {
                 0 => {
                     // Standard limit order
-                    if let Ok(_) = order_book.add_limit_order(
-                        id,
-                        price,
-                        quantity,
-                        side,
-                        TimeInForce::Gtc,
-                        Some(metadata),
-                    ) {
+                    if order_book
+                        .add_limit_order(
+                            id,
+                            price,
+                            quantity,
+                            side,
+                            TimeInForce::Gtc,
+                            Some(metadata),
+                        )
+                        .is_ok()
+                    {
                         order_added = true;
                     }
                 }
                 1 => {
                     // Post-only order
-                    if let Ok(_) = order_book.add_post_only_order(
-                        id,
-                        price,
-                        quantity,
-                        side,
-                        TimeInForce::Gtc,
-                        Some(metadata),
-                    ) {
+                    if order_book
+                        .add_post_only_order(
+                            id,
+                            price,
+                            quantity,
+                            side,
+                            TimeInForce::Gtc,
+                            Some(metadata),
+                        )
+                        .is_ok()
+                    {
                         order_added = true;
                     }
                 }
                 2 => {
                     // Iceberg order
-                    if let Ok(_) = order_book.add_iceberg_order(
-                        id,
-                        price,
-                        quantity / 4,
-                        quantity * 3 / 4,
-                        side,
-                        TimeInForce::Gtc,
-                        Some(metadata),
-                    ) {
+                    if order_book
+                        .add_iceberg_order(
+                            id,
+                            price,
+                            quantity / 4,
+                            quantity * 3 / 4,
+                            side,
+                            TimeInForce::Gtc,
+                            Some(metadata),
+                        )
+                        .is_ok()
+                    {
                         order_added = true;
                     }
                 }
@@ -418,14 +427,17 @@ fn spawn_maker_thread(
                     } else {
                         BASE_BID_PRICE - 10
                     };
-                    if let Ok(_) = order_book.add_limit_order(
-                        id,
-                        cross_price,
-                        quantity,
-                        side,
-                        TimeInForce::Ioc,
-                        Some(metadata),
-                    ) {
+                    if order_book
+                        .add_limit_order(
+                            id,
+                            cross_price,
+                            quantity,
+                            side,
+                            TimeInForce::Ioc,
+                            Some(metadata),
+                        )
+                        .is_ok()
+                    {
                         // IOC orders that don't fully execute may still leave resting quantity
                         order_added = true;
                     }
@@ -437,27 +449,28 @@ fn spawn_maker_thread(
                     } else {
                         BASE_BID_PRICE - 5
                     };
-                    if let Ok(_) = order_book.add_limit_order(
-                        id,
-                        cross_price,
-                        quantity,
-                        side,
-                        TimeInForce::Fok,
-                        Some(metadata),
-                    ) {
+                    if order_book
+                        .add_limit_order(
+                            id,
+                            cross_price,
+                            quantity,
+                            side,
+                            TimeInForce::Fok,
+                            Some(metadata),
+                        )
+                        .is_ok()
+                    {
                         order_added = true;
                     }
                 }
             }
 
             // Add order ID to queue for potential cancellation if it was successfully added
-            if order_added {
-                if let Ok(mut queue) = order_id_queue.try_lock() {
-                    queue.push_back(id);
-                    // Keep queue size reasonable
-                    if queue.len() > 1000 {
-                        queue.pop_front();
-                    }
+            if order_added && let Ok(mut queue) = order_id_queue.try_lock() {
+                queue.push_back(id);
+                // Keep queue size reasonable
+                if queue.len() > 1000 {
+                    queue.pop_front();
                 }
             }
 
@@ -513,10 +526,10 @@ fn spawn_taker_thread(
             let result = order_book.submit_market_order(id, quantity, side);
 
             // Only count successful matches
-            if let Ok(match_result) = result {
-                if match_result.executed_quantity().unwrap_or(Quantity::new(0)) > Quantity::new(0) {
-                    local_count += 1;
-                }
+            if let Ok(match_result) = result
+                && match_result.executed_quantity().unwrap_or(Quantity::new(0)) > Quantity::new(0)
+            {
+                local_count += 1;
             }
 
             // Update global counter periodically

--- a/examples/src/bin/price_level_transition.rs
+++ b/examples/src/bin/price_level_transition.rs
@@ -133,7 +133,7 @@ fn main() {
 
                     local_counter += 1;
 
-                    if local_counter % 100 == 0 {
+                    if local_counter.is_multiple_of(100) {
                         thread::sleep(Duration::from_micros(10));
                     }
                 }

--- a/examples/src/bin/trade_listener_channels.rs
+++ b/examples/src/bin/trade_listener_channels.rs
@@ -91,7 +91,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Add multiple order books
     let symbols = vec!["BTC/USD", "ETH/USD", "SOL/USD"];
     for symbol in &symbols {
-        manager.add_book(symbol);
+        manager.add_book(symbol).expect("add book");
     }
 
     // Start the trade processor
@@ -150,7 +150,7 @@ mod tests {
         let mut manager = BookManagerStd::<()>::new();
 
         // Add a book
-        manager.add_book("TEST/USD");
+        manager.add_book("TEST/USD").expect("add book");
 
         // Verify book was added
         assert!(manager.get_book("TEST/USD").is_some());

--- a/examples/src/bin/trade_listener_demo.rs
+++ b/examples/src/bin/trade_listener_demo.rs
@@ -56,7 +56,7 @@ fn main() {
 fn fill_orderbook_with_liquidity(book: &OrderBook) {
     // Add bid orders (buy side)
     info!("Adding BID orders (buy side):");
-    let bid_orders = vec![
+    let bid_orders = [
         (3000, 50), // price, quantity
         (2980, 75),
         (2960, 100),
@@ -80,7 +80,7 @@ fn fill_orderbook_with_liquidity(book: &OrderBook) {
     }
 
     info!("\nAdding ASK orders (sell side):");
-    let ask_orders = vec![
+    let ask_orders = [
         (3020, 50), // price, quantity
         (3040, 75),
         (3060, 100),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,7 +443,7 @@
 //!
 //! # Performance Analysis of the OrderBook System
 //!
-//! This analyzes the performance of the OrderBook system based on tests conducted on an Apple M4 Max processor. The data comes from a High-Frequency Trading (HFT) simulation and price level distribution performance tests.
+//! This analyzes the performance of the OrderBook system based on tests conducted on an Apple M4 Max processor. The data comes from a High-Frequency Trading (HFT) simulation and price level distribution performance tests. The figures below are representative single-run numbers measured on **orderbook-rs 0.9.0** with the bundled examples `orderbook_hft_simulation` and `orderbook_contention_test` (`cargo run --release -p examples --bin <name>`); absolute throughput is workload-, machine-, and run-dependent.
 //!
 //! ## 1. High-Frequency Trading (HFT) Simulation
 //!
@@ -460,50 +460,74 @@
 //!
 //! | Metric | Total Operations | Operations/Second |
 //! |---------|---------------------|---------------------|
-//! | Orders Added | 506,105 | 101,152.80 |
-//! | Orders Matched | 314,245 | 62,806.66 |
-//! | Orders Cancelled | 204,047 | 40,781.91 |
-//! | **Total Operations** | **1,024,397** | **204,741.37** |
+//! | Orders Added | 465,314 | 93,040.99 |
+//! | Orders Matched | 191,555 | 38,302.02 |
+//! | Orders Cancelled | 183,700 | 36,731.39 |
+//! | **Total Operations** | **840,569** | **168,074.41** |
 //!
 //! ### Initial vs. Final OrderBook State
 //!
 //! | Metric | Initial State | Final State |
 //! |---------|----------------|---------------|
-//! | Best Bid | 9,900 | 9,900 |
-//! | Best Ask | 10,000 | 10,070 |
+//! | Best Bid | 9,900 | 9,840 |
+//! | Best Ask | 10,000 | 10,010 |
 //! | Spread | 100 | 170 |
-//! | Mid Price | 9,950.00 | 9,985.00 |
-//! | Total Orders | 1,020 | 34,850 |
+//! | Mid Price | 9,950.00 | 9,925.00 |
+//! | Total Orders | 1,020 | 44,987 |
 //! | Bid Price Levels | 21 | 11 |
-//! | Ask Price Levels | 21 | 10 |
-//! | Total Bid Quantity | 7,750 | 274,504 |
-//! | Total Ask Quantity | 7,750 | 360,477 |
+//! | Ask Price Levels | 21 | 12 |
+//! | Total Bid Quantity | 7,750 | 346,031 |
+//! | Total Ask Quantity | 7,750 | 473,092 |
 //!
-//! ## 2. Price Level Distribution Performance Tests
+//! ## 2. Contention Pattern Performance Tests
 //!
 //! ### Configuration
-//! - **Test Duration:** 5000 ms (5 seconds)
+//! - **Threads:** 12
+//! - **Test Duration:** 3000 ms per sub-test
 //! - **Concurrent Operations:** Multi-threaded lock-free architecture
 //!
-//! ### Price Level Distribution Performance
+//! ### Read / Write Operation Ratio
+//!
+//! Mixed read/write workload over 500 resting orders across 40 price levels;
+//! the `Read %` is the fraction of operations that are read-only (snapshot /
+//! best-price / depth queries) versus mutating (add / cancel / match).
 //!
 //! | Read % | Operations/Second |
 //! |------------|---------------------|
-//! | 0%         | 430,081.91          |
-//! | 25%        | 17,031.12           |
-//! | 50%        | 15,965.15           |
-//! | 75%        | 20,590.32           |
-//! | 95%        | 42,451.24           |
+//! | 0%         | 305,435.88          |
+//! | 25%        | 63,103.90           |
+//! | 50%        | 51,933.72           |
+//! | 75%        | 54,960.34           |
+//! | 95%        | 100,379.54          |
+//!
+//! ### Price Level Distribution
+//!
+//! Throughput as the resting depth is spread across a varying number of price
+//! levels (100 orders per level, except the 5- and 1-level cases which pack the
+//! same orders into fewer levels).
+//!
+//! | Price Levels | Operations/Second |
+//! |--------------|---------------------|
+//! | 100          | 184,986.35          |
+//! | 50           | 188,085.24          |
+//! | 10           | 70,338.52           |
+//! | 5            | 68,610.25           |
+//! | 1            | 61,302.26           |
 //!
 //! ### Hot Spot Contention Test
 //!
+//! All threads hammer a single shared price level (20 hot-spot orders + 480
+//! regular); higher hot-spot percentages concentrate more operations on that one
+//! lock-free level, where the `crossbeam-skiplist` + `dashmap` + atomics design
+//! shines.
+//!
 //! | % Operations on Hot Spot | Operations/Second   |
 //! |--------------------------|---------------------|
-//! | 0%                       | 2,742,810.37        |
-//! | 25%                      | 3,414,940.27        |
-//! | 50%                      | 4,542,931.02        |
-//! | 75%                      | 8,834,677.82        |
-//! | 100%                     | 19,403,341.34       |
+//! | 0%                       | 14,978,484.36       |
+//! | 25%                      | 19,191,927.99       |
+//! | 50%                      | 25,890,620.87       |
+//! | 75%                      | 31,529,898.64       |
+//! | 100%                     | 31,607,744.24       |
 //!
 //! ### Performance Improvements and Deadlock Resolution
 //!
@@ -513,35 +537,35 @@
 //!
 //! - **New Implementation:** The `OrderQueue` was re-designed to use a combination of:
 //!   1. A `dashmap::DashMap` for storing orders, allowing for highly concurrent, O(1) average-case time complexity for insertions, lookups, and removals by `Id`.
-//!   2. A `crossbeam::queue::SegQueue` that now only stores `Id`s to maintain the crucial First-In-First-Out (FIFO) order for matching.
+//!   2. A sequence-keyed index (a `crossbeam_skiplist::SkipMap<sequence, Id>`) that maintains the crucial First-In-First-Out (FIFO) order for matching while still allowing O(log n) ordered iteration and deterministic snapshots.
 //!
 //! This hybrid approach eliminates the previous bottleneck, allowing threads to operate on the order collection with minimal contention, which is reflected in the massive throughput increase in the hot spot tests.
 //!
 //! ## 3. Analysis and Conclusions
 //!
 //! ### Overall Performance
-//! The system demonstrates excellent capability to handle over **200,000 operations per second** in the high-frequency trading simulation, distributed across order creations, matches, and cancellations.
+//! The system demonstrates excellent capability to handle over **165,000 operations per second** in the high-frequency trading simulation, distributed across order creations, matches, and cancellations.
 //!
 //! ### Price Level Distribution Behavior
-//! - **Optimal Performance Range:** The system performs best with 50-100 price levels, achieving 66,000-67,000 operations per second.
-//! - **Performance Degradation:** Performance decreases significantly with fewer price levels, dropping to around 23,000-29,000 operations per second with 1-10 levels.
+//! - **Optimal Performance Range:** The system performs best with 50-100 price levels, achieving roughly 185,000-188,000 operations per second.
+//! - **Performance Degradation:** Performance decreases with fewer price levels (more per-level contention), dropping to around 61,000-70,000 operations per second with 1-10 levels.
 //! - **Scalability:** The lock-free architecture demonstrates excellent scalability characteristics across different price level distributions.
 //!
 //! ### Hot Spot Contention
-//! - Surprisingly, performance **increases** as more operations concentrate on a hot spot, reaching its maximum with 100% concentration (19,403,341 ops/s).
+//! - Surprisingly, performance **increases** as more operations concentrate on a hot spot, reaching its maximum with 100% concentration (31,607,744 ops/s).
 //! - This counter-intuitive behavior might indicate:
 //!   1. Very efficient cache effects when operations are concentrated in one memory area
 //!   2. Internal optimizations to handle high-contention cases
 //!   3. Benefits of the system's lock-free architecture
 //!
 //! ### OrderBook State Behavior
-//! - During the HFT simulation, the order book handled a significant increase in order volume (from 1,020 to 34,850).
+//! - During the HFT simulation, the order book handled a significant increase in order volume (from 1,020 to 44,987).
 //! - The spread increased from 100 to 170, reflecting realistic market behavior under pressure.
-//! - The final state shows substantial liquidity with over 274,000 bid quantity and 360,000 ask quantity.
+//! - The final state shows substantial liquidity with over 346,000 bid quantity and 473,000 ask quantity.
 //!
 //! ## 4. Practical Implications
 //!
-//! - The system is suitable for high-frequency trading environments with the capacity to process over 200,000 operations per second.
+//! - The system is suitable for high-frequency trading environments with the capacity to process over 165,000 mixed operations per second (and tens of millions of operations per second on a single hot price level).
 //! - The lock-free architecture proves to be extremely effective at handling contention, especially at hot spots.
 //! - Optimal performance is achieved with moderate price level distribution (50-100 levels).
 //! - For real-world use cases, the system demonstrates excellent scalability and maintains performance under concurrent load.


### PR DESCRIPTION
## Summary

Verification + doc refresh requested after the 0.9.0 work. **No library code change.**

### Examples — now clippy-clean and verified
The `examples` package isn't covered by the root `make lint`, so lints had accumulated.
- **Fixes a #105 regression**: `BookManager::add_book` (now `-> Result`) was called with the `Result` ignored in `trade_listener_channels` (2 sites) — an ignored `Err` would silently hide a real "book already exists" failure. Now `.expect(...)`.
- Cleared every clippy lint across the example bins: `vec!`→array for iterate-only literals, redundant `u128 as u128` casts, manual `is_multiple_of`, `(x % n) * 1` identity-op, `if let Ok(_)`→`.is_ok()`.
- **All 26 examples build clippy-clean (`-D warnings`) and run cleanly**; the 2 example unit tests pass.

### Performance docs — refreshed to 0.9.0 (Apple M4 Max, Darwin 25.5.0, rustc 1.96.0)
- **`src/lib.rs` "Performance Analysis"**: fresh HFT-simulation throughput + initial/final state, read/write ratio, price-level distribution, and hot-spot contention tables (from `orderbook_hft_simulation` + `orderbook_contention_test`), plus corrected conclusions. The mislabeled "Price Level Distribution Performance" table (it was actually the read/write-ratio test) is renamed and a real per-level distribution table added. **README regenerated** via `make readme` (idempotent).
- **`BENCH.md`**: fresh HDR tail-latency tables for all scenarios + the new `stp_sweep` scenario (#107), updated run-conditions block, and an honest caveat on the `bytes_alloc/op` figure.
- **`BENCHMARKS.md`**: fresh Criterion medians (snapshot/restore, journal/replay, order ops, serialization, concurrency) + toolchain bump.

## Verification
- `cargo test --all-features`: green. `cargo fmt --all --check`: clean. Root **and** examples `clippy --all-targets -D warnings`: clean. All 7 HDR benches + the Criterion suite + `alloc_count` run successfully.

## ⚠️ Note for maintainer
The `alloc_count` bench reports `bytes_alloc/op ≈ 790 KB` (reproducible), vs the ~4.9 KB 0.7.0 reference — ~160× higher, while `allocs/op` is unchanged (~15). It is **not** FOK-related (the workload is GTC + market orders, no FOK). It looks like a real bytes-allocation characteristic of the deep-book synthetic workload (large transient buffers on market sweeps against very deep levels) and is documented with a caveat in `BENCH.md`, but it's worth a closer look as a possible regression. `allocs/op` (the CI-guarded metric) is unaffected and tests pass.

Closes nothing (maintenance).
