### PR TITLE
release: 0.10.0 — host-driven GTD/DAY expiry sweep (journaled), non_exhaustive sequencer enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,70 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] — 2026-07-10
+
+### Breaking
+
+- **`SequencerCommand` and `SequencerResult` are now `#[non_exhaustive]`.**
+  Downstream code that matches them exhaustively must add a wildcard arm
+  (`_ => …`) and recompile. This is a one-time source break: future
+  command/result variants become source-compatible additions instead of
+  repeating it. Surfaced by adding `EvictExpiredOrders` below — on the
+  previously-exhaustive enum that addition would itself have broken
+  downstream matches silently inside the 0.9.x range (which is why this
+  release is 0.10.0 and not 0.9.3). Wire format is unaffected: bincode
+  variant indices and JSON encodings are unchanged, and existing journals
+  replay as-is.
+
+### Added
+
+- **Host-driven GTD / DAY expiry sweep (#189)** — new
+  `OrderBook::evict_expired_orders(now_ms)` removes every resting order whose
+  time-in-force has expired as of the caller-supplied timestamp. `now_ms` is a
+  `TimestampMs` (Unix milliseconds, the unit `clock().now_millis()` compares
+  against) passed in by the caller — the sweep never reads the book's own clock,
+  so a scheduler drives cadence and the sequencer can journal the exact cutoff.
+  The matching hot path is untouched: there is no lazy per-match expiry check, so
+  expiry is an explicit maintenance pass rather than an implicit per-submit cost.
+  Expiry uses the same boundary predicate as admission (`now >= deadline` for
+  `Gtd`, `now >= market_close` for `Day`), so an order admitted at an instant is
+  never simultaneously evictable at that instant. Returns the evicted orders as
+  `Vec<Arc<OrderType<T>>>`; a second sweep at the same `now_ms` is idempotent and
+  returns empty.
+- **Manager parity for the sweep (#189).** `BookManagerStd` and
+  `BookManagerTokio` gain `evict_expired_orders(symbol, now_ms)` (per-symbol
+  pass-through, `None` for an unknown symbol) and
+  `evict_expired_across_books(now_ms)` (all books, mirroring the
+  `cancel_*_across_books` idiom).
+- **`SequencerCommand::EvictExpiredOrders { now_ms }` (#189).** New command
+  variant (appended, so existing journals' bincode variant indices are
+  unchanged). Replay applies the journaled cutoff — never the replay clock — so
+  the sweep reproduces byte-identically and `snapshots_match` holds between a
+  live book and its replay. Old journals replay unchanged; new journals carrying
+  the variant fail on older binaries, consistent with the `MarketOrderByAmount`
+  precedent. No `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump required — the version
+  gates the snapshot package, not the journal command enum.
+- **`TimestampMs` re-exported** at the crate root and via `prelude`, so the new
+  `now_ms` parameter can be constructed without importing from `pricelevel`
+  directly.
+
+### Documentation
+
+- **Deterministic eviction order documented (#189).** The rustdoc on
+  `evict_expired_orders` states the fixed, replay-stable order in which orders
+  are evicted and side-effect events emitted: bids first then asks; within a
+  side, ascending price (the `SkipMap`'s natural key order, no sort); within a
+  level, ascending insertion sequence (the exact order the matching engine
+  consumes resting orders, not the non-deterministic `iter_orders` view). Each
+  order is removed through the same single-order cancel path as `cancel_order`,
+  tagged `CancelReason::TimeInForceExpired`, so the price-level cache, depth
+  statistics, `order_locations` / `user_orders` indices, risk state,
+  special-order tracker, and order-state tracker all stay consistent.
+- Runnable example `examples/src/bin/gtd_expiry_sweep.rs`
+  (`cargo run -p examples --bin gtd_expiry_sweep`) seeds GTD orders on a
+  `StubClock` book, sweeps at explicit timestamps, and logs the evicted orders
+  via `tracing`.
+
 ## [0.9.2] — 2026-07-10
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orderbook-rs"
-version = "0.9.2"
+version = "0.10.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."

--- a/README.md
+++ b/README.md
@@ -46,6 +46,63 @@ This order book engine is built with the following design principles:
 - **Research**: Platform for studying market microstructure and order flow
 - **Educational**: Reference implementation for understanding modern exchange architecture
 
+### What's New in Version 0.10.0
+
+#### v0.10.0 — host-driven GTD / DAY expiry sweep (#189)
+
+- **New `OrderBook::evict_expired_orders(now_ms)`** — a host-driven sweep
+  that removes every resting order whose time-in-force has expired as of the
+  caller-supplied timestamp. `now_ms` is [`TimestampMs`] (Unix milliseconds,
+  the same unit `clock().now_millis()` compares against) and is passed in by
+  the caller — the sweep never reads the book's own clock — so a scheduler
+  drives cadence and the sequencer can journal the exact cutoff. The matching
+  hot path is untouched: there is no lazy per-match expiry check, so expiry is
+  an explicit maintenance pass, not an implicit cost on every submit. The
+  honest consequence: an expired-but-unswept `Gtd` / `Day` order remains
+  resting and matchable — it can still trade until the host calls the sweep;
+  the no-post-expiry-trade guarantee holds only after the sweep runs. Expiry
+  uses the single boundary predicate that admission uses (`now >= deadline`
+  for `Gtd`, `now >= market_close` for `Day`), so an order admitted at a given
+  instant is never simultaneously evictable at that instant. Returns the
+  evicted orders as `Vec<Arc<OrderType<T>>>`; a second sweep at the same
+  `now_ms` is idempotent and returns empty.
+- **Deterministic eviction order.** Evicted orders — and the
+  `Cancelled { reason: TimeInForceExpired }` state transitions and
+  `PriceLevelChangedEvent`s emitted as a side effect — follow one fixed,
+  replay-stable order: bids first then asks; within a side, price levels in
+  ascending price (the `SkipMap`'s natural key order, no sort); within a
+  level, ascending insertion sequence (the exact order the matching engine
+  consumes resting orders — not the non-deterministic `iter_orders` view).
+  Each order is removed through the same single-order cancel path as
+  `cancel_order`, so the price-level cache, depth statistics,
+  `order_locations` / `user_orders` indices, risk state, special-order
+  tracker, and order-state tracker all stay consistent.
+- **Manager parity.** `BookManagerStd` and `BookManagerTokio` gain
+  `evict_expired_orders(symbol, now_ms)` (per-symbol pass-through, `None` for
+  an unknown symbol) and `evict_expired_across_books(now_ms)` (all books,
+  mirroring the `cancel_*_across_books` idiom).
+- **Journaled as a sequencer command.** New
+  `SequencerCommand::EvictExpiredOrders { now_ms }` variant (appended, so
+  existing journals' bincode variant indices are unchanged). Replay applies
+  the journaled cutoff — never the replay clock — so the sweep reproduces
+  byte-identically; `snapshots_match` holds between a live book and its
+  replay. Old journals replay unchanged; new journals carrying the variant
+  fail on older binaries, consistent with the `MarketOrderByAmount`
+  precedent. No `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump required (the version
+  gates the snapshot package, not the journal command enum).
+- **Breaking (the reason this is 0.10.0):** `SequencerCommand` and
+  `SequencerResult` are now `#[non_exhaustive]`. Downstream code that
+  matches them exhaustively must add a wildcard arm (`_ => …`) once and
+  recompile; in exchange, future command/result additions are
+  source-compatible instead of repeating this break. Adding the
+  `EvictExpiredOrders` variant itself is what surfaced the hazard: on the
+  previously-exhaustive enum it would have silently broken downstream
+  matches inside the 0.9.x range.
+- **`TimestampMs` re-exported** at the crate root and via [`prelude`], so the
+  new `now_ms` parameter can be constructed without reaching into
+  `pricelevel` directly.
+- Runnable example: `cargo run -p examples --bin gtd_expiry_sweep`.
+
 ### What's New in Version 0.9.2
 
 #### v0.9.2 — constant-work per-price aggregates + attribution & unit docs (#185, #186, #187)

--- a/examples/src/bin/gtd_expiry_sweep.rs
+++ b/examples/src/bin/gtd_expiry_sweep.rs
@@ -1,0 +1,114 @@
+// examples/src/bin/gtd_expiry_sweep.rs
+//
+// Demonstrates the host-driven GTD / DAY expiry sweep
+// (`OrderBook::evict_expired_orders`).
+//
+// The sweep never reads the book's own clock: the caller passes an explicit
+// `TimestampMs` (Unix milliseconds), so a scheduler drives the cadence and the
+// sequencer can journal the exact cutoff. Eviction order is deterministic —
+// bids before asks, ascending price within a side, ascending insertion
+// sequence within a level — which is what keeps replay byte-identical.
+//
+// Run with:
+//
+//     cargo run -p examples --bin gtd_expiry_sweep
+
+use std::sync::Arc;
+
+use orderbook_rs::{Clock, OrderBook, StubClock, TimestampMs};
+use pricelevel::{Id, Side, TimeInForce, setup_logger};
+use tracing::info;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = setup_logger();
+    info!("GTD / DAY expiry sweep demo");
+
+    // A StubClock starting at logical t=0 so the small GTD deadlines below are
+    // admitted. Under the default wall-clock (`MonotonicClock`), a deadline of
+    // 1_000 ms since the Unix epoch would be treated as already expired at
+    // admission and rejected.
+    let book: OrderBook<()> = OrderBook::with_clock(
+        "BTC/USDT",
+        Arc::new(StubClock::starting_at(0)) as Arc<dyn Clock>,
+    );
+
+    // A DAY order expires at the configured market close.
+    book.set_market_close_timestamp(3_000);
+
+    seed(&book)?;
+    info!(
+        "Seeded book: best_bid={:?} best_ask={:?}",
+        book.best_bid(),
+        book.best_ask()
+    );
+
+    // t = 999: nothing has expired yet (expiry boundary is `now >= deadline`).
+    sweep(&book, 999);
+
+    // t = 1_500: the two GTD orders with deadline 1_000 expire; the DAY order
+    // (market close 3_000) and the GTD at 5_000 and the GTC survive.
+    sweep(&book, 1_500);
+
+    // t = 3_000: the DAY order expires at market close.
+    sweep(&book, 3_000);
+
+    // t = 5_000: the last GTD expires; only the GTC remains.
+    sweep(&book, 5_000);
+
+    info!(
+        "Final book: best_bid={:?} best_ask={:?} (the GTC order remains)",
+        book.best_bid(),
+        book.best_ask()
+    );
+    Ok(())
+}
+
+fn seed(book: &OrderBook<()>) -> Result<(), Box<dyn std::error::Error>> {
+    // Two GTD bids expiring at t=1_000, at different prices so the sweep must
+    // visit them in ascending-price order.
+    book.add_limit_order(
+        Id::new_uuid(),
+        95,
+        5,
+        Side::Buy,
+        TimeInForce::Gtd(1_000),
+        None,
+    )?;
+    book.add_limit_order(
+        Id::new_uuid(),
+        96,
+        5,
+        Side::Buy,
+        TimeInForce::Gtd(1_000),
+        None,
+    )?;
+    // A GTC bid that never expires.
+    book.add_limit_order(Id::new_uuid(), 97, 5, Side::Buy, TimeInForce::Gtc, None)?;
+    // A DAY ask expiring at the market close (3_000).
+    book.add_limit_order(Id::new_uuid(), 101, 5, Side::Sell, TimeInForce::Day, None)?;
+    // A GTD ask expiring at t=5_000.
+    book.add_limit_order(
+        Id::new_uuid(),
+        102,
+        5,
+        Side::Sell,
+        TimeInForce::Gtd(5_000),
+        None,
+    )?;
+    Ok(())
+}
+
+fn sweep(book: &OrderBook<()>, now_ms: u64) {
+    let evicted = book.evict_expired_orders(TimestampMs::new(now_ms));
+    info!("--- sweep at t={now_ms} ms: {} evicted ---", evicted.len());
+    // Evicted orders are returned in the deterministic contract order.
+    for order in &evicted {
+        info!(
+            "    evicted id={} side={:?} price={} tif={:?}",
+            order.id(),
+            order.side(),
+            order.price().as_u128(),
+            order.time_in_force(),
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,63 @@
 //! - **Research**: Platform for studying market microstructure and order flow
 //! - **Educational**: Reference implementation for understanding modern exchange architecture
 //!
+//! ## What's New in Version 0.10.0
+//!
+//! ### v0.10.0 — host-driven GTD / DAY expiry sweep (#189)
+//!
+//! - **New `OrderBook::evict_expired_orders(now_ms)`** — a host-driven sweep
+//!   that removes every resting order whose time-in-force has expired as of the
+//!   caller-supplied timestamp. `now_ms` is [`TimestampMs`] (Unix milliseconds,
+//!   the same unit `clock().now_millis()` compares against) and is passed in by
+//!   the caller — the sweep never reads the book's own clock — so a scheduler
+//!   drives cadence and the sequencer can journal the exact cutoff. The matching
+//!   hot path is untouched: there is no lazy per-match expiry check, so expiry is
+//!   an explicit maintenance pass, not an implicit cost on every submit. The
+//!   honest consequence: an expired-but-unswept `Gtd` / `Day` order remains
+//!   resting and matchable — it can still trade until the host calls the sweep;
+//!   the no-post-expiry-trade guarantee holds only after the sweep runs. Expiry
+//!   uses the single boundary predicate that admission uses (`now >= deadline`
+//!   for `Gtd`, `now >= market_close` for `Day`), so an order admitted at a given
+//!   instant is never simultaneously evictable at that instant. Returns the
+//!   evicted orders as `Vec<Arc<OrderType<T>>>`; a second sweep at the same
+//!   `now_ms` is idempotent and returns empty.
+//! - **Deterministic eviction order.** Evicted orders — and the
+//!   `Cancelled { reason: TimeInForceExpired }` state transitions and
+//!   `PriceLevelChangedEvent`s emitted as a side effect — follow one fixed,
+//!   replay-stable order: bids first then asks; within a side, price levels in
+//!   ascending price (the `SkipMap`'s natural key order, no sort); within a
+//!   level, ascending insertion sequence (the exact order the matching engine
+//!   consumes resting orders — not the non-deterministic `iter_orders` view).
+//!   Each order is removed through the same single-order cancel path as
+//!   `cancel_order`, so the price-level cache, depth statistics,
+//!   `order_locations` / `user_orders` indices, risk state, special-order
+//!   tracker, and order-state tracker all stay consistent.
+//! - **Manager parity.** `BookManagerStd` and `BookManagerTokio` gain
+//!   `evict_expired_orders(symbol, now_ms)` (per-symbol pass-through, `None` for
+//!   an unknown symbol) and `evict_expired_across_books(now_ms)` (all books,
+//!   mirroring the `cancel_*_across_books` idiom).
+//! - **Journaled as a sequencer command.** New
+//!   `SequencerCommand::EvictExpiredOrders { now_ms }` variant (appended, so
+//!   existing journals' bincode variant indices are unchanged). Replay applies
+//!   the journaled cutoff — never the replay clock — so the sweep reproduces
+//!   byte-identically; `snapshots_match` holds between a live book and its
+//!   replay. Old journals replay unchanged; new journals carrying the variant
+//!   fail on older binaries, consistent with the `MarketOrderByAmount`
+//!   precedent. No `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump required (the version
+//!   gates the snapshot package, not the journal command enum).
+//! - **Breaking (the reason this is 0.10.0):** `SequencerCommand` and
+//!   `SequencerResult` are now `#[non_exhaustive]`. Downstream code that
+//!   matches them exhaustively must add a wildcard arm (`_ => …`) once and
+//!   recompile; in exchange, future command/result additions are
+//!   source-compatible instead of repeating this break. Adding the
+//!   `EvictExpiredOrders` variant itself is what surfaced the hazard: on the
+//!   previously-exhaustive enum it would have silently broken downstream
+//!   matches inside the 0.9.x range.
+//! - **`TimestampMs` re-exported** at the crate root and via [`prelude`], so the
+//!   new `now_ms` parameter can be constructed without reaching into
+//!   `pricelevel` directly.
+//! - Runnable example: `cargo run -p examples --bin gtd_expiry_sweep`.
+//!
 //! ## What's New in Version 0.9.2
 //!
 //! ### v0.9.2 — constant-work per-price aggregates + attribution & unit docs (#185, #186, #187)
@@ -704,7 +761,7 @@ pub type LegacyOrderBook = OrderBook<()>;
 pub type DefaultOrderBook = OrderBook<()>;
 
 // Re-export pricelevel types with aliases
-pub use pricelevel::{Id, OrderType, Side, TimeInForce};
+pub use pricelevel::{Id, OrderType, Side, TimeInForce, TimestampMs};
 
 /// Legacy type alias for backward compatibility with code using `OrderId`.
 pub type OrderId = Id;

--- a/src/orderbook/manager.rs
+++ b/src/orderbook/manager.rs
@@ -13,7 +13,7 @@ use crate::orderbook::OrderBook;
 use crate::orderbook::error::ManagerError;
 use crate::orderbook::mass_cancel::MassCancelResult;
 use crate::orderbook::trade::{TradeEvent, TradeListener, TradeResult};
-use pricelevel::{Hash32, Side};
+use pricelevel::{Hash32, OrderType, Side, TimestampMs};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{error, info};
@@ -217,6 +217,40 @@ where
         self.books
             .iter()
             .map(|(symbol, book)| (symbol.clone(), book.cancel_orders_by_side(side)))
+            .collect()
+    }
+
+    /// Evict expired resting orders from a single managed book.
+    ///
+    /// Pass-through to [`OrderBook::evict_expired_orders`]. `now_ms` is
+    /// caller-supplied Unix milliseconds (see that method for the boundary and
+    /// determinism contract). Returns `None` when `symbol` is not managed, or
+    /// `Some(evicted)` with the evicted orders in the book's documented
+    /// deterministic order (empty when nothing expired).
+    #[must_use]
+    pub fn evict_expired_orders(
+        &self,
+        symbol: &str,
+        now_ms: TimestampMs,
+    ) -> Option<Vec<Arc<OrderType<T>>>> {
+        self.books
+            .get(symbol)
+            .map(|book| book.evict_expired_orders(now_ms))
+    }
+
+    /// Evict expired resting orders across all managed books at `now_ms`.
+    ///
+    /// Returns a map from symbol to that book's evicted orders (in the book's
+    /// documented deterministic order). Books with nothing expired map to an
+    /// empty vector. `now_ms` is caller-supplied Unix milliseconds.
+    #[must_use]
+    pub fn evict_expired_across_books(
+        &self,
+        now_ms: TimestampMs,
+    ) -> HashMap<String, Vec<Arc<OrderType<T>>>> {
+        self.books
+            .iter()
+            .map(|(symbol, book)| (symbol.clone(), book.evict_expired_orders(now_ms)))
             .collect()
     }
 }
@@ -434,6 +468,40 @@ where
         self.books
             .iter()
             .map(|(symbol, book)| (symbol.clone(), book.cancel_orders_by_side(side)))
+            .collect()
+    }
+
+    /// Evict expired resting orders from a single managed book.
+    ///
+    /// Pass-through to [`OrderBook::evict_expired_orders`]. `now_ms` is
+    /// caller-supplied Unix milliseconds (see that method for the boundary and
+    /// determinism contract). Returns `None` when `symbol` is not managed, or
+    /// `Some(evicted)` with the evicted orders in the book's documented
+    /// deterministic order (empty when nothing expired).
+    #[must_use]
+    pub fn evict_expired_orders(
+        &self,
+        symbol: &str,
+        now_ms: TimestampMs,
+    ) -> Option<Vec<Arc<OrderType<T>>>> {
+        self.books
+            .get(symbol)
+            .map(|book| book.evict_expired_orders(now_ms))
+    }
+
+    /// Evict expired resting orders across all managed books at `now_ms`.
+    ///
+    /// Returns a map from symbol to that book's evicted orders (in the book's
+    /// documented deterministic order). Books with nothing expired map to an
+    /// empty vector. `now_ms` is caller-supplied Unix milliseconds.
+    #[must_use]
+    pub fn evict_expired_across_books(
+        &self,
+        now_ms: TimestampMs,
+    ) -> HashMap<String, Vec<Arc<OrderType<T>>>> {
+        self.books
+            .iter()
+            .map(|(symbol, book)| (symbol.clone(), book.evict_expired_orders(now_ms)))
             .collect()
     }
 }

--- a/src/orderbook/mass_cancel.rs
+++ b/src/orderbook/mass_cancel.rs
@@ -12,8 +12,9 @@
 use super::book::OrderBook;
 use super::book_change_event::PriceLevelChangedEvent;
 use super::order_state::{CancelReason, OrderStatus};
-use pricelevel::{Hash32, Id, Side};
+use pricelevel::{Hash32, Id, OrderType, Side, TimestampMs};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use tracing::trace;
 
 /// Result of a mass cancel operation.
@@ -371,6 +372,148 @@ where
         }
 
         self.cancel_order_batch_with_reason(&order_ids, CancelReason::MassCancelByPriceRange)
