### PR TITLE
chore(deps): bump pricelevel 0.8.2 → 0.8.3 (fixes per-match over-allocation, PriceLevel#106)

### DIFF
--- a/BENCH.md
+++ b/BENCH.md
@@ -27,32 +27,33 @@ static A: CountingAllocator<System> = CountingAllocator::new(System);
 workload as `mixed_70_20_10_hdr` but reports `allocs_per_op` and
 `bytes_alloc/op` over the measurement window (200 000 warmup +
 1 000 000 measured). A reference run on the M4 Max host (orderbook-rs
-0.9.0):
+0.9.0, `pricelevel` 0.8.3):
 
-| counter        | value           |
-|----------------|-----------------|
-| allocs         | 14 945 144      |
-| deallocs       | 14 834 805      |
-| bytes_alloc    | 790 864 668 474 |
-| bytes_dealloc  | 790 836 738 974 |
-| **allocs/op**  | **14.95**       |
-| bytes_alloc/op | 790 865         |
+| counter        | value         |
+|----------------|---------------|
+| allocs         | 18 809 336    |
+| deallocs       | 18 698 998    |
+| bytes_alloc    | 6 180 736 806 |
+| bytes_dealloc  | 6 152 807 510 |
+| **allocs/op**  | **18.81**     |
+| bytes_alloc/op | 6 181         |
 
-`allocs/op` is the headline number for "what does the matching engine
-cost in alloc pressure on a realistic workload" — useful as a
-regression signal much more than as an absolute target. It is balanced
-(allocs ≈ deallocs, no leak) and is in the same ballpark as the 0.7.0
-reference (`~17.76`). Note `allocs/op` is workload-randomness-sensitive
-on this synthetic stream — repeat runs land in the `~15–19` range.
+Both counters are balanced (allocs ≈ deallocs, no leak). `allocs/op` is
+the headline number for "what does the matching engine cost in alloc
+pressure on a realistic workload" — useful as a regression signal much
+more than as an absolute target; it is in the same ballpark as the
+0.7.0 reference (`~17.76`) and is workload-randomness-sensitive on this
+synthetic stream (repeat runs land in the `~15–19` range).
+`bytes_alloc/op` (`~6 KB`) is likewise close to the 0.7.0 reference
+(`~4 926`).
 
-> **Note (`bytes_alloc/op`).** On this monotonically-growing
-> deep-book workload the per-op *bytes* allocated is large and much
-> higher than the historical 0.7.0 reference (`~4 926`). It is dominated
-> by the few large transient buffers a market sweep allocates against a
-> very deep price level (the workload concentrates ~700 k resting orders
-> into a narrow band, so individual levels get thousands of orders deep).
-> Treat `bytes_alloc/op` as a coarse signal only; `allocs/op` is the
-> stable regression metric and is what CI guards.
+> **Fixed in `pricelevel` 0.8.3 (PriceLevel#106).** Earlier `pricelevel`
+> 0.8.2 pre-sized each match `MatchResult` to the *whole* level depth, so
+> a qty-1 market order against a deep level allocated a multi-MB transient
+> buffer (`bytes_alloc/op` ballooned to `~790 KB`). 0.8.3 bounds the
+> pre-allocation to `min(incoming_quantity, order_count)`, so a small
+> taker no longer reserves the level — `bytes_alloc/op` is back to the
+> low-KB range.
 
 The integration test `tests/alloc_budget.rs` runs a smaller 10 000-op
 slice and asserts `allocs/op` stays under a fixed ceiling to catch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.0] — 2026-06-24
 
+### Performance
+
+- **Bump `pricelevel` 0.8.2 → 0.8.3 — fixes per-match over-allocation
+  (PriceLevel#106).** `PriceLevel::match_order` previously pre-sized each
+  `MatchResult` to the *whole* level depth (`order_count`), so a small taker
+  against a deep price level allocated (and immediately freed) a multi-MB
+  transient buffer — a qty-1 market order against a 100 k-deep level allocated
+  ~17.6 MB. 0.8.3 bounds the pre-allocation to
+  `min(incoming_quantity, order_count)`. The `alloc_count` bench's
+  `bytes_alloc/op` drops from `~790 KB` back to `~6 KB` (the per-match cost is
+  now flat in level depth instead of linear); `allocs/op` is unchanged. No
+  source change in orderbook-rs — dependency bump only.
+
 ### Fixed
 
 - **Surface swallowed re-price failures + clamp telemetry (#174).** The special-order

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ members = [
 
 [workspace.dependencies]
 orderbook-rs = { path = "." }
-pricelevel = "0.8.2"
+pricelevel = "0.8.3"
 tracing = "0.1"
 uuid = { version = "1.23", features = ["v4", "v5", "serde"] }
 dashmap = "6.2"


### PR DESCRIPTION
## Summary

Picks up **pricelevel 0.8.3**, which fixes the per-match over-allocation I traced from the 0.9.0 bench re-baseline (PriceLevel#106).

`pricelevel` 0.8.2's `PriceLevel::match_order` pre-sized each `MatchResult` to the **whole level depth** (`order_count`), so a small taker against a deep price level allocated — and immediately freed — a multi-MB transient buffer. 0.8.3 bounds the pre-allocation to `min(incoming_quantity, order_count)`.

## Verified on this host

| Metric | pricelevel 0.8.2 | pricelevel 0.8.3 |
|---|---|---|
| `alloc_count` `bytes_alloc/op` | ~790 KB | **~6 KB** |
| qty-1 match vs 100k-deep level (probe) | 17.6 MB | **~913 B** (flat in depth) |
| `allocs/op` | ~15–19 | ~15–19 (unchanged) |

`bytes_alloc/op` is back to the ~4.9 KB 0.7.0 range; the per-match cost is now flat in level depth instead of linear.

## Scope

**Dependency bump only — no orderbook-rs source change.** `Cargo.toml` `[workspace.dependencies]` `0.8.2 → 0.8.3`; CHANGELOG entry + BENCH.md alloc-profile table/note updated (the prior "under investigation" caveat is replaced with the fix reference). `cargo test --all-features`, `clippy --all-targets --all-features -D warnings`, `fmt --check`, `build --release --all-features` all clean.

Closes nothing (maintenance); resolves the alloc finding from PR #182.
