### PR TITLE
feat(modifications): add method that returns trade result immediately after adding order to book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.0] — 2026-06-24
 
+### Added
+
+- **`OrderBook::add_order_with_result` (#184).** Submit an order and receive
+  the `TradeResult` produced by the match directly in the return value —
+  `Ok((Arc<OrderType<T>>, Option<TradeResult>))` — instead of relying on the
+  `TradeListener` callback. The trade result is `None` when the order produced
+  no fills; when a listener is installed it still fires with the exact same
+  `TradeResult` (same fills, fees, and `engine_seq`). `add_order` is now a thin
+  wrapper that discards the result, and the `TradeResult` is only constructed
+  when a listener is installed and/or the caller asked for it, so the plain
+  `add_order` path without a listener stays free of the extra `MatchResult`
+  clone. Contributed by @Dev380.
+
 ### Performance
 
 - **Bump `pricelevel` 0.8.2 → 0.8.3 — fixes per-match over-allocation

--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ This order book engine is built with the following design principles:
 
 ### What's New in Version 0.9.0
 
+#### v0.9.0 — `add_order_with_result` (#184)
+
+- **New public API** on [`OrderBook<T>`]: `add_order_with_result` submits an
+  order and returns the `TradeResult` produced by the match directly —
+  `Ok((Arc<OrderType<T>>, Option<TradeResult>))` — instead of relying on the
+  `TradeListener` callback. `None` when the order produced no fills; an
+  installed listener still fires with the exact same `TradeResult`.
+  `add_order` is unchanged in behavior and stays free of the extra
+  `MatchResult` clone when no listener is installed.
+
 #### v0.9.0 — Upgrade to `pricelevel` 0.8.0 (#130)
 
 - **Price-time priority preserved across partial fills.** Picks up the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,16 @@
 //!
 //! ## What's New in Version 0.9.0
 //!
+//! ### v0.9.0 — `add_order_with_result` (#184)
+//!
+//! - **New public API** on [`OrderBook<T>`]: `add_order_with_result` submits an
+//!   order and returns the `TradeResult` produced by the match directly —
+//!   `Ok((Arc<OrderType<T>>, Option<TradeResult>))` — instead of relying on the
+//!   `TradeListener` callback. `None` when the order produced no fills; an
+//!   installed listener still fires with the exact same `TradeResult`.
+//!   `add_order` is unchanged in behavior and stays free of the extra
+//!   `MatchResult` clone when no listener is installed.
+//!
 //! ### v0.9.0 — Upgrade to `pricelevel` 0.8.0 (#130)
 //!
 //! - **Price-time priority preserved across partial fills.** Picks up the

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -1017,11 +1017,30 @@ where
 
     /// Add a new order to the book, automatically matching it if it's aggressive.
     ///
+    /// This convenience method calls [`Self::add_order_with_result`] internally but
+    /// ignores the trade result in the output.
+    ///
     /// # Errors
     /// Returns [`OrderBookError::KillSwitchActive`] when the kill switch
     /// is engaged. The check runs before any cache invalidation, STP
     /// validation, tick/lot validation, or matching work.
-    pub fn add_order(&self, mut order: OrderType<T>) -> Result<Arc<OrderType<T>>, OrderBookError> {
+    pub fn add_order(&self, order: OrderType<T>) -> Result<Arc<OrderType<T>>, OrderBookError> {
+        self.add_order_with_result(order).map(|(order, _)| order)
+    }
+
+    /// Add a new order to the book, automatically matching it if it's aggressive, also
+    /// returning the trade result directly.
+    ///
+    /// This method also calls the trade listener if enabled in addition to returning the trade result.
+    ///
+    /// # Errors
+    /// Returns [`OrderBookError::KillSwitchActive`] when the kill switch
+    /// is engaged. The check runs before any cache invalidation, STP
+    /// validation, tick/lot validation, or matching work.    
+    pub fn add_order_with_result(
+        &self,
+        mut order: OrderType<T>,
+    ) -> Result<(Arc<OrderType<T>>, Option<TradeResult>), OrderBookError> {
         self.check_kill_switch_or_reject(order.id())?;
         // Pre-trade risk gate: per-account open-orders / notional /
         // price band. No-op when no `RiskConfig` is installed.
@@ -1096,20 +1115,6 @@ where
             order.user_id(),
         )?;
 
-        let trades_emitted = match_result.trades().len() as u64;
-        if trades_emitted > 0 {
-            crate::orderbook::metrics::record_trades(trades_emitted);
-            if let Some(ref listener) = self.trade_listener {
-                let mut trade_result = TradeResult::with_fees(
-                    self.symbol.clone(),
-                    match_result.clone(),
-                    self.fee_schedule,
-                );
-                trade_result.engine_seq = self.next_engine_seq();
-                listener(&trade_result) // emit trade events to listener
-            }
-        }
-
         // True (non-self) executed quantity. `remaining_quantity` only decrements on
         // real trades, so STP-prevented self-fills never count toward it.
         let original_qty = order.total_quantity();
@@ -1134,6 +1139,24 @@ where
                 user_id: order.user_id(),
             });
         }