+    }
+
+    /// Evict every resting order whose time-in-force has expired at `now_ms`.
+    ///
+    /// Resting `Gtd` and `Day` orders are only checked for expiry at
+    /// *admission* (via `validate_order_shape`); once resting they are never
+    /// re-examined by the matching hot path. This is the explicit sweep that
+    /// removes them after their deadline. It is **not** invoked automatically —
+    /// call it from a scheduler, a per-tick pass, or the sequencer so the
+    /// timestamp is journalled and replay stays deterministic.
+    ///
+    /// # Timestamp
+    ///
+    /// `now_ms` is **caller-supplied Unix milliseconds** — the same unit as a
+    /// `Gtd` deadline and the market-close timestamp. It is taken as an
+    /// argument (this method never reads the book's own clock) precisely so the
+    /// sequencer can journal the exact instant and reproduce the eviction
+    /// byte-for-byte on replay. Boundary behaviour matches admission's
+    /// `has_expired`: an order is expired when `now_ms >= deadline` (`Gtd`) or
+    /// `now_ms >= market_close` (`Day`); a `Gtd` whose deadline equals `now_ms`
+    /// is evicted. `Gtc`, `Ioc`, and `Fok` resting orders are never touched.
+    ///
+    /// # Determinism contract
+    ///
+    /// The returned vector — and the [`PriceLevelChangedEvent`] and
+    /// `Cancelled { reason: TimeInForceExpired }` state transitions emitted as a
+    /// side effect — follow one fixed, replay-stable order:
+    ///
+    /// 1. **Bids first, then asks.**
+    /// 2. Within a side, price levels in **ascending price** order (the
+    ///    `SkipMap`'s natural key order — no sorting required).
+    /// 3. Within a price level, orders in **ascending insertion sequence** —
+    ///    the exact order the matching engine consumes resting orders
+    ///    (`PriceLevel::snapshot_by_seq_into`), i.e. oldest first. Note
+    ///    this is stable regardless of client-supplied timestamps, unlike the
+    ///    non-deterministic `iter_orders` view.
+    ///
+    /// Every evicted order is removed through the same single-order cancel path
+    /// as [`Self::cancel_order`], so the price-level cache, depth statistics,
+    /// `order_locations` / `user_orders` indices, risk state, special-order
+    /// tracker, and the order-state tracker all stay consistent. Each removal is
+    /// tagged with [`CancelReason::TimeInForceExpired`].
+    ///
+    /// # Idempotence
+    ///
+    /// A second sweep at the same `now_ms` returns an empty vector: the expired
+    /// orders are already gone.
+    ///
+    /// # Returns
+    ///
+    /// The evicted orders as `Arc<OrderType<T>>`, in the deterministic order
+    /// above. Empty when nothing was expired.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orderbook_rs::{Clock, OrderBook, StubClock};
+    /// use pricelevel::{Id, Side, TimeInForce, TimestampMs};
+    /// use std::sync::Arc;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// // A logical clock starting at 0 so the small GTD deadline is admitted
+    /// // (wall-clock admission would treat it as already expired).
+    /// let book: OrderBook<()> =
+    ///     OrderBook::with_clock("TEST", Arc::new(StubClock::starting_at(0)) as Arc<dyn Clock>);
+    /// let gtd = Id::new_uuid();
+    /// // A resting GTD order that expires at t = 1_000 ms.
+    /// book.add_limit_order(gtd, 100, 10, Side::Buy, TimeInForce::Gtd(1_000), None)?;
+    ///
+    /// // Nothing expired yet at t = 999.
+    /// assert!(book.evict_expired_orders(TimestampMs::new(999)).is_empty());
+    ///
+    /// // At the deadline the order is evicted and no longer rests.
+    /// let evicted = book.evict_expired_orders(TimestampMs::new(1_000));
+    /// assert_eq!(evicted.len(), 1);
+    /// assert_eq!(book.best_bid(), None);
+    ///
+    /// // Idempotent: a second sweep at the same instant evicts nothing.
+    /// assert!(book.evict_expired_orders(TimestampMs::new(1_000)).is_empty());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn evict_expired_orders(&self, now_ms: TimestampMs) -> Vec<Arc<OrderType<T>>> {
+        let now = now_ms.as_u64();
+        trace!(
+            "Order book {}: Evicting expired orders as of {} ms",
+            self.symbol, now
+        );
+
+        // Phase 1: collect the IDs of every expired resting order in the fixed
+        // determinism-contract order (bids ascending, then asks ascending;
+        // within each level, ascending insertion sequence). `SkipMap::iter`
+        // yields ascending price keys, and `snapshot_by_seq_into` yields the
+        // exact order the matching engine consumes resting orders — the
+        // non-deterministic `iter_orders` view must NOT be used here or replay
+        // would diverge. One scratch buffer is reused across levels to avoid a
+        // per-level allocation. Expiry uses `tif_expired_at` — the same
+        // definition admission uses — so the boundary case (deadline == now)
+        // can never diverge.
+        let mut expired_ids: Vec<Id> = Vec::new();
+        let mut level_orders: Vec<Arc<OrderType<()>>> = Vec::new();
+        for entry in self.bids.iter() {
+            entry.value().snapshot_by_seq_into(&mut level_orders);
+            for order in &level_orders {
+                if self.tif_expired_at(order.time_in_force(), now) {
+                    expired_ids.push(order.id());
+                }
+            }
+        }
+        for entry in self.asks.iter() {
+            entry.value().snapshot_by_seq_into(&mut level_orders);
+            for order in &level_orders {
+                if self.tif_expired_at(order.time_in_force(), now) {
+                    expired_ids.push(order.id());
+                }
+            }
+        }
+
+        if expired_ids.is_empty() {
+            return Vec::new();
+        }
+
+        // Phase 2: cancel each expired order through the shared single-order
+        // path, preserving the collection order. This is what keeps the caches,
+        // trackers, and emitted events consistent and in the documented order.
+        let mut evicted = Vec::with_capacity(expired_ids.len());
+        for order_id in expired_ids {
+            if let Ok(Some(order)) =
+                self.cancel_order_with_reason(order_id, CancelReason::TimeInForceExpired)
+            {
+                evicted.push(order);
+            }
+        }
+
+        trace!(
+            symbol = %self.symbol,
+            now_ms = now,
+            evicted = evicted.len(),
+            "expired orders evicted"
+        );
+
+        evicted
     }
 
     /// Internal helper: cancel a batch of orders by their IDs with a reason.
