### PR TITLE
release: 0.9.2 — per-price aggregates, per-call fill attribution wrappers, GTD ms unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] — 2026-07-10
+
+### Added
+
+- **Constant-work per-price aggregate accessors (#186)** — an O(log N) point
+  lookup + O(1) counter read, with no per-order materialization. Four read-only
+  methods on `OrderBook<T>`: `visible_quantity_at_price`,
+  `hidden_quantity_at_price`, `total_quantity_at_price`, and
+  `order_count_at_price`. Each performs an O(log N) `SkipMap` point lookup then
+  reads the level's maintained atomic counter (one relaxed load; two for
+  `total_quantity_at_price`, which sums visible + hidden) — no per-order `Arc`
+  is materialized and no `T: Default` conversion runs, so they are the cheap
+  way to poll one level's depth or order count. `order_count_at_price` is the
+  counterpart to `queue_ahead_at_price` that drops the per-order term: O(log N)
+  here vs O(log N + K) for the queue-walking version, which is left unchanged.
+  All four return `None` for an absent level and read advisory,
+  eventually-consistent counters; use `create_snapshot` for a
+  mutually-consistent view. `total_quantity_at_price` saturates a (practically
+  unreachable) `visible + hidden` overflow to `u64::MAX`, never `0`, so an
+  overflow signals "enormous", never "empty".
+- **`add_limit_order_with_result` / `add_limit_order_with_user_and_result`
+  (#185).** Result-returning counterparts of `add_limit_order` /
+  `add_limit_order_with_user`: they build the same `Standard` order and route
+  through `add_order_with_result`, returning
+  `Ok((Arc<OrderType<T>>, Option<TradeResult>))` so callers get the match's
+  `TradeResult` directly instead of relying on the `TradeListener` callback.
+
+### Documentation
+
+- **Per-call fill attribution guarantee for `add_order_with_result` (#185).**
+  The rustdoc now states explicitly that concurrent submits on the same book
+  each receive exactly their own fills — the `TradeResult` is built from that
+  call's private `MatchResult`, never from shared capture state, because the
+  engine holds no cross-call trade accumulator. On the error-after-fills paths
+  (an unfillable IOC remainder, or a self-trade-prevention cancellation after
+  earlier non-self fills) the caller instead gets the typed `Err` and the
+  executed fills reach only the trade listener. A multi-thread concurrency test
+  (`test_add_order_with_result_concurrent_per_call_attribution`) pins the
+  guarantee.
+- **GTD / market-close timestamps documented as milliseconds (#187).**
+  `has_expired`, `set_market_close_timestamp`, and the `time_in_force`
+  parameter docs on the limit / iceberg / post-only builders now state that GTD
+  deadlines and the market-close timestamp are **milliseconds since the Unix
+  epoch** — the same unit `clock().now_millis()` compares against. The pinning
+  test `gtd_expiry_unit_is_milliseconds` proves a seconds-form deadline reads
+  as instantly expired.
+
 ## [0.9.1] — 2026-07-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orderbook-rs"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."
@@ -147,7 +147,7 @@ members = [
 
 [workspace.dependencies]
 orderbook-rs = { path = "." }
-pricelevel = "0.8.3"
+pricelevel = "0.8.4"
 tracing = "0.1"
 uuid = { version = "1.23", features = ["v4", "v5", "serde"] }
 dashmap = "6.2"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,42 @@ This order book engine is built with the following design principles:
 - **Research**: Platform for studying market microstructure and order flow
 - **Educational**: Reference implementation for understanding modern exchange architecture
 
+### What's New in Version 0.9.2
+
+#### v0.9.2 — constant-work per-price aggregates + attribution & unit docs (#185, #186, #187)
+
+- **Constant-work per-price aggregate accessors (#186)** — an O(log N)
+  point lookup + O(1) counter read, with no per-order materialization. New
+  read-only methods on [`OrderBook<T>`]: `visible_quantity_at_price`,
+  `hidden_quantity_at_price`, `total_quantity_at_price`, and
+  `order_count_at_price`. Each does an O(log N) `SkipMap` point lookup then
+  reads the level's maintained atomic counter (one relaxed load; two for
+  `total_quantity_at_price`, which sums visible + hidden) — no per-order
+  `Arc` is materialized and no `T: Default` conversion runs, so they are the
+  cheap way to poll one level's depth or count. `order_count_at_price` is
+  the counterpart to `queue_ahead_at_price` that drops the per-order term:
+  O(log N) here vs O(log N + K) for the queue-walking version. All four
+  return `None` for an absent level and read advisory, eventually-consistent
+  counters — take `create_snapshot` for a mutually-consistent view.
+- **Per-call fill attribution, documented and proven (#185).** The
+  `add_order_with_result` guarantee is now explicit: concurrent submits on
+  the same book each receive exactly their own fills, because the
+  `TradeResult` is built from that call's private `MatchResult` and the
+  engine holds no shared trade accumulator. On the error-after-fills paths
+  (an unfillable IOC remainder, or a self-trade-prevention cancellation
+  after earlier non-self fills) the caller instead gets the typed `Err` and
+  the executed fills reach only the trade listener. A multi-thread
+  concurrency test pins it. New convenience wrappers
+  `add_limit_order_with_result` and `add_limit_order_with_user_and_result`
+  mirror the plain `add_limit_order*` builders while returning the
+  `TradeResult` directly.
+- **GTD / market-close millisecond unit documented (#187).** `has_expired`,
+  `set_market_close_timestamp`, and the `time_in_force` parameter docs now
+  state that GTD deadlines and the market-close timestamp are milliseconds
+  since the Unix epoch (the same unit `clock().now_millis()` compares
+  against). A pinning test proves a seconds-form deadline reads as instantly
+  expired.
+
 ### What's New in Version 0.9.1
 
 #### v0.9.1 — `add_order_with_result` (#184)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,42 @@
 //! - **Research**: Platform for studying market microstructure and order flow
 //! - **Educational**: Reference implementation for understanding modern exchange architecture
 //!
+//! ## What's New in Version 0.9.2
+//!
+//! ### v0.9.2 — constant-work per-price aggregates + attribution & unit docs (#185, #186, #187)
+//!
+//! - **Constant-work per-price aggregate accessors (#186)** — an O(log N)
+//!   point lookup + O(1) counter read, with no per-order materialization. New
+//!   read-only methods on [`OrderBook<T>`]: `visible_quantity_at_price`,
+//!   `hidden_quantity_at_price`, `total_quantity_at_price`, and
+//!   `order_count_at_price`. Each does an O(log N) `SkipMap` point lookup then
+//!   reads the level's maintained atomic counter (one relaxed load; two for
+//!   `total_quantity_at_price`, which sums visible + hidden) — no per-order
+//!   `Arc` is materialized and no `T: Default` conversion runs, so they are the
+//!   cheap way to poll one level's depth or count. `order_count_at_price` is
+//!   the counterpart to `queue_ahead_at_price` that drops the per-order term:
+//!   O(log N) here vs O(log N + K) for the queue-walking version. All four
+//!   return `None` for an absent level and read advisory, eventually-consistent
+//!   counters — take `create_snapshot` for a mutually-consistent view.
+//! - **Per-call fill attribution, documented and proven (#185).** The
+//!   `add_order_with_result` guarantee is now explicit: concurrent submits on
+//!   the same book each receive exactly their own fills, because the
+//!   `TradeResult` is built from that call's private `MatchResult` and the
+//!   engine holds no shared trade accumulator. On the error-after-fills paths
+//!   (an unfillable IOC remainder, or a self-trade-prevention cancellation
+//!   after earlier non-self fills) the caller instead gets the typed `Err` and
+//!   the executed fills reach only the trade listener. A multi-thread
+//!   concurrency test pins it. New convenience wrappers
+//!   `add_limit_order_with_result` and `add_limit_order_with_user_and_result`
+//!   mirror the plain `add_limit_order*` builders while returning the
+//!   `TradeResult` directly.
+//! - **GTD / market-close millisecond unit documented (#187).** `has_expired`,
+//!   `set_market_close_timestamp`, and the `time_in_force` parameter docs now
+//!   state that GTD deadlines and the market-close timestamp are milliseconds
+//!   since the Unix epoch (the same unit `clock().now_millis()` compares
+//!   against). A pinning test proves a seconds-form deadline reads as instantly
+//!   expired.
+//!
 //! ## What's New in Version 0.9.1
 //!
 //! ### v0.9.1 — `add_order_with_result` (#184)

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -1121,7 +1121,13 @@ where
         &self.symbol
     }
 
-    /// Set the market close timestamp for DAY orders
+    /// Set the market close timestamp for DAY orders.
+    ///
+    /// `timestamp` is **milliseconds since the Unix epoch** — the same clock
+    /// unit `has_expired` compares against (`self.clock().now_millis()`). A
+    /// `Day` order is expired once the current time reaches this value; passing
+    /// a seconds-based timestamp would place market close in 1970 and expire
+    /// every `Day` order immediately.
     pub fn set_market_close_timestamp(&self, timestamp: u64) {
         self.market_close_timestamp
             .store(timestamp, Ordering::SeqCst);
@@ -2378,6 +2384,163 @@ where
     {
         self.levels_with_cumulative_depth(side)
             .find(|level| predicate(level))
+    }
+
+    /// Returns the visible (displayed) resting quantity at a price level, in
+    /// quantity units, or `None` when no level exists there.
+    ///
+    /// O(log N) `SkipMap` point lookup followed by a single relaxed atomic
+    /// load of the level's visible counter — no per-order [`Arc`] is
+    /// materialized and no `T: Default` conversion is performed, so this is
+    /// the cheap way to poll displayed depth at one price (contrast
+    /// [`Self::get_orders_at_price`], which clones every order).
+    ///
+    /// # Arguments
+    /// - `price`: The price level to read (in price units).
+    /// - `side`: The side to read (`Buy` for bids, `Sell` for asks).
+    ///
+    /// # Returns
+    /// - `Some(qty)` when a level exists at `price`. `Some(0)` denotes a live
+    ///   level whose visible depth is momentarily zero (e.g. a fully-hidden
+    ///   iceberg tranche) — distinct from `None`.
+    /// - `None` when no level exists at `price` on that side.
+    ///
+    /// # Consistency
+    /// This is an **advisory, eventually-consistent** counter read (see
+    /// `pricelevel`'s `PriceLevel::visible_quantity`): under concurrent
+    /// `add_order` / matching / `update_order` it can briefly lead or lag the
+    /// queue contents, and it is not guaranteed mutually consistent with a
+    /// separately-read [`Self::order_count_at_price`] /
+    /// [`Self::hidden_quantity_at_price`] / [`Self::total_quantity_at_price`].
+    /// For a view where the counters and the order list agree, take
+    /// [`Self::create_snapshot`] and read from it.
+    #[must_use]
+    pub fn visible_quantity_at_price(&self, price: u128, side: Side) -> Option<u64> {
+        let price_levels = match side {
+            Side::Buy => &self.bids,
+            Side::Sell => &self.asks,
+        };
+        price_levels
+            .get(&price)
+            .map(|entry| entry.value().visible_quantity())
+    }
+
+    /// Returns the hidden (reserve) resting quantity at a price level, in
+    /// quantity units, or `None` when no level exists there.
+    ///
+    /// The symmetric counterpart to [`Self::visible_quantity_at_price`]: same
+    /// O(log N) lookup plus one relaxed atomic load of the level's hidden
+    /// counter, no allocation, no `T: Default` bound. Hidden quantity is the
+    /// undisplayed reserve of iceberg / reserve orders.
+    ///
+    /// # Arguments
+    /// - `price`: The price level to read (in price units).
+    /// - `side`: The side to read (`Buy` for bids, `Sell` for asks).
+    ///
+    /// # Returns
+    /// - `Some(qty)` when a level exists at `price` (`Some(0)` = a live level
+    ///   with no hidden reserve, distinct from `None`).
+    /// - `None` when no level exists at `price` on that side.
+    ///
+    /// # Consistency
+    /// **Advisory, eventually-consistent** counter read (see
+    /// `pricelevel`'s `PriceLevel::hidden_quantity`): under concurrent
+    /// mutation it can briefly lead or lag the queue, and it is not guaranteed
+    /// mutually consistent with a separately-read visible / count / total. For
+    /// a mutually-consistent view, take [`Self::create_snapshot`].
+    #[must_use]
+    pub fn hidden_quantity_at_price(&self, price: u128, side: Side) -> Option<u64> {
+        let price_levels = match side {
+            Side::Buy => &self.bids,
+            Side::Sell => &self.asks,
+        };
+        price_levels
+            .get(&price)
+            .map(|entry| entry.value().hidden_quantity())
+    }
+
+    /// Returns the total (visible + hidden) resting quantity at a price level,
+    /// in quantity units, or `None` when no level exists there.
+    ///
+    /// O(log N) `SkipMap` point lookup plus two relaxed atomic loads summed by
+    /// `pricelevel`'s `PriceLevel::total_quantity`. That sum returns a
+    /// `Result` that only errors on a `u64` overflow of `visible + hidden`,
+    /// which is unreachable for any real book; on that overflow this method
+    /// **saturates to `u64::MAX`** rather than collapsing to `0`, so an
+    /// overflow signals "enormous", never "empty" (a `0` would be the exact
+    /// inversion of an overflowed level).
+    ///
+    /// # Arguments
+    /// - `price`: The price level to read (in price units).
+    /// - `side`: The side to read (`Buy` for bids, `Sell` for asks).
+    ///
+    /// # Returns
+    /// - `Some(qty)` when a level exists at `price`. A `Some(0)` here is only a
+    ///   brief concurrency transient during level removal — an empty level is
+    ///   eagerly removed from the `SkipMap` on every removal path, so a settled
+    ///   level always has positive total quantity. `Some(u64::MAX)` denotes a
+    ///   (practically unreachable) counter overflow, never an empty level.
+    /// - `None` when no level exists at `price` on that side.
+    ///
+    /// # Consistency
+    /// **Advisory, eventually-consistent** read — it sums two independent
+    /// atomic counters (see `pricelevel`'s `PriceLevel::visible_quantity`), so
+    /// under concurrent mutation the two loads may straddle a mutation and it
+    /// is not guaranteed mutually consistent with the per-side visible / hidden
+    /// / count read separately. For a mutually-consistent view, take
+    /// [`Self::create_snapshot`].
+    #[must_use]
+    pub fn total_quantity_at_price(&self, price: u128, side: Side) -> Option<u64> {
+        let price_levels = match side {
+            Side::Buy => &self.bids,
+            Side::Sell => &self.asks,
+        };
+        price_levels
+            .get(&price)
+            // Saturate an (unreachable) `visible + hidden` overflow to
+            // `u64::MAX`: a `0` would read as "empty level" — the exact
+            // inversion — so signal "enormous" instead.
+            .map(|entry| entry.value().total_quantity().unwrap_or(u64::MAX))
+    }
+
+    /// Returns the number of resting orders at a price level, or `None` when no
+    /// level exists there.
+    ///
+    /// Cheaper counterpart to [`Self::queue_ahead_at_price`], which counts by
+    /// iterating the level's order queue. Both do the same O(log N) `SkipMap`
+    /// point lookup; this method then reads the level's maintained
+    /// `order_count` atomic (a single relaxed load) instead of walking the K
+    /// orders at the level, so it drops the per-order term: O(log N) here vs
+    /// O(log N + K) for `queue_ahead_at_price`. Prefer this when you only need
+    /// the count; [`Self::queue_ahead_at_price`] is left unchanged and still
+    /// returns `0` (not `None`) for an absent level.
+    ///
+    /// # Arguments
+    /// - `price`: The price level to read (in price units).
+    /// - `side`: The side to read (`Buy` for bids, `Sell` for asks).
+    ///
+    /// # Returns
+    /// - `Some(count)` when a level exists at `price`. A `Some(0)` here is only
+    ///   a brief concurrency transient during level removal — an empty level is
+    ///   eagerly removed from the `SkipMap` on every removal path, so a settled
+    ///   level always has at least one order.
+    /// - `None` when no level exists at `price` on that side.
+    ///
+    /// # Consistency
+    /// **Advisory, eventually-consistent** counter read (see `pricelevel`'s
+    /// `PriceLevel::order_count`): under concurrent mutation it can briefly
+    /// lead or lag the queue and is not guaranteed mutually consistent with a
+    /// separately-read quantity. For a mutually-consistent view, take
+    /// [`Self::create_snapshot`].
+    #[must_use]
+    pub fn order_count_at_price(&self, price: u128, side: Side) -> Option<usize> {
+        let price_levels = match side {
+            Side::Buy => &self.bids,
+            Side::Sell => &self.asks,
+        };
+        price_levels
+            .get(&price)
+            .map(|entry| entry.value().order_count())
     }
 
     /// Get all orders at a specific price level

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -1040,6 +1040,14 @@ where
     /// is installed, the listener is invoked with the exact same `TradeResult`
     /// that is returned here — same fills, same fees, same `engine_seq`.
     ///
+    /// Per-call attribution: concurrent submits on the same book each receive
+    /// exactly their own fills; the result is built from this call's private
+    /// match outcome, never from shared capture state. The engine holds no
+    /// cross-call trade accumulator — each returned `TradeResult` is
+    /// constructed from the `MatchResult` produced by this invocation alone —
+    /// so two threads submitting crossing orders concurrently cannot observe
+    /// each other's fills in their own returned result.
+    ///
     /// On error paths that follow real fills (an unfillable IOC remainder, or
     /// a self-trade-prevention cancellation after earlier non-self fills) the
     /// typed error is returned instead, so those fills reach the trade

--- a/src/orderbook/operations.rs
+++ b/src/orderbook/operations.rs
@@ -2,6 +2,7 @@
 
 use super::book::OrderBook;
 use super::error::OrderBookError;
+use super::trade::TradeResult;
 use pricelevel::{Hash32, Id, MatchResult, OrderType, Price, Quantity, Side, TimeInForce};
 use std::sync::Arc;
 use tracing::trace;
@@ -15,6 +16,9 @@ where
     /// This convenience method sets `user_id` to `Hash32::zero()`.  When STP
     /// is enabled on this book, use [`Self::add_limit_order_with_user`] instead
     /// to supply the owner identity.
+    ///
+    /// `time_in_force` accepts a GTD deadline in Unix milliseconds — see
+    /// [`Self::add_limit_order_with_user`] for full argument docs.
     ///
     /// # Errors
     /// Returns [`OrderBookError::MissingUserId`] when STP is enabled.
@@ -48,7 +52,7 @@ where
     /// * `price` — Limit price.
     /// * `quantity` — Order quantity.
     /// * `side` — Buy or Sell.
-    /// * `time_in_force` — Time-in-force policy.
+    /// * `time_in_force` — Time-in-force policy (GTD deadline in Unix milliseconds).
     /// * `user_id` — Owner identity for STP checks.
     /// * `extra_fields` — Optional application-specific payload.
     ///
@@ -87,10 +91,116 @@ where
         self.add_order(order)
     }
 
+    /// Add a limit order to the book and return the [`TradeResult`] produced by
+    /// the match directly to the caller.
+    ///
+    /// The result-returning counterpart of [`Self::add_limit_order`]: it builds
+    /// the same `Standard` order and routes through
+    /// [`Self::add_order_with_result`], so the returned tuple carries the
+    /// resting order plus `Some(TradeResult)` when the order produced fills, or
+    /// `None` when it rested without matching. This convenience method sets
+    /// `user_id` to `Hash32::zero()`; when STP is enabled use
+    /// [`Self::add_limit_order_with_user_and_result`] instead.
+    ///
+    /// Per-call attribution: the `TradeResult` is built from this call's own
+    /// private match outcome, never from shared capture state, so concurrent
+    /// submits on the same book each receive exactly their own fills.
+    ///
+    /// `time_in_force` accepts a GTD deadline in Unix milliseconds — see
+    /// [`Self::add_limit_order_with_user_and_result`] for full argument docs.
+    ///
+    /// # Errors
+    /// Returns [`OrderBookError::MissingUserId`] when STP is enabled.
+    pub fn add_limit_order_with_result(
+        &self,
+        id: Id,
+        price: u128,
+        quantity: u64,
+        side: Side,
+        time_in_force: TimeInForce,
+        extra_fields: Option<T>,
+    ) -> Result<(Arc<OrderType<T>>, Option<TradeResult>), OrderBookError> {
+        self.add_limit_order_with_user_and_result(
+            id,
+            price,
+            quantity,
+            side,
+            time_in_force,
+            Hash32::zero(),
+            extra_fields,
+        )
+    }
+
+    /// Add a limit order to the book with an explicit `user_id` and return the
+    /// [`TradeResult`] produced by the match directly to the caller.
+    ///
+    /// The result-returning counterpart of [`Self::add_limit_order_with_user`]:
+    /// it builds the same `Standard` order and routes through
+    /// [`Self::add_order_with_result`]. The returned tuple carries the resting
+    /// order plus `Some(TradeResult)` when the order produced fills, or `None`
+    /// when it rested without matching. When a trade listener is installed it
+    /// still fires with the exact same `TradeResult` (same fills, same fees,
+    /// same `engine_seq`).
+    ///
+    /// Per-call attribution: the `TradeResult` is built from this call's own
+    /// private match outcome, never from shared capture state, so concurrent
+    /// submits on the same book each receive exactly their own fills.
+    ///
+    /// # Arguments
+    /// * `id` — Unique order identifier.
+    /// * `price` — Limit price.
+    /// * `quantity` — Order quantity.
+    /// * `side` — Buy or Sell.
+    /// * `time_in_force` — Time-in-force policy (GTD deadline in Unix milliseconds).
+    /// * `user_id` — Owner identity for STP checks.
+    /// * `extra_fields` — Optional application-specific payload.
+    ///
+    /// # Errors
+    /// Returns [`OrderBookError::MissingUserId`] when STP is enabled and
+    /// `user_id` is `Hash32::zero()`.
+    /// On error paths that follow real fills (an unfillable IOC remainder, or a
+    /// self-trade-prevention cancellation after earlier non-self fills) the
+    /// typed error is returned instead, so those fills reach the trade listener
+    /// only.
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_limit_order_with_user_and_result(
+        &self,
+        id: Id,
+        price: u128,
+        quantity: u64,
+        side: Side,
+        time_in_force: TimeInForce,
+        user_id: Hash32,
+        extra_fields: Option<T>,
+    ) -> Result<(Arc<OrderType<T>>, Option<TradeResult>), OrderBookError> {
+        // Top-of-fn kill-switch gate so we skip the clock read and
+        // extra_fields / OrderType construction below when halted.
+        self.check_kill_switch_or_reject(id)?;
+        let extra_fields: T = extra_fields.unwrap_or_default();
+        let order = OrderType::Standard {
+            id,
+            price: Price::new(price),
+            quantity: Quantity::new(quantity),
+            side,
+            user_id,
+            timestamp: self.clock().now_millis(),
+            time_in_force,
+            extra_fields,
+        };
+        trace!(
+            "Adding limit order (with result) {} {} {} {} {}",
+            id, price, quantity, side, time_in_force
+        );
+        self.add_order_with_result(order)
+    }
+
     /// Add an iceberg order to the book.
     ///
     /// This convenience method sets `user_id` to `Hash32::zero()`.  When STP
     /// is enabled, use [`Self::add_iceberg_order_with_user`] instead.
+    ///
+    /// `time_in_force` accepts a GTD deadline in Unix milliseconds — see
+    /// [`Self::add_iceberg_order_with_user`] for full argument docs.
     ///
     /// # Errors
     /// Returns [`OrderBookError::MissingUserId`] when STP is enabled.
@@ -125,7 +235,7 @@ where
     /// * `visible_quantity` — Displayed quantity.
     /// * `hidden_quantity` — Hidden (reserve) quantity.
     /// * `side` — Buy or Sell.
-    /// * `time_in_force` — Time-in-force policy.
+    /// * `time_in_force` — Time-in-force policy (GTD deadline in Unix milliseconds).
     /// * `user_id` — Owner identity for STP checks.
     /// * `extra_fields` — Optional application-specific payload.
     ///
@@ -171,6 +281,9 @@ where
     /// This convenience method sets `user_id` to `Hash32::zero()`.  When STP
     /// is enabled, use [`Self::add_post_only_order_with_user`] instead.
     ///
+    /// `time_in_force` accepts a GTD deadline in Unix milliseconds — see
+    /// [`Self::add_post_only_order_with_user`] for full argument docs.
+    ///
     /// # Errors
     /// Returns [`OrderBookError::MissingUserId`] when STP is enabled.
     pub fn add_post_only_order(
@@ -200,7 +313,7 @@ where
     /// * `price` — Limit price.
     /// * `quantity` — Order quantity.
     /// * `side` — Buy or Sell.
-    /// * `time_in_force` — Time-in-force policy.
+    /// * `time_in_force` — Time-in-force policy (GTD deadline in Unix milliseconds).
     /// * `user_id` — Owner identity for STP checks.
     /// * `extra_fields` — Optional application-specific payload.
     ///

--- a/src/orderbook/private.rs
+++ b/src/orderbook/private.rs
@@ -8,7 +8,14 @@ impl<T> OrderBook<T>
 where
     T: Clone + Send + Sync + Default + 'static,
 {
-    /// Check if an order has expired
+    /// Check if an order has expired.
+    ///
+    /// The comparison unit is **milliseconds since the Unix epoch**: the
+    /// current time comes from `self.clock().now_millis()`, and a `Gtd`
+    /// order's deadline (and the market-close timestamp used for `Day` orders,
+    /// see [`Self::set_market_close_timestamp`]) must be supplied in the same
+    /// unit. A deadline expressed in seconds would be treated as a moment in
+    /// 1970 and the order would read as instantly expired.
     pub fn has_expired(&self, order: &OrderType<T>) -> bool {
         let time_in_force = order.time_in_force();
         let current_time = self.clock().now_millis().as_u64();

--- a/src/orderbook/tests/book.rs
+++ b/src/orderbook/tests/book.rs
@@ -1377,4 +1377,166 @@ mod test_book_specific {
         book.release_kill_switch();
         assert!(!book.is_kill_switch_engaged());
     }
+
+    // ---- O(1) per-price aggregate accessors (#186) ----
+
+    /// Seed a book with a mix of standard and iceberg orders on several
+    /// price levels across both sides. Returns the book plus the levels
+    /// exercised on each side.
+    fn seed_mixed_book() -> (OrderBook<()>, [(u128, Side); 4]) {
+        let book = OrderBook::<()>::new("TEST");
+
+        // Bid side: two standard orders share level 100; an iceberg rests at 99.
+        let _ = book.add_limit_order(
+            create_order_id(),
+            100,
+            10,
+            Side::Buy,
+            TimeInForce::Gtc,
+            None,
+        );
+        let _ = book.add_limit_order(
+            create_order_id(),
+            100,
+            20,
+            Side::Buy,
+            TimeInForce::Gtc,
+            None,
+        );
+        let _ = book.add_iceberg_order(
+            create_order_id(),
+            99,
+            5,
+            15,
+            Side::Buy,
+            TimeInForce::Gtc,
+            None,
+        );
+
+        // Ask side: one standard at 110; an iceberg at 111.
+        let _ = book.add_limit_order(
+            create_order_id(),
+            110,
+            30,
+            Side::Sell,
+            TimeInForce::Gtc,
+            None,
+        );
+        let _ = book.add_iceberg_order(
+            create_order_id(),
+            111,
+            8,
+            12,
+            Side::Sell,
+            TimeInForce::Gtc,
+            None,
+        );
+
+        (
+            book,
+            [
+                (100, Side::Buy),
+                (99, Side::Buy),
+                (110, Side::Sell),
+                (111, Side::Sell),
+            ],
+        )
+    }
+
+    #[test]
+    fn test_visible_quantity_at_price_equals_sum_of_orders() {
+        let (book, levels) = seed_mixed_book();
+
+        for (price, side) in levels {
+            let expected: u64 = book
+                .get_orders_at_price(price, side)
+                .iter()
+                .map(|o| o.visible_quantity().as_u64())
+                .sum();
+            assert_eq!(
+                book.visible_quantity_at_price(price, side),
+                Some(expected),
+                "visible aggregate must equal the per-order sum at {price} on {side:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_hidden_quantity_at_price_equals_sum_of_orders() {
+        let (book, levels) = seed_mixed_book();
+
+        for (price, side) in levels {
+            let expected: u64 = book
+                .get_orders_at_price(price, side)
+                .iter()
+                .map(|o| o.hidden_quantity().as_u64())
+                .sum();
+            assert_eq!(
+                book.hidden_quantity_at_price(price, side),
+                Some(expected),
+                "hidden aggregate must equal the per-order sum at {price} on {side:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_total_quantity_at_price_equals_visible_plus_hidden() {
+        let (book, levels) = seed_mixed_book();
+
+        for (price, side) in levels {
+            let visible = book
+                .visible_quantity_at_price(price, side)
+                .expect("level exists");
+            let hidden = book
+                .hidden_quantity_at_price(price, side)
+                .expect("level exists");
+            assert_eq!(
+                book.total_quantity_at_price(price, side),
+                Some(visible + hidden),
+                "total must equal visible + hidden at {price} on {side:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_order_count_at_price_equals_queue_ahead() {
+        let (book, levels) = seed_mixed_book();
+
+        for (price, side) in levels {
+            assert_eq!(
+                book.order_count_at_price(price, side),
+                Some(book.queue_ahead_at_price(price, side)),
+                "order_count must equal queue_ahead at {price} on {side:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_aggregate_accessors_none_on_absent_level() {
+        let (book, _levels) = seed_mixed_book();
+
+        // A price with no level on either side yields `None` from every
+        // accessor — distinct from a live-but-empty `Some(0)`.
+        for side in [Side::Buy, Side::Sell] {
+            assert_eq!(book.visible_quantity_at_price(500, side), None);
+            assert_eq!(book.hidden_quantity_at_price(500, side), None);
+            assert_eq!(book.total_quantity_at_price(500, side), None);
+            assert_eq!(book.order_count_at_price(500, side), None);
+        }
+
+        // A live bid level is absent on the ask side (and vice versa).
+        assert_eq!(book.visible_quantity_at_price(100, Side::Sell), None);
+        assert!(book.visible_quantity_at_price(100, Side::Buy).is_some());
+    }
+
+    #[test]
+    fn test_iceberg_level_visible_hidden_split() {
+        let (book, _levels) = seed_mixed_book();
+
+        // The iceberg at bid 99 was seeded visible=5, hidden=15.
+        assert_eq!(book.visible_quantity_at_price(99, Side::Buy), Some(5));
+        assert_eq!(book.hidden_quantity_at_price(99, Side::Buy), Some(15));
+        assert_eq!(book.total_quantity_at_price(99, Side::Buy), Some(20));
+        assert_eq!(book.order_count_at_price(99, Side::Buy), Some(1));
+    }
 }

--- a/src/orderbook/tests/modifications.rs
+++ b/src/orderbook/tests/modifications.rs
@@ -1029,4 +1029,116 @@ mod test_add_order_with_result {
             Some(Quantity::new(5))
         );
     }
+
+    /// Per-call fill attribution under concurrency (#185): several threads
+    /// submit crossing takers on the SAME book at the same instant, and each
+    /// returned `TradeResult` must carry only that call's own fills — the
+    /// engine builds it from this call's private `MatchResult`, never from a
+    /// shared accumulator.
+    ///
+    /// Each iteration seeds resting liquidity exactly equal to the combined
+    /// taker demand, releases all takers in lockstep via a `Barrier`, and
+    /// asserts, per thread: the result's `order_id` equals the submitted id,
+    /// the per-trade quantities sum to the order's executed quantity, and that
+    /// executed quantity is this taker's full size. Across the batch the
+    /// executed quantities sum to the consumed resting size and the book is
+    /// emptied.
+    #[test]
+    fn test_add_order_with_result_concurrent_per_call_attribution() {
+        use std::sync::Barrier;
+        use std::thread;
+
+        const NUM_TAKERS: usize = 4;
+        const PER_TAKER: u64 = 5;
+        const RESTING_TOTAL: u64 = NUM_TAKERS as u64 * PER_TAKER;
+        const ITERATIONS: usize = 250;
+
+        for iteration in 0..ITERATIONS {
+            let book: OrderBook<()> = OrderBook::new("TEST");
+
+            // Seed resting liquidity exactly equal to the combined demand.
+            let seed = standard_order(100, RESTING_TOTAL, Side::Sell, user(1));
+            assert!(
+                book.add_order(seed).is_ok(),
+                "iteration {iteration}: failed to seed resting liquidity"
+            );
+
+            let barrier = Barrier::new(NUM_TAKERS);
+            let mut combined_executed: u64 = 0;
+
+            thread::scope(|scope| {
+                let handles: Vec<_> = (0..NUM_TAKERS)
+                    .map(|i| {
+                        let book = &book;
+                        let barrier = &barrier;
+                        scope.spawn(move || {
+                            // Distinct, non-zero taker identities.
+                            let taker = user(10 + i as u8);
+                            let order = standard_order(100, PER_TAKER, Side::Buy, taker);
+                            let submitted_id = order.id();
+                            // Release all takers together to maximize overlap.
+                            barrier.wait();
+                            let result = book.add_order_with_result(order);
+                            (submitted_id, result)
+                        })
+                    })
+                    .collect();
+
+                for handle in handles {
+                    let (submitted_id, result) = handle.join().expect("taker thread panicked");
+                    let Ok((added, Some(trade_result))) = result else {
+                        panic!("iteration {iteration}: expected a filled taker, got {result:?}");
+                    };
+
+                    // Per-call attribution: both the returned order and the
+                    // TradeResult identify THIS call's own order, never a peer's.
+                    assert_eq!(
+                        added.id(),
+                        submitted_id,
+                        "iteration {iteration}: returned order id must be the submitted id"
+                    );
+                    assert_eq!(
+                        trade_result.match_result.order_id(),
+                        submitted_id,
+                        "iteration {iteration}: TradeResult must attribute to the submitting call"
+                    );
+
+                    // The result's per-trade fills sum to this order's executed
+                    // quantity, and this taker fully filled its own size.
+                    let per_trade_sum: u64 = trade_result
+                        .match_result
+                        .trades()
+                        .as_vec()
+                        .iter()
+                        .map(|t| t.quantity().as_u64())
+                        .sum();
+                    let executed = trade_result
+                        .match_result
+                        .executed_quantity()
+                        .expect("executed quantity")
+                        .as_u64();
+                    assert_eq!(
+                        per_trade_sum, executed,
+                        "iteration {iteration}: per-trade fills must sum to executed quantity"
+                    );
+                    assert_eq!(
+                        executed, PER_TAKER,
+                        "iteration {iteration}: each taker must fully fill its own size"
+                    );
+
+                    combined_executed += executed;
+                }
+            });
+
+            // Combined fills equal the consumed resting size; the book empties.
+            assert_eq!(
+                combined_executed, RESTING_TOTAL,
+                "iteration {iteration}: combined fills must equal consumed resting size"
+            );
+            assert!(
+                book.best_ask().is_none(),
+                "iteration {iteration}: all resting liquidity must have been consumed"
+            );
+        }
+    }
 }

--- a/tests/unit/private_coverage_tests.rs
+++ b/tests/unit/private_coverage_tests.rs
@@ -553,6 +553,50 @@ mod tests {
         assert!(book.has_expired(&gtd_order));
     }
 
+    /// Pins the GTD deadline unit to milliseconds since the Unix epoch.
+    ///
+    /// `has_expired` compares against `clock().now_millis()`, so a deadline
+    /// expressed in seconds (roughly `now_millis / 1000`) lands ~1970 and reads
+    /// as instantly expired — the observable proof that the unit is
+    /// milliseconds, not seconds.
+    #[test]
+    fn gtd_expiry_unit_is_milliseconds() {
+        let book = OrderBook::<TestExtraFields>::new("TEST");
+        let now_millis = current_time_millis();
+
+        let gtd = |deadline: u64| OrderType::Standard {
+            id: create_order_id(),
+            price: Price::new(100),
+            quantity: Quantity::new(10),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(now_millis),
+            time_in_force: TimeInForce::Gtd(deadline),
+            extra_fields: TestExtraFields::default(),
+        };
+
+        // A deadline 60 s into the future (in milliseconds) is NOT expired.
+        assert!(
+            !book.has_expired(&gtd(now_millis + 60_000)),
+            "a millisecond deadline in the future must not be expired"
+        );
+
+        // A deadline 1 s in the past (in milliseconds) IS expired.
+        assert!(
+            book.has_expired(&gtd(now_millis - 1_000)),
+            "a millisecond deadline in the past must be expired"
+        );
+
+        // The SAME logical future instant expressed in SECONDS collapses to
+        // ~1970 when interpreted as milliseconds, so it reads as expired.
+        // This is the pin: it can only pass if the unit is milliseconds.
+        assert!(
+            book.has_expired(&gtd((now_millis + 60_000) / 1000)),
+            "a seconds-form deadline must (wrongly) read as instantly expired, \
+             proving the comparison unit is milliseconds"
+        );
+    }
+
     #[test]
     fn test_will_cross_market_no_opposite_side() {
         // Test will_cross_market when there's no opposite side


### PR DESCRIPTION
## Summary

Release 0.9.2 (additive, semver z-bump). Implements #186 and the orderbook-rs half of #187; ships the docs+wrappers portion of #185 (engine side already per-call since #184 — behavioral migration belongs to the wrapper crate, re-scope comment on the issue).

### Per-price aggregate accessors (#186)
- `visible_quantity_at_price`, `hidden_quantity_at_price`, `total_quantity_at_price`, `order_count_at_price` on `OrderBook<T>`.
- Constant-work: O(log N) SkipMap point lookup + O(1) relaxed atomic counter read (two loads for `total`, which sums visible + hidden). No per-order materialization — drops the per-order K term vs `queue_ahead_at_price`.
- `None` = no resting level at that price. `Some(0)` for total/count is a brief concurrency transient during eager level removal. `total_quantity_at_price` saturates to `u64::MAX` on overflow.

### Per-call fill attribution (#185, docs + wrappers)
- New `add_limit_order_with_result` / `add_limit_order_with_user_and_result` returning `(Arc<OrderType<T>>, Option<TradeResult>)` built on `add_order_with_result` (stack-local `MatchResult`, per-call by construction).
- `add_order_with_result` docs now state the per-call attribution guarantee explicitly + concurrent 4-thread attribution test (250 iterations, Barrier-synced).
- Documented error-after-fills caveat: on STP taker-cancel / unfillable IOC the caller gets the typed `Err` and executed fills reach only the trade listener.

### GTD unit = Unix milliseconds (#187)
- `has_expired` compares against `clock().now_millis()` — docs across all builders now state GTD deadlines are Unix **milliseconds**; ms-unit pinning tests added here and in pricelevel 0.8.4 (upstream half already released).
- `pricelevel` floor bumped to 0.8.4.

## Gates
- `make pre-push` clean; clippy `-D warnings` zero; `cargo test --all-features`: 767 lib + 455 integration + 44 doctests + auxiliary suites, 0 failures.
- determinism-auditor: CLEAN (replay-safe). microstructure-critic: ready for release (all 7 review nits applied).

Closes #186. Closes #187.