+
+        let trades_emitted = match_result.trades().len() as u64;
+        let trade_result = if trades_emitted > 0 {
+            crate::orderbook::metrics::record_trades(trades_emitted);
+            let mut trade_result = TradeResult::with_fees(
+                self.symbol.clone(),
+                match_result.clone(),
+                self.fee_schedule,
+            );
+            trade_result.engine_seq = self.next_engine_seq();
+            if let Some(ref listener) = self.trade_listener {
+                listener(&trade_result)
+            }
+
+            Some(trade_result)
+        } else {
+            None
+        };
 
         // If the order was not fully filled, add the remainder to the book
         if match_result.remaining_quantity().as_u64() > 0 {
@@ -1238,7 +1261,7 @@ where
 
             // Convert back to generic type for return
             let generic_order = self.convert_from_unit_type(&unit_order_arc);
-            Ok(Arc::new(generic_order))
+            Ok((Arc::new(generic_order), trade_result))
         } else {
             // The order was fully matched
             self.track_state(
@@ -1247,7 +1270,7 @@ where
                     filled_quantity: original_qty,
                 },
             );
-            Ok(Arc::new(order))
+            Ok((Arc::new(order), trade_result))
         }
     }
 }

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -1017,29 +1017,59 @@ where
 
     /// Add a new order to the book, automatically matching it if it's aggressive.
     ///
-    /// This convenience method calls [`Self::add_order_with_result`] internally but
-    /// ignores the trade result in the output.
+    /// This convenience method calls the same implementation as
+    /// [`Self::add_order_with_result`] but discards the trade result. When no
+    /// trade listener is installed, the `TradeResult` is never constructed, so
+    /// this path stays free of the extra `MatchResult` clone.
     ///
     /// # Errors
     /// Returns [`OrderBookError::KillSwitchActive`] when the kill switch
     /// is engaged. The check runs before any cache invalidation, STP
     /// validation, tick/lot validation, or matching work.
+    #[inline]
     pub fn add_order(&self, order: OrderType<T>) -> Result<Arc<OrderType<T>>, OrderBookError> {
-        self.add_order_with_result(order).map(|(order, _)| order)
+        self.add_order_inner(order, false).map(|(order, _)| order)
     }
 
-    /// Add a new order to the book, automatically matching it if it's aggressive, also
-    /// returning the trade result directly.
+    /// Add a new order to the book, automatically matching it if it's
+    /// aggressive, and additionally return the [`TradeResult`] produced by the
+    /// match directly to the caller.
     ///
-    /// This method also calls the trade listener if enabled in addition to returning the trade result.
+    /// The trade result is `None` when the order produced no fills (it rested
+    /// on the book, or was admitted without matching). When a trade listener
+    /// is installed, the listener is invoked with the exact same `TradeResult`
+    /// that is returned here — same fills, same fees, same `engine_seq`.
+    ///
+    /// On error paths that follow real fills (an unfillable IOC remainder, or
+    /// a self-trade-prevention cancellation after earlier non-self fills) the
+    /// typed error is returned instead, so those fills reach the trade
+    /// listener only.
+    ///
+    /// Every trade-producing call consumes one `engine_seq` tick, even when no
+    /// trade listener is installed (plain [`Self::add_order`] only consumes one
+    /// when a listener is present). `engine_seq` is per-instance and not
+    /// replay-reproducible; consumers that need a stable ordering key should
+    /// use the journal's `sequence_num` / `timestamp_ns` instead.
     ///
     /// # Errors
     /// Returns [`OrderBookError::KillSwitchActive`] when the kill switch
     /// is engaged. The check runs before any cache invalidation, STP