@@ -769,5 +912,207 @@ mod tests {
         let book: OrderBook<()> = OrderBook::new("TEST");
         let result = book.cancel_all_orders();
         assert!(result.is_empty());
+    }
+
+    // ---- evict_expired_orders --------------------------------------------
+
+    use crate::orderbook::clock::StubClock;
+
+    /// A book whose clock starts at logical `0`, so small `Gtd` deadlines are
+    /// admitted (not seen as already-expired by wall-clock admission) and the
+    /// caller-supplied eviction timestamp is what drives expiry.
+    fn expiring_book() -> OrderBook<()> {
+        OrderBook::with_clock("TEST", Arc::new(StubClock::starting_at(0)))
+    }
+
+    #[test]
+    fn test_evict_expired_empty_book_returns_empty() {
+        let book = expiring_book();
+        assert!(
+            book.evict_expired_orders(TimestampMs::new(10_000))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_evict_expired_gtd_removed_and_unmatchable() {
+        let book = expiring_book();
+        let gtd = Id::new_uuid();
+        book.add_limit_order(gtd, 100, 10, Side::Buy, TimeInForce::Gtd(1_000), None)
+            .expect("add gtd");
+
+        // Before the deadline: untouched.
+        assert!(book.evict_expired_orders(TimestampMs::new(999)).is_empty());
+        assert_eq!(book.best_bid(), Some(100));
+
+        // At the deadline (>=): evicted.
+        let evicted = book.evict_expired_orders(TimestampMs::new(1_000));
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0].id(), gtd);
+        assert_eq!(book.best_bid(), None);
+        assert!(!book.order_locations.contains_key(&gtd));
+
+        // No longer matchable: a crossing sell finds no liquidity.
+        let taker = Id::new_uuid();
+        assert!(book.match_market_order(taker, 10, Side::Sell).is_err());
+    }
+
+    #[test]
+    fn test_evict_expired_leaves_gtc_and_unexpired_gtd_untouched() {
+        let book = expiring_book();
+        let gtc = Id::new_uuid();
+        let gtd_future = Id::new_uuid();
+        let gtd_past = Id::new_uuid();
+        book.add_limit_order(gtc, 100, 10, Side::Buy, TimeInForce::Gtc, None)
+            .expect("gtc");
+        book.add_limit_order(gtd_future, 99, 5, Side::Buy, TimeInForce::Gtd(5_000), None)
+            .expect("gtd future");
+        book.add_limit_order(gtd_past, 98, 5, Side::Buy, TimeInForce::Gtd(1_000), None)
+            .expect("gtd past");
+
+        let evicted = book.evict_expired_orders(TimestampMs::new(2_000));
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0].id(), gtd_past);
+
+        assert!(book.order_locations.contains_key(&gtc));
+        assert!(book.order_locations.contains_key(&gtd_future));
+        assert!(!book.order_locations.contains_key(&gtd_past));
+    }
+
+    #[test]
+    fn test_evict_expired_boundary_matches_has_expired_semantics() {
+        // is_expired is `now >= deadline`; has_expired delegates to the same
+        // definition the sweep uses, so `deadline - 1` is not expired and
+        // `deadline` is. The sweep must honour that exact boundary.
+        let book = expiring_book();
+        let id = Id::new_uuid();
+        book.add_limit_order(id, 100, 10, Side::Sell, TimeInForce::Gtd(1_000), None)
+            .expect("add");
+
+        // 999 -> not expired.
+        assert!(book.evict_expired_orders(TimestampMs::new(999)).is_empty());
+        // Exactly at the deadline -> evicted.
+        let evicted = book.evict_expired_orders(TimestampMs::new(1_000));
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0].id(), id);
+    }
+
+    #[test]
+    fn test_evict_expired_day_uses_market_close() {
+        let book = expiring_book();
+        book.set_market_close_timestamp(2_000);
+        let day = Id::new_uuid();
+        book.add_limit_order(day, 100, 10, Side::Buy, TimeInForce::Day, None)
+            .expect("day");
+
+        // Before close: untouched.
+        assert!(
+            book.evict_expired_orders(TimestampMs::new(1_999))
+                .is_empty()
+        );
+        // At/after close: evicted.
+        let evicted = book.evict_expired_orders(TimestampMs::new(2_000));
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0].id(), day);
+    }
+
+    #[test]
+    fn test_evict_expired_deterministic_order_multiple_levels_sides() {
+        let book = expiring_book();
+
+        // Bids at two levels (ascending: 90 then 95), FIFO within each level.
+        let b95a = Id::new_uuid();
+        let b95b = Id::new_uuid();
+        let b90 = Id::new_uuid();
+        book.add_limit_order(b95a, 95, 1, Side::Buy, TimeInForce::Gtd(1_000), None)
+            .expect("b95a");
+        book.add_limit_order(b95b, 95, 1, Side::Buy, TimeInForce::Gtd(1_000), None)
+            .expect("b95b");
+        book.add_limit_order(b90, 90, 1, Side::Buy, TimeInForce::Gtd(1_000), None)
+            .expect("b90");
+
+        // Asks at two levels (ascending: 100 then 110).
+        let a100 = Id::new_uuid();
+        let a110 = Id::new_uuid();
+        book.add_limit_order(a100, 100, 1, Side::Sell, TimeInForce::Gtd(1_000), None)
+            .expect("a100");
+        book.add_limit_order(a110, 110, 1, Side::Sell, TimeInForce::Gtd(1_000), None)
+            .expect("a110");
+
+        let evicted = book.evict_expired_orders(TimestampMs::new(2_000));
+        let ids: Vec<Id> = evicted.iter().map(|o| o.id()).collect();
+
+        // Contract: bids ascending (90, then 95 FIFO), then asks ascending.
+        assert_eq!(ids, vec![b90, b95a, b95b, a100, a110]);
+    }
+
+    #[test]
+    fn test_evict_expired_second_sweep_is_idempotent() {
+        let book = expiring_book();
+        let id = Id::new_uuid();
+        book.add_limit_order(id, 100, 10, Side::Buy, TimeInForce::Gtd(1_000), None)
+            .expect("add");
+
+        let first = book.evict_expired_orders(TimestampMs::new(1_000));
+        assert_eq!(first.len(), 1);
+        let second = book.evict_expired_orders(TimestampMs::new(1_000));
+        assert!(second.is_empty());
+    }
+
+    #[test]
+    fn test_evict_expired_fires_book_change_events() {
+        use crate::orderbook::book_change_event::PriceLevelChangedEvent;
+        use std::sync::Mutex;
+
+        let events: Arc<Mutex<Vec<PriceLevelChangedEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&events);
+        let mut book = expiring_book();
+        book.set_price_level_listener(Arc::new(move |ev: PriceLevelChangedEvent| {
+            if let Ok(mut v) = sink.lock() {
+                v.push(ev);
+            }
+        }));
+
+        let id = Id::new_uuid();
+        book.add_limit_order(id, 100, 10, Side::Buy, TimeInForce::Gtd(1_000), None)
+            .expect("add");
+
+        let evicted = book.evict_expired_orders(TimestampMs::new(1_000));
+        assert_eq!(evicted.len(), 1);
+
+        let recorded = events.lock().expect("lock");
+        // The cancel path emits a level-change event for the touched level.
+        assert!(
+            recorded
+                .iter()
+                .any(|ev| ev.side == Side::Buy && ev.price == 100 && ev.quantity == 0)
+        );
+    }
+
+    #[test]
+    fn test_evict_expired_records_time_in_force_expired_reason() {
+        use crate::orderbook::order_state::{OrderStateTracker, OrderStatus};
+
+        let mut book = expiring_book();
+        book.set_order_state_tracker(OrderStateTracker::new());
+
+        let id = Id::new_uuid();
+        book.add_limit_order(id, 100, 10, Side::Buy, TimeInForce::Gtd(1_000), None)
+            .expect("add");
+
+        let evicted = book.evict_expired_orders(TimestampMs::new(1_000));
+        assert_eq!(evicted.len(), 1);
+
+        let status = book
+            .order_state_tracker()
+            .and_then(|t| t.get(id))
+            .expect("status");
+        assert!(matches!(
+            status,
+            OrderStatus::Cancelled {
+                reason: CancelReason::TimeInForceExpired,
+                ..
+            }
+        ));
     }
 }