-    /// validation, tick/lot validation, or matching work.    
+    /// validation, tick/lot validation, or matching work.
     pub fn add_order_with_result(
         &self,
+        order: OrderType<T>,
+    ) -> Result<(Arc<OrderType<T>>, Option<TradeResult>), OrderBookError> {
+        self.add_order_inner(order, true)
+    }
+
+    /// Shared implementation behind [`Self::add_order`] and
+    /// [`Self::add_order_with_result`]. `want_result` gates `TradeResult`
+    /// construction so the plain `add_order` path only pays for it when an
+    /// installed trade listener needs it anyway.
+    fn add_order_inner(
+        &self,
         mut order: OrderType<T>,
+        want_result: bool,
     ) -> Result<(Arc<OrderType<T>>, Option<TradeResult>), OrderBookError> {
         self.check_kill_switch_or_reject(order.id())?;
         // Pre-trade risk gate: per-account open-orders / notional /
@@ -1115,6 +1145,34 @@ where
             order.user_id(),
         )?;
 
+        // Emit trades BEFORE any early return below: the STP taker-cancel and
+        // unfillable-IOC paths return `Err` after real (non-self) fills already
+        // executed, and those fills must still reach the metrics and the trade
+        // listener. The `TradeResult` is only constructed when someone consumes
+        // it — the installed listener and/or an `add_order_with_result` caller —
+        // so the plain `add_order` hot path skips the `MatchResult` clone.
+        let trades_emitted = match_result.trades().len() as u64;
+        let trade_result = if trades_emitted > 0 {
+            crate::orderbook::metrics::record_trades(trades_emitted);
+            let listener = self.trade_listener.as_ref();
+            if want_result || listener.is_some() {
+                let mut trade_result = TradeResult::with_fees(
+                    self.symbol.clone(),
+                    match_result.clone(),
+                    self.fee_schedule,
+                );
+                trade_result.engine_seq = self.next_engine_seq();
+                if let Some(listener) = listener {
+                    listener(&trade_result) // emit trade events to listener
+                }
+                Some(trade_result)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         // True (non-self) executed quantity. `remaining_quantity` only decrements on
         // real trades, so STP-prevented self-fills never count toward it.
         let original_qty = order.total_quantity();
@@ -1139,24 +1197,6 @@ where
                 user_id: order.user_id(),
             });
         }