--- a/src/orderbook/private.rs
+++ b/src/orderbook/private.rs
@@ -1,6 +1,6 @@
 use crate::orderbook::book_change_event::PriceLevelChangedEvent;
 use crate::{OrderBook, OrderBookError};
-use pricelevel::{OrderType, PriceLevel, Side};
+use pricelevel::{OrderType, PriceLevel, Side, TimeInForce};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
@@ -8,7 +8,41 @@ impl<T> OrderBook<T>
 where
     T: Clone + Send + Sync + Default + 'static,
 {
-    /// Check if an order has expired.
+    /// The market-close timestamp (Unix milliseconds) used for `Day`-order
+    /// expiry, or `None` when no market close has been configured via
+    /// [`Self::set_market_close_timestamp`].
+    ///
+    /// Single source of the market-close input shared by [`Self::has_expired`]
+    /// and [`Self::tif_expired_at`] so admission and eviction agree on `Day`
+    /// boundary behaviour.
+    #[inline]
+    pub(super) fn market_close_for_expiry(&self) -> Option<u64> {
+        if self.has_market_close.load(Ordering::Relaxed) {
+            Some(self.market_close_timestamp.load(Ordering::Relaxed))
+        } else {
+            None
+        }
+    }
+
+    /// Whether a [`TimeInForce`] is expired at an explicit `now_ms`.
+    ///
+    /// This is the single definition of expiry in the book: both admission
+    /// (via [`Self::has_expired`]) and the eviction sweep
+    /// ([`Self::evict_expired_orders`](crate::OrderBook::evict_expired_orders))
+    /// route through it, so they cannot disagree on the boundary case
+    /// (`deadline == now_ms`, which counts as expired for `Gtd`, and
+    /// `now_ms == market_close` for `Day`).
+    ///
+    /// `now_ms` is **milliseconds since the Unix epoch** — the same unit as a
+    /// `Gtd` deadline and the market-close timestamp. A value expressed in
+    /// seconds would be treated as a moment in 1970.
+    #[inline]
+    #[must_use]
+    pub(super) fn tif_expired_at(&self, time_in_force: TimeInForce, now_ms: u64) -> bool {
+        time_in_force.is_expired(now_ms, self.market_close_for_expiry())
+    }
+
+    /// Check if an order has expired **as of the book's own clock**.
     ///
     /// The comparison unit is **milliseconds since the Unix epoch**: the
     /// current time comes from `self.clock().now_millis()`, and a `Gtd`
@@ -16,18 +50,15 @@ where
     /// see [`Self::set_market_close_timestamp`]) must be supplied in the same
     /// unit. A deadline expressed in seconds would be treated as a moment in
     /// 1970 and the order would read as instantly expired.
+    ///
+    /// The boundary predicate (`now >= deadline` for `Gtd`,
+    /// `now >= market_close` for `Day`) is defined once internally and shared
+    /// with the caller-supplied-timestamp eviction sweep
+    /// ([`Self::evict_expired_orders`](crate::OrderBook::evict_expired_orders)),
+    /// so admission and eviction never disagree.
     pub fn has_expired(&self, order: &OrderType<T>) -> bool {
-        let time_in_force = order.time_in_force();
         let current_time = self.clock().now_millis().as_u64();
-
-        // Only check market close timestamp if we have one set
-        let market_close = if self.has_market_close.load(Ordering::Relaxed) {
-            Some(self.market_close_timestamp.load(Ordering::Relaxed))
-        } else {
-            None
-        };
-
-        time_in_force.is_expired(current_time, market_close)
+        self.tif_expired_at(order.time_in_force(), current_time)
     }
 
     /// Check if there would be a price crossing

--- a/src/orderbook/sequencer/file_journal.rs
+++ b/src/orderbook/sequencer/file_journal.rs
@@ -1448,4 +1448,42 @@ mod tests {
         let decoded = decoded.unwrap_or_else(|_| panic!("decode"));
         assert_eq!(decoded.sequence_num, 7);
     }
+
+    /// #189: an `EvictExpiredOrders` command survives a full `FileJournal`
+    /// append/read cycle (CRC-verified, memory-mapped), keeping `FileJournal`
+    /// in parity with `InMemoryJournal` for the appended variant. The
+    /// journaled `now_ms` decodes byte-identically.
+    #[test]
+    fn test_evict_expired_orders_command_file_journal_roundtrip() {
+        use pricelevel::TimestampMs;
+
+        let dir = tempfile::tempdir().unwrap_or_else(|_| panic!("tempdir"));
+        let journal = FileJournal::<()>::open(dir.path()).unwrap_or_else(|_| panic!("open"));
+
+        let event = SequencerEvent::<()> {
+            sequence_num: 0,
+            timestamp_ns: 0,
+            command: SequencerCommand::EvictExpiredOrders {
+                now_ms: TimestampMs::new(1_700_000_000_000),
+            },
+            result: SequencerResult::OrderCancelled {
+                order_id: Id::new_uuid(),
+            },
+        };
+        assert!(journal.append(&event).is_ok());
+        assert!(journal.verify_integrity().is_ok());
+
+        let decoded = journal
+            .read_from(0)
+            .unwrap_or_else(|_| panic!("read_from"))
+            .next()
+            .and_then(Result::ok)
+            .unwrap_or_else(|| panic!("decode"));
+        match decoded.event.command {
+            SequencerCommand::EvictExpiredOrders { now_ms } => {
+                assert_eq!(now_ms, TimestampMs::new(1_700_000_000_000));
+            }
+            other => panic!("expected EvictExpiredOrders, got {other:?}"),
+        }
+    }
 }