-
-        let trades_emitted = match_result.trades().len() as u64;
-        let trade_result = if trades_emitted > 0 {
-            crate::orderbook::metrics::record_trades(trades_emitted);
-            let mut trade_result = TradeResult::with_fees(
-                self.symbol.clone(),
-                match_result.clone(),
-                self.fee_schedule,
-            );
-            trade_result.engine_seq = self.next_engine_seq();
-            if let Some(ref listener) = self.trade_listener {
-                listener(&trade_result)
-            }
-
-            Some(trade_result)
-        } else {
-            None
-        };
 
         // If the order was not fully filled, add the remainder to the book
         if match_result.remaining_quantity().as_u64() > 0 {

--- a/src/orderbook/tests/modifications.rs
+++ b/src/orderbook/tests/modifications.rs
@@ -795,3 +795,238 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+mod test_add_order_with_result {
+    use crate::orderbook::modifications::OrderQuantity;
+    use crate::orderbook::stp::STPMode;
+    use crate::{OrderBook, OrderBookError, TradeListener, TradeResult};
+    use pricelevel::{Hash32, Id, OrderType, Price, Quantity, Side, TimeInForce, TimestampMs};
+    use std::sync::{Arc, Mutex};
+
+    /// Helper: create a non-zero user hash from a single byte value.
+    fn user(byte: u8) -> Hash32 {
+        Hash32::new([byte; 32])
+    }
+
+    /// Helper: build a standard GTC order.
+    fn standard_order(price: u128, quantity: u64, side: Side, user_id: Hash32) -> OrderType<()> {
+        OrderType::Standard {
+            id: Id::new(),
+            price: Price::new(price),
+            quantity: Quantity::new(quantity),
+            side,
+            user_id,
+            timestamp: TimestampMs::new(crate::utils::current_time_millis()),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        }
+    }
+
+    /// Helper: book whose trade listener captures every emitted `TradeResult`.
+    fn book_with_capturing_listener() -> (OrderBook<()>, Arc<Mutex<Vec<TradeResult>>>) {
+        let captured: Arc<Mutex<Vec<TradeResult>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&captured);
+        let listener: TradeListener = Arc::new(move |tr: &TradeResult| {
+            if let Ok(mut guard) = sink.lock() {
+                guard.push(tr.clone());
+            }
+        });
+        (OrderBook::with_trade_listener("TEST", listener), captured)
+    }
+
+    #[test]
+    fn test_add_order_with_result_full_fill_returns_trade_result() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+        let maker = user(1);
+        let taker = user(2);
+
+        let result = book.add_order(standard_order(100, 5, Side::Sell, maker));
+        assert!(result.is_ok(), "failed to rest maker: {result:?}");
+
+        let result = book.add_order_with_result(standard_order(100, 5, Side::Buy, taker));
+        let Ok((_, Some(trade_result))) = result else {
+            panic!("expected Ok with a trade result, got {result:?}");
+        };
+        assert_eq!(trade_result.symbol, "TEST");
+        assert_eq!(
+            trade_result.match_result.executed_quantity().ok(),
+            Some(Quantity::new(5)),
+            "full fill must execute the entire quantity"
+        );
+        assert!(trade_result.match_result.is_complete());
+    }
+
+    #[test]
+    fn test_add_order_with_result_resting_order_returns_none() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+
+        let order = standard_order(100, 10, Side::Buy, user(1));
+        let order_id = order.id();
+        let result = book.add_order_with_result(order);
+        let Ok((added, trade_result)) = result else {
+            panic!("expected Ok, got {result:?}");
+        };
+        assert!(
+            trade_result.is_none(),
+            "an order that matched nothing must return no trade result"
+        );
+        assert_eq!(added.id(), order_id);
+        assert!(book.get_order(order_id).is_some(), "order must rest");
+    }
+
+    #[test]
+    fn test_add_order_with_result_partial_fill_rests_remainder() {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+        let maker = user(1);
+        let taker = user(2);
+
+        let result = book.add_order(standard_order(100, 5, Side::Sell, maker));
+        assert!(result.is_ok(), "failed to rest maker: {result:?}");
+
+        let result = book.add_order_with_result(standard_order(100, 20, Side::Buy, taker));
+        let Ok((added, Some(trade_result))) = result else {
+            panic!("expected Ok with a trade result, got {result:?}");
+        };
+        assert_eq!(
+            trade_result.match_result.executed_quantity().ok(),
+            Some(Quantity::new(5)),
+            "only the resting 5 units can fill"
+        );
+        assert_eq!(added.quantity(), 15, "the 15-unit remainder must rest");
+        assert!(book.get_order(added.id()).is_some());
+    }
+
+    #[test]
+    fn test_add_order_with_result_listener_receives_same_trade_result() {
+        let (book, captured) = book_with_capturing_listener();
+        let maker = user(1);
+        let taker = user(2);
+
+        let result = book.add_order(standard_order(100, 5, Side::Sell, maker));
+        assert!(result.is_ok(), "failed to rest maker: {result:?}");
+
+        let result = book.add_order_with_result(standard_order(100, 5, Side::Buy, taker));
+        let Ok((_, Some(trade_result))) = result else {
+            panic!("expected Ok with a trade result, got {result:?}");
+        };
+
+        let captured = captured.lock().expect("listener mutex poisoned");
+        assert_eq!(captured.len(), 1, "listener must fire exactly once");
+        assert_eq!(
+            captured[0].engine_seq, trade_result.engine_seq,
+            "listener and caller must see the same engine_seq"
+        );
+        assert_eq!(
+            captured[0].match_result.executed_quantity().ok(),
+            trade_result.match_result.executed_quantity().ok(),
+            "listener and caller must see the same fills"
+        );
+    }
+
+    /// Regression: the trade emission block must run BEFORE the STP
+    /// taker-cancel early return. A taker that partially fills against
+    /// another user and is then STP-cancelled surfaces the typed error,
+    /// but the real (non-self) fills must still reach the trade listener.
+    #[test]
+    fn test_add_order_stp_cancel_taker_partial_fill_still_reaches_listener() {
+        let (mut book, captured) = book_with_capturing_listener();
+        book.set_stp_mode(STPMode::CancelTaker);
+
+        let taker_user = user(7);
+        let other = user(1);
+
+        // Non-self liquidity at the better price; the taker's own order behind it.
+        let result = book.add_order(standard_order(100, 5, Side::Sell, other));
+        assert!(result.is_ok(), "failed to rest other maker: {result:?}");
+        let result = book.add_order(standard_order(200, 10, Side::Sell, taker_user));
+        assert!(result.is_ok(), "failed to rest self maker: {result:?}");
+
+        // GTC buy 20 at limit 200: fills 5 vs `other` at 100, then hits its own
+        // order at 200 -> CancelTaker cancels the taker.
+        let result = book.add_order(standard_order(200, 20, Side::Buy, taker_user));
+        assert!(
+            matches!(result, Err(OrderBookError::SelfTradePrevented { .. })),
+            "partial self-cross under CancelTaker must surface the STP error, got {result:?}"
+        );
+
+        let captured = captured.lock().expect("listener mutex poisoned");
+        assert_eq!(
+            captured.len(),
+            1,
+            "the 5-unit non-self fill must reach the trade listener"
+        );
+        assert_eq!(
+            captured[0].match_result.executed_quantity().ok(),
+            Some(Quantity::new(5))
+        );
+    }
+
+    /// Same STP partial-fill scenario through `add_order_with_result`: the
+    /// typed error is returned (no trade result), the listener still fires.
+    #[test]
+    fn test_add_order_with_result_stp_cancel_taker_partial_fill_errors_and_emits() {
+        let (mut book, captured) = book_with_capturing_listener();
+        book.set_stp_mode(STPMode::CancelTaker);
+
+        let taker_user = user(7);
+        let other = user(1);
+
+        let result = book.add_order(standard_order(100, 5, Side::Sell, other));
+        assert!(result.is_ok(), "failed to rest other maker: {result:?}");
+        let result = book.add_order(standard_order(200, 10, Side::Sell, taker_user));
+        assert!(result.is_ok(), "failed to rest self maker: {result:?}");
+
+        let result = book.add_order_with_result(standard_order(200, 20, Side::Buy, taker_user));
+        assert!(
+            matches!(result, Err(OrderBookError::SelfTradePrevented { .. })),
+            "partial self-cross under CancelTaker must surface the STP error, got {result:?}"
+        );
+
+        let captured = captured.lock().expect("listener mutex poisoned");
+        assert_eq!(
+            captured.len(),
+            1,
+            "the 5-unit non-self fill must reach the trade listener"
+        );
+    }
+
+    /// An IOC that partially fills and cannot complete returns
+    /// `InsufficientLiquidity`; the partial fill still reaches the listener.
+    #[test]
+    fn test_add_order_with_result_ioc_partial_fill_errors_and_emits() {
+        let (book, captured) = book_with_capturing_listener();
+        let maker = user(1);
+        let taker = user(2);
+
+        let result = book.add_order(standard_order(100, 5, Side::Sell, maker));
+        assert!(result.is_ok(), "failed to rest maker: {result:?}");
+
+        let ioc = OrderType::Standard {
+            id: Id::new(),
+            price: Price::new(100),
+            quantity: Quantity::new(20),
+            side: Side::Buy,
+            user_id: taker,
+            timestamp: TimestampMs::new(crate::utils::current_time_millis()),
+            time_in_force: TimeInForce::Ioc,
+            extra_fields: (),
+        };
+        let result = book.add_order_with_result(ioc);
+        assert!(
+            matches!(result, Err(OrderBookError::InsufficientLiquidity { .. })),
+            "unfillable IOC remainder must error, got {result:?}"
+        );
+
+        let captured = captured.lock().expect("listener mutex poisoned");
+        assert_eq!(
+            captured.len(),
+            1,
+            "the 5-unit partial fill must reach the trade listener"
+        );
+        assert_eq!(
+            captured[0].match_result.executed_quantity().ok(),
+            Some(Quantity::new(5))
+        );
+    }
+}


### PR DESCRIPTION
Currently the orderbook only supports `add_order` or `match_order` to add orders to the book, excluding convenience functions. This makes the API slightly annoying to use in certain exchange designs because to get the result of an order, you either have to use `match_order` and give up the flexibility of using any `OrderType` object, or you have to use `add_order` and wait for the listener to process it, which may not be ideal especially if you want to read the trade result in the same function that the order is added. This adds an `add_order_with_result` method that also returns the TradeResult and makes `add_order` a simple wrapper around it for compatibility.