--- a/src/orderbook/sequencer/replay.rs
+++ b/src/orderbook/sequencer/replay.rs
@@ -610,6 +610,12 @@ where
             } => {
                 let _ = book.cancel_orders_by_price_range(*side, *min_price, *max_price);
             }
+            SequencerCommand::EvictExpiredOrders { now_ms } => {
+                // Apply the journaled cutoff, never the replay clock, so the
+                // sweep evicts exactly the orders it evicted live. The sweep
+                // is idempotent, so a duplicate replay is a no-op.
+                let _ = book.evict_expired_orders(*now_ms);
+            }
         }
 
         Ok(())
@@ -1073,5 +1079,137 @@ mod tests {
             }
             other => panic!("expected MarketOrderByAmount, got {other:?}"),
         }
+    }
+
+    /// #189: the appended `EvictExpiredOrders` command round-trips through
+    /// JSON — the `now_ms` cutoff decodes byte-identically. `TimestampMs` is
+    /// `#[serde(transparent)]`, so it encodes as a bare millisecond count.
+    #[test]
+    fn test_evict_expired_orders_command_serde_json_roundtrip() {
+        let cmd: SequencerCommand<()> = SequencerCommand::EvictExpiredOrders {
+            now_ms: TimestampMs::new(1_700_000_000_000),
+        };
+        let json = serde_json::to_vec(&cmd).expect("serialize");
+        let decoded: SequencerCommand<()> = serde_json::from_slice(&json).expect("deserialize");
+        match decoded {
+            SequencerCommand::EvictExpiredOrders { now_ms } => {
+                assert_eq!(now_ms, TimestampMs::new(1_700_000_000_000));
+            }
+            other => panic!("expected EvictExpiredOrders, got {other:?}"),
+        }
+    }
+
+    /// #189: the appended `EvictExpiredOrders` command round-trips through
+    /// bincode with no trailing bytes. Because the variant is appended after
+    /// every prior variant, old journals keep their bincode variant indices.
+    #[cfg(feature = "bincode")]
+    #[test]
+    fn test_evict_expired_orders_command_bincode_roundtrip() {
+        use bincode::config::standard;
+        use bincode::serde::{decode_from_slice, encode_to_vec};
+        let cmd: SequencerCommand<()> = SequencerCommand::EvictExpiredOrders {
+            now_ms: TimestampMs::new(42_000),
+        };
+        let bytes = encode_to_vec(&cmd, standard()).expect("encode");
+        let (decoded, n) =
+            decode_from_slice::<SequencerCommand<()>, _>(&bytes, standard()).expect("decode");
+        assert_eq!(n, bytes.len());
+        match decoded {
+            SequencerCommand::EvictExpiredOrders { now_ms } => {
+                assert_eq!(now_ms, TimestampMs::new(42_000));
+            }
+            other => panic!("expected EvictExpiredOrders, got {other:?}"),
+        }
+    }
+
+    /// #189: an `EvictExpiredOrders` command replays deterministically. Drive a
+    /// live book through a set of GTD / GTC adds plus a sweep, journaling each
+    /// command; replay the journal into a fresh book (with a matching logical
+    /// clock so the small GTD deadlines re-admit) and require the post-sweep
+    /// state to match the live one. `snapshots_match` is the oracle. The sweep
+    /// consumes the journaled `now_ms`, never the replay clock — that is the
+    /// determinism contract for the variant.
+    #[test]
+    fn test_replay_evict_expired_orders_matches_live_book() {
+        use crate::orderbook::mass_cancel::MassCancelResult;
+
+        fn order(id: Id, price: u128, qty: u64, side: Side, tif: TimeInForce) -> OrderType<()> {
+            OrderType::Standard {
+                id,
+                price: Price::new(price),
+                quantity: Quantity::new(qty),
+                side,
+                time_in_force: tif,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(0),
+                extra_fields: (),
+            }
+        }
+
+        let symbol = "TEST";
+        let journal: InMemoryJournal<()> = InMemoryJournal::new();
+
+        // Two GTD orders expire at t=1_000; one GTD rests until t=10_000; a GTC
+        // order never expires. Built once so the live book and the journal carry
+        // identical AddOrder commands.
+        let expiring_bid = order(Id::new_uuid(), 100, 5, Side::Buy, TimeInForce::Gtd(1_000));
+        let future_bid = order(Id::new_uuid(), 99, 3, Side::Buy, TimeInForce::Gtd(10_000));
+        let gtc_bid = order(Id::new_uuid(), 98, 4, Side::Buy, TimeInForce::Gtc);
+        let expiring_ask = order(Id::new_uuid(), 101, 7, Side::Sell, TimeInForce::Gtd(1_000));
+        let orders = [expiring_bid, future_bid, gtc_bid, expiring_ask];
+
+        // Live book on a logical clock so the small deadlines admit (wall-clock
+        // admission would treat them as already expired).
+        let clock_live: Arc<dyn Clock> = Arc::new(StubClock::starting_at(0));
+        let live = OrderBook::<()>::with_clock(symbol, clock_live);
+
+        let mut seq = 0u64;
+        for ord in &orders {
+            live.add_order(*ord).expect("live add");
+            let ev = SequencerEvent::<()> {
+                sequence_num: seq,
+                timestamp_ns: 0,
+                command: SequencerCommand::AddOrder(*ord),
+                result: SequencerResult::OrderAdded { order_id: ord.id() },
+            };
+            assert!(journal.append(&ev).is_ok());
+            seq += 1;
+        }
+
+        // Sweep live at t=5_000: evicts the two t=1_000 orders, keeps the rest.
+        let now = TimestampMs::new(5_000);
+        let evicted = live.evict_expired_orders(now);
+        assert_eq!(evicted.len(), 2, "two GTD orders expire by t=5_000");
+        let sweep = SequencerEvent::<()> {
+            sequence_num: seq,
+            timestamp_ns: 0,
+            command: SequencerCommand::EvictExpiredOrders { now_ms: now },
+            result: SequencerResult::MassCancelled {
+                result: MassCancelResult::new(
+                    evicted.len(),
+                    evicted.iter().map(|o| o.id()).collect(),
+                ),
+            },
+        };
+        assert!(journal.append(&sweep).is_ok());
+
+        // Replay with a matching logical clock so AddOrder re-admissions succeed;
+        // the sweep applies the journaled cutoff, not the clock.
+        let clock_replay: Arc<dyn Clock> = Arc::new(StubClock::starting_at(0));
+        let (replayed, last_seq) =
+            ReplayEngine::<()>::replay_from_with_clock(&journal, 0, symbol, clock_replay)
+                .expect("replay must succeed");
+        assert_eq!(last_seq, seq);
+
+        let live_snap = live.create_snapshot(usize::MAX);
+        let replayed_snap = replayed.create_snapshot(usize::MAX);
+        assert!(
+            snapshots_match(&live_snap, &replayed_snap),
+            "post-sweep live and replayed snapshots must match"
+        );
+
+        // Sanity: the expired levels are gone, the survivors remain.
+        assert_eq!(replayed_snap.bids.len(), 2, "99 and 98 bids survive");
+        assert!(replayed_snap.asks.is_empty(), "the only ask expired");
     }
 }

--- a/src/orderbook/sequencer/types.rs
+++ b/src/orderbook/sequencer/types.rs
@@ -7,7 +7,7 @@
 
 use crate::orderbook::mass_cancel::MassCancelResult;
 use crate::orderbook::trade::TradeResult;
-use pricelevel::{Hash32, Id, OrderType, OrderUpdate, Side};
+use pricelevel::{Hash32, Id, OrderType, OrderUpdate, Side, TimestampMs};
 use serde::{Deserialize, Serialize};
 
 /// A command submitted to the Sequencer for total-ordered execution.
@@ -18,7 +18,14 @@ use serde::{Deserialize, Serialize};
 ///
 /// The generic parameter `T` represents extra fields carried by
 /// `OrderType<T>` (e.g., custom metadata per order).
+///
+/// This enum is `#[non_exhaustive]`: new commands are added over time, so
+/// downstream `match` expressions must include a wildcard arm. This makes
+/// future variant additions source-compatible; wire compatibility is
+/// preserved separately by only ever appending variants (existing bincode
+/// variant indices never shift).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum SequencerCommand<T> {
     /// Submit a new order to the book.
     AddOrder(OrderType<T>),
@@ -83,13 +90,50 @@ pub enum SequencerCommand<T> {
         /// Maximum price (inclusive).
         max_price: u128,
     },
+
+    /// Evict every resting order whose time-in-force has expired as of
+    /// `now_ms` (Unix milliseconds), in the engine's deterministic sweep
+    /// order. Ferries through [`OrderBook::evict_expired_orders`] on replay.
+    ///
+    /// [`OrderBook::evict_expired_orders`]:
+    /// crate::orderbook::OrderBook::evict_expired_orders
+    ///
+    /// The journaled `now_ms` is the sole deterministic input: replay MUST
+    /// apply the journaled value rather than read the replay clock, so the
+    /// sweep reproduces the exact set of evictions on every run. `now_ms` is
+    /// a [`TimestampMs`], which is `#[serde(transparent)]` over `u64`, so the
+    /// variant encodes to the same bytes a bare millisecond count would in
+    /// both JSON and bincode.
+    ///
+    /// Wire-compatible addition: existing journals replay unchanged and
+    /// their bincode variant indices are unaffected because it is appended
+    /// after every prior variant. Journals carrying `EvictExpiredOrders`
+    /// will fail to decode against older binaries — this matches the
+    /// precedent set by [`Self::MarketOrderByAmount`]. No
+    /// `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump is required (that version
+    /// governs the snapshot package format, not the sequencer command enum).
+    /// On the Rust API side the variant ships together with
+    /// `#[non_exhaustive]` on this enum in 0.10.0, so subsequent additions
+    /// are source-compatible as well.
+    EvictExpiredOrders {
+        /// Caller-supplied cutoff in Unix milliseconds. Every resting order
+        /// whose time-in-force has expired at `now_ms` is evicted:
+        /// `Gtd(deadline)` when `now_ms >= deadline`, and `Day` when
+        /// `now_ms >=` the book's configured market close.
+        now_ms: TimestampMs,
+    },
 }
 
 /// The outcome of executing a [`SequencerCommand`] against the order book.
 ///
 /// Each variant captures the result of the corresponding command, including
 /// any generated trades or the reason for rejection.
+///
+/// Like [`SequencerCommand`], this enum is `#[non_exhaustive]`: new result
+/// shapes accompany new commands, so downstream `match` expressions must
+/// include a wildcard arm.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum SequencerResult {
     /// An order was successfully added to the book.
     OrderAdded {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -43,7 +43,7 @@ pub use crate::orderbook::trade::{
 pub use crate::orderbook::book_change_event::{PriceLevelChangedEvent, PriceLevelChangedListener};
 
 // Order types and enums from pricelevel
-pub use pricelevel::{Id, OrderType, Side, TimeInForce};
+pub use pricelevel::{Id, OrderType, Side, TimeInForce, TimestampMs};
 
 // Legacy alias for backward compatibility
 pub use crate::OrderId;

--- a/tests/unit/evict_expired_tests.rs
+++ b/tests/unit/evict_expired_tests.rs
@@ -1,0 +1,238 @@
+//! Integration tests for time-in-force eviction (`evict_expired_orders`).
+//!
+//! Covers the explicit sweep that removes resting `Gtd` / `Day` orders after
+//! their deadline (issue #189). Resting expiry is *not* checked on the matching
+//! hot path — the sweep is the only eviction point — so these tests assert the
+//! deterministic output order, the `deadline == now` boundary, idempotence,
+//! event emission, order-tracker reason, and manager parity.
+
+use orderbook_rs::orderbook::manager::{BookManager, BookManagerStd, BookManagerTokio};
+use orderbook_rs::orderbook::order_state::{CancelReason, OrderStatus};
+use orderbook_rs::{Clock, OrderBook, StubClock};
+use pricelevel::{Id, Side, TimeInForce, TimestampMs};
+use std::sync::{Arc, Mutex};
+
+/// A book whose clock starts at logical `0` so small `Gtd` deadlines are
+/// admitted (wall-clock admission would treat them as already expired) and the
+/// caller-supplied sweep timestamp is what drives expiry.
+fn expiring_book(symbol: &str) -> OrderBook<()> {
+    OrderBook::with_clock(
+        symbol,
+        Arc::new(StubClock::starting_at(0)) as Arc<dyn Clock>,
+    )
+}
+
+#[test]
+fn expired_gtd_is_evicted_and_no_longer_matchable() {
+    let book = expiring_book("TEST");
+    let gtd = Id::new_uuid();
+    book.add_limit_order(gtd, 100, 10, Side::Sell, TimeInForce::Gtd(1_000), None)
+        .expect("add gtd");
+
+    let evicted = book.evict_expired_orders(TimestampMs::new(1_000));
+    assert_eq!(evicted.len(), 1);
+    assert_eq!(evicted[0].id(), gtd);
+    assert_eq!(book.best_ask(), None);
+
+    // A crossing buy now finds no liquidity.
+    let taker = Id::new_uuid();
+    assert!(book.match_market_order(taker, 10, Side::Buy).is_err());
+}
+
+#[test]
+fn unexpired_gtd_and_gtc_are_untouched() {
+    let book = expiring_book("TEST");
+    let gtc = Id::new_uuid();
+    let gtd_future = Id::new_uuid();
+    book.add_limit_order(gtc, 100, 10, Side::Buy, TimeInForce::Gtc, None)
+        .expect("gtc");
+    book.add_limit_order(gtd_future, 99, 5, Side::Buy, TimeInForce::Gtd(10_000), None)
+        .expect("gtd future");
+
+    let evicted = book.evict_expired_orders(TimestampMs::new(5_000));
+    assert!(evicted.is_empty());
+    assert_eq!(book.best_bid(), Some(100));
+}
+
+#[test]
+fn boundary_deadline_equals_now_is_expired() {
+    let book = expiring_book("TEST");
+    let id = Id::new_uuid();
+    book.add_limit_order(id, 100, 10, Side::Buy, TimeInForce::Gtd(1_000), None)
+        .expect("add");
+
+    // deadline - 1: not expired.
+    assert!(book.evict_expired_orders(TimestampMs::new(999)).is_empty());
+    // deadline exactly: expired (matches is_expired's `now >= deadline`).
+    assert_eq!(book.evict_expired_orders(TimestampMs::new(1_000)).len(), 1);
+}
+
+#[test]
+fn deterministic_order_bids_then_asks_ascending_fifo() {
+    let book = expiring_book("TEST");
+
+    // Bids across two levels; FIFO within the 95 level.
+    let b95a = Id::new_uuid();
+    let b95b = Id::new_uuid();
+    let b90 = Id::new_uuid();
+    book.add_limit_order(b95a, 95, 1, Side::Buy, TimeInForce::Gtd(1_000), None)
+        .expect("b95a");
+    book.add_limit_order(b95b, 95, 1, Side::Buy, TimeInForce::Gtd(1_000), None)
+        .expect("b95b");
+    book.add_limit_order(b90, 90, 1, Side::Buy, TimeInForce::Gtd(1_000), None)
+        .expect("b90");
+
+    // Asks across two levels.
+    let a100 = Id::new_uuid();
+    let a110 = Id::new_uuid();
+    book.add_limit_order(a100, 100, 1, Side::Sell, TimeInForce::Gtd(1_000), None)
+        .expect("a100");
+    book.add_limit_order(a110, 110, 1, Side::Sell, TimeInForce::Gtd(1_000), None)
+        .expect("a110");
+
+    let ids: Vec<Id> = book
+        .evict_expired_orders(TimestampMs::new(2_000))
+        .iter()
+        .map(|o| o.id())
+        .collect();
+
+    // Contract: bids ascending (90, then the 95 level FIFO), then asks ascending.
+    assert_eq!(ids, vec![b90, b95a, b95b, a100, a110]);
+}
+
+#[test]
+fn second_sweep_at_same_now_is_idempotent() {
+    let book = expiring_book("TEST");
+    let id = Id::new_uuid();
+    book.add_limit_order(id, 100, 10, Side::Buy, TimeInForce::Gtd(1_000), None)
+        .expect("add");
+
+    assert_eq!(book.evict_expired_orders(TimestampMs::new(1_000)).len(), 1);
+    assert!(
+        book.evict_expired_orders(TimestampMs::new(1_000))
+            .is_empty()
+    );
+}
+
+#[test]
+fn eviction_fires_book_change_event_for_touched_level() {
+    use orderbook_rs::orderbook::book_change_event::PriceLevelChangedEvent;
+
+    let events: Arc<Mutex<Vec<PriceLevelChangedEvent>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&events);
+    let mut book = expiring_book("TEST");
+    book.set_price_level_listener(Arc::new(move |ev: PriceLevelChangedEvent| {
+        if let Ok(mut v) = sink.lock() {
+            v.push(ev);
+        }
+    }));
+
+    let id = Id::new_uuid();
+    book.add_limit_order(id, 100, 10, Side::Buy, TimeInForce::Gtd(1_000), None)
+        .expect("add");
+
+    assert_eq!(book.evict_expired_orders(TimestampMs::new(1_000)).len(), 1);
+
+    let recorded = events.lock().expect("lock");
+    assert!(
+        recorded
+            .iter()
+            .any(|ev| ev.side == Side::Buy && ev.price == 100 && ev.quantity == 0),
+        "expected a qty->0 level change for the evicted level"
+    );
+}
+
+#[test]
+fn order_tracker_records_time_in_force_expired() {
+    use orderbook_rs::orderbook::order_state::OrderStateTracker;
+
+    let mut book = expiring_book("TEST");
+    book.set_order_state_tracker(OrderStateTracker::new());
+
+    let id = Id::new_uuid();
+    book.add_limit_order(id, 100, 10, Side::Buy, TimeInForce::Gtd(1_000), None)
+        .expect("add");
+
+    assert_eq!(book.evict_expired_orders(TimestampMs::new(1_000)).len(), 1);
+
+    let status = book
+        .order_state_tracker()
+        .and_then(|t| t.get(id))
+        .expect("status present");
+    assert!(matches!(
+        status,
+        OrderStatus::Cancelled {
+            reason: CancelReason::TimeInForceExpired,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn manager_std_per_symbol_and_all_books_parity() {
+    let mut mgr: BookManagerStd<()> = BookManagerStd::new();
+    mgr.add_book("BTC/USD").expect("add BTC");
+    mgr.add_book("ETH/USD").expect("add ETH");
+
+    // Swap in a logical clock per book so small Gtd deadlines admit.
+    if let Some(book) = mgr.get_book_mut("BTC/USD") {
+        book.set_clock(Arc::new(StubClock::starting_at(0)) as Arc<dyn Clock>);
+    }
+    if let Some(book) = mgr.get_book_mut("ETH/USD") {
+        book.set_clock(Arc::new(StubClock::starting_at(0)) as Arc<dyn Clock>);
+    }
+
+    let btc_id = Id::new_uuid();
+    let eth_id = Id::new_uuid();
+    if let Some(book) = mgr.get_book("BTC/USD") {
+        book.add_limit_order(btc_id, 100, 1, Side::Buy, TimeInForce::Gtd(1_000), None)
+            .expect("btc order");
+    }
+    if let Some(book) = mgr.get_book("ETH/USD") {
+        book.add_limit_order(eth_id, 100, 1, Side::Buy, TimeInForce::Gtd(1_000), None)
+            .expect("eth order");
+    }
+
+    // Per-symbol pass-through.
+    let btc_evicted = mgr
+        .evict_expired_orders("BTC/USD", TimestampMs::new(1_000))
+        .expect("BTC managed");
+    assert_eq!(btc_evicted.len(), 1);
+    assert_eq!(btc_evicted[0].id(), btc_id);
+    // Unknown symbol -> None.
+    assert!(
+        mgr.evict_expired_orders("NOPE", TimestampMs::new(1_000))
+            .is_none()
+    );
+
+    // All-books variant covers the remaining book.
+    let all = mgr.evict_expired_across_books(TimestampMs::new(1_000));
+    assert_eq!(all.get("ETH/USD").map(|v| v.len()), Some(1));
+    // BTC was already swept, so nothing left there.
+    assert_eq!(all.get("BTC/USD").map(|v| v.len()), Some(0));
+}
+
+#[test]
+fn manager_tokio_per_symbol_and_all_books_parity() {
+    let mut mgr: BookManagerTokio<()> = BookManagerTokio::new();
+    mgr.add_book("BTC/USD").expect("add BTC");
+
+    if let Some(book) = mgr.get_book_mut("BTC/USD") {
+        book.set_clock(Arc::new(StubClock::starting_at(0)) as Arc<dyn Clock>);
+    }
+
+    let id = Id::new_uuid();
+    if let Some(book) = mgr.get_book("BTC/USD") {
+        book.add_limit_order(id, 100, 1, Side::Buy, TimeInForce::Gtd(1_000), None)
+            .expect("order");
+    }
+
+    let evicted = mgr
+        .evict_expired_orders("BTC/USD", TimestampMs::new(1_000))
+        .expect("managed");
+    assert_eq!(evicted.len(), 1);
+
+    // Idempotent across the all-books variant too.
+    let all = mgr.evict_expired_across_books(TimestampMs::new(1_000));
+    assert_eq!(all.get("BTC/USD").map(|v| v.len()), Some(0));
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -3,6 +3,7 @@ mod book_manager_cross_cancel_tests;
 mod clock_determinism_tests;
 mod common;
 mod engine_seq_monotonic_tests;
+mod evict_expired_tests;
 #[cfg(feature = "journal")]
 mod filejournal_edge_case_tests;
 mod implied_volatility_tests;


### PR DESCRIPTION
## Summary

Implements #189 and releases **0.10.0**.

### Host-driven expiry sweep (#189)
- `OrderBook::evict_expired_orders(now_ms: TimestampMs)` — evicts every resting order whose time-in-force has expired at the caller-supplied Unix-ms cutoff. The sweep never reads the book's clock (scheduler drives cadence; sequencer journals the exact cutoff). Matching hot path untouched — no lazy per-match check. Honest caveat documented: an expired-but-unswept order remains matchable until the sweep runs.
- Boundary predicate factored and shared with admission (`tif_expired_at`: `now >= deadline` for Gtd, `now >= market_close` for Day) — admission and eviction can never disagree at the boundary.
- **Deterministic eviction order** (replay contract): bids→asks, ascending price (SkipMap natural order), ascending insertion seq within level (`snapshot_by_seq_into`, not the unstable `iter_orders`). Removal via the single-order cancel path, tagged `CancelReason::TimeInForceExpired` — caches/statistics/trackers stay consistent.
- Manager parity: `evict_expired_orders(symbol, now_ms)` + `evict_expired_across_books(now_ms)` on both managers.
- Sequencer: `SequencerCommand::EvictExpiredOrders { now_ms }` appended (old journals replay unchanged, bincode indices stable); replay applies the journaled cutoff; `snapshots_match` verified live-vs-replay. No snapshot format version bump (gates the snapshot package, not the command enum).

### Why 0.10.0, not 0.9.3 (review blocker)
The determinism and architecture reviewers both flagged it: `SequencerCommand` was an **exhaustive** pub enum, so appending a variant is a major break (`cargo-semver-checks: enum_variant_added`) — it would have broken downstream exhaustive matches silently inside 0.9.x. Fix shipped here: `#[non_exhaustive]` on `SequencerCommand` **and** `SequencerResult` (one-time break; future additions become source-compatible), release bumped to 0.10.0. `cargo semver-checks --baseline-rev main` passes (major slot). Wire format unaffected.

### Also
- `TimestampMs` re-exported at root + prelude; runnable example `gtd_expiry_sweep`; What's New/CHANGELOG/README.
- Review panel: determinism-auditor + hotpath-reviewer + microstructure-critic + architect; blockers fixed (version/semver), nits applied (trace-level sweep log, doc precision on Day expiry, honest matchability window, `#[must_use]` consistency). Follow-up filed: #190 (pre-existing mass-cancel result ordering not replay-stable).

## Gates
- `make pre-push` clean; clippy `-D warnings` zero; `cargo test --all-features`: 1318 passed / 0 failed; doctests green; `cargo semver-checks --baseline-rev main`: pass.

Closes #189.