### PR TITLE
fix: replay-stable mass-cancel result ordering — 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] — 2026-07-10
+
+### Changed
+
+- **Deterministic, replay-stable mass-cancel result ordering (#190).**
+  `OrderBook::cancel_all_orders`, `cancel_orders_by_side`, and
+  `cancel_orders_by_price_range` now enumerate the cancelled orders through the
+  same fixed traversal the eviction sweep uses — bids first then asks; within a
+  side, price levels in ascending price (the `SkipMap`'s natural key order); and
+  within a level, ascending insertion sequence via
+  `PriceLevel::snapshot_by_seq_into`. Previously these methods collected ids from
+  order-unstable structures (`order_locations` / per-level `iter_orders`), whose
+  `DashMap` hasher is seeded per instance, so two processes replaying the same
+  command stream could produce different `MassCancelResult::cancelled_order_ids`
+  orderings — and therefore divergent journaled `SequencerResult::MassCancelled`
+  payloads. The cancelled **set** and **count** are unchanged; only the order of
+  `cancelled_order_ids` is now deterministic across processes and replay.
+  `cancel_orders_by_user` was already replay-stable (it drains the `user_orders`
+  index in admission-history order) and is unchanged; its determinism contract is
+  now documented.
+- No wire-format or public-API change: no new fields, no event-shape change, and
+  no `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump.
+
 ## [0.10.0] — 2026-07-10
 
 ### Breaking

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orderbook-rs"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."

--- a/README.md
+++ b/README.md
@@ -46,6 +46,28 @@ This order book engine is built with the following design principles:
 - **Research**: Platform for studying market microstructure and order flow
 - **Educational**: Reference implementation for understanding modern exchange architecture
 
+### What's New in Version 0.10.1
+
+#### v0.10.1 — replay-stable mass-cancel result ordering (#190)
+
+- **Deterministic `cancelled_order_ids` ordering.** `cancel_all_orders`,
+  `cancel_orders_by_side`, and `cancel_orders_by_price_range` now enumerate
+  cancelled orders through the same fixed traversal the eviction sweep uses:
+  bids first then asks; within a side, price levels in ascending price (the
+  `SkipMap`'s natural key order, no sort); within a level, ascending insertion
+  sequence (`PriceLevel::snapshot_by_seq_into`, the exact order the matching
+  engine consumes resting orders). Previously the ids were read from
+  order-unstable structures (`order_locations` / per-level `iter_orders`) whose
+  `DashMap` hasher is seeded per instance, so two processes replaying the same
+  command stream could journal divergent `SequencerResult::MassCancelled`
+  payloads. The cancelled **set** and **count** are unchanged — only the order
+  of `cancelled_order_ids` is now byte-identical across processes and replay.
+- **`cancel_orders_by_user` is unchanged** and was already replay-stable: it
+  drains the `user_orders` index in admission-history order. That determinism
+  contract is now documented alongside the others.
+- No wire-format or public-API change: no new fields, no event-shape change,
+  and no `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump.
+
 ### What's New in Version 0.10.0
 
 #### v0.10.0 — host-driven GTD / DAY expiry sweep (#189)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,28 @@
 //! - **Research**: Platform for studying market microstructure and order flow
 //! - **Educational**: Reference implementation for understanding modern exchange architecture
 //!
+//! ## What's New in Version 0.10.1
+//!
+//! ### v0.10.1 — replay-stable mass-cancel result ordering (#190)
+//!
+//! - **Deterministic `cancelled_order_ids` ordering.** `cancel_all_orders`,
+//!   `cancel_orders_by_side`, and `cancel_orders_by_price_range` now enumerate
+//!   cancelled orders through the same fixed traversal the eviction sweep uses:
+//!   bids first then asks; within a side, price levels in ascending price (the
+//!   `SkipMap`'s natural key order, no sort); within a level, ascending insertion
+//!   sequence (`PriceLevel::snapshot_by_seq_into`, the exact order the matching
+//!   engine consumes resting orders). Previously the ids were read from
+//!   order-unstable structures (`order_locations` / per-level `iter_orders`) whose
+//!   `DashMap` hasher is seeded per instance, so two processes replaying the same
+//!   command stream could journal divergent `SequencerResult::MassCancelled`
+//!   payloads. The cancelled **set** and **count** are unchanged — only the order
+//!   of `cancelled_order_ids` is now byte-identical across processes and replay.
+//! - **`cancel_orders_by_user` is unchanged** and was already replay-stable: it
+//!   drains the `user_orders` index in admission-history order. That determinism
+//!   contract is now documented alongside the others.
+//! - No wire-format or public-API change: no new fields, no event-shape change,
+//!   and no `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump.
+//!
 //! ## What's New in Version 0.10.0
 //!
 //! ### v0.10.0 — host-driven GTD / DAY expiry sweep (#189)

--- a/src/orderbook/mass_cancel.rs
+++ b/src/orderbook/mass_cancel.rs
@@ -109,6 +109,25 @@ where
     ///
     /// A [`MassCancelResult`] with the count and IDs of all cancelled orders.
     ///
+    /// # Determinism
+    ///
+    /// [`MassCancelResult::cancelled_order_ids`] — and therefore the journaled
+    /// `SequencerResult::MassCancelled` payload — follows one fixed,
+    /// replay-stable order, identical to the
+    /// [`Self::evict_expired_orders`] contract:
+    ///
+    /// 1. **Bids first, then asks.**
+    /// 2. Within a side, price levels in **ascending price** order (the
+    ///    `SkipMap`'s natural key order — no sorting required).
+    /// 3. Within a price level, orders in **ascending insertion sequence** —
+    ///    the exact order the matching engine consumes resting orders
+    ///    (`PriceLevel::snapshot_by_seq_into`), i.e. oldest first.
+    ///
+    /// This traversal is independent of the `order_locations` / `user_orders`
+    /// `DashMap` iteration order (each instance seeds its own randomised
+    /// hasher), so the id sequence — and the `SequencerResult::MassCancelled`
+    /// event that carries it — is byte-identical across processes and replay.
+    ///
     /// # Examples
     ///
     /// ```
@@ -133,8 +152,28 @@ where
         self.cache.invalidate();
         trace!("Order book {}: Mass cancel ALL orders (bulk)", self.symbol);
 
-        // 1. Collect all order IDs before clearing
-        let cancelled_order_ids: Vec<Id> = self.order_locations.iter().map(|e| *e.key()).collect();
+        // 1. Collect all order IDs before clearing, in the fixed
+        // determinism-contract order (bids ascending price, then asks ascending
+        // price; within each level ascending insertion sequence). `SkipMap::iter`
+        // yields ascending price keys, and `snapshot_by_seq_into` yields the exact
+        // order the matching engine consumes resting orders — the `order_locations`
+        // `DashMap` iteration order must NOT be used here or replay would diverge
+        // across processes (its hasher is seeded per-instance). One scratch buffer
+        // is reused across levels to avoid a per-level allocation.
+        let mut cancelled_order_ids: Vec<Id> = Vec::new();
+        let mut level_orders: Vec<Arc<OrderType<()>>> = Vec::new();
+        for entry in self.bids.iter() {
+            entry.value().snapshot_by_seq_into(&mut level_orders);
+            for order in &level_orders {
+                cancelled_order_ids.push(order.id());
+            }
+        }
+        for entry in self.asks.iter() {
+            entry.value().snapshot_by_seq_into(&mut level_orders);
+            for order in &level_orders {
+                cancelled_order_ids.push(order.id());
+            }
+        }
         let cancelled_count = cancelled_order_ids.len();
 
         if cancelled_count == 0 {
@@ -225,6 +264,23 @@ where
     ///
     /// A [`MassCancelResult`] with the count and IDs of cancelled orders.
     ///
+    /// # Determinism
+    ///
+    /// [`MassCancelResult::cancelled_order_ids`] — and therefore the journaled
+    /// `SequencerResult::MassCancelled` payload — follows one fixed,
+    /// replay-stable order, matching the [`Self::evict_expired_orders`]
+    /// contract restricted to the requested side:
+    ///
+    /// 1. Price levels in **ascending price** order (the `SkipMap`'s natural
+    ///    key order — no sorting required).
+    /// 2. Within a price level, orders in **ascending insertion sequence** —
+    ///    the exact order the matching engine consumes resting orders
+    ///    (`PriceLevel::snapshot_by_seq_into`), i.e. oldest first.
+    ///
+    /// The traversal never observes the `order_locations` / `user_orders`
+    /// `DashMap` iteration order (seeded per instance), so the id sequence is
+    /// byte-identical across processes and replay.
+    ///
     /// # Examples
     ///
     /// ```
@@ -266,6 +322,24 @@ where
     /// # Returns
     ///
     /// A [`MassCancelResult`] with the count and IDs of cancelled orders.
+    ///
+    /// # Determinism
+    ///
+    /// [`MassCancelResult::cancelled_order_ids`] follows the user's
+    /// **admission-history order**: the `user_orders` index is a `Vec<Id>`
+    /// appended to (never reordered) as each of the user's orders is admitted
+    /// (`track_user_order`), and this method drains that `Vec` in place. Under a
+    /// serialized command stream — as replayed from the journal — that ordering
+    /// is fixed and byte-identical across processes, so the emitted
+    /// `SequencerResult::MassCancelled` payload is replay-stable without any
+    /// price-level traversal. This differs from the price-then-sequence order
+    /// used by [`Self::cancel_all_orders`] and [`Self::cancel_orders_by_side`],
+    /// but is equally deterministic.
+    ///
+    /// Caveat: the guarantee is scoped to *pure journal replay*. After a
+    /// snapshot restore (`restore_from_snapshot_package`) the `user_orders`
+    /// index is rebuilt by level iteration, so a by-user cancel issued after a
+    /// restore follows the rebuild order, not admission history.
     ///
     /// # Examples
     ///
@@ -324,6 +398,23 @@ where
     ///
     /// A [`MassCancelResult`] with the count and IDs of cancelled orders.
     ///
+    /// # Determinism
+    ///
+    /// [`MassCancelResult::cancelled_order_ids`] — and therefore the journaled
+    /// `SequencerResult::MassCancelled` payload — follows one fixed,
+    /// replay-stable order over the levels in `[min_price, max_price]`, matching
+    /// the [`Self::evict_expired_orders`] contract restricted to that range:
+    ///
+    /// 1. Price levels in **ascending price** order (the `SkipMap`'s ordered
+    ///    range iteration — no sorting required).
+    /// 2. Within a price level, orders in **ascending insertion sequence** —
+    ///    the exact order the matching engine consumes resting orders
+    ///    (`PriceLevel::snapshot_by_seq_into`), i.e. oldest first.
+    ///
+    /// The traversal never observes the `order_locations` / `user_orders`
+    /// `DashMap` iteration order (seeded per instance), so the id sequence is
+    /// byte-identical across processes and replay.
+    ///
     /// # Examples
     ///
     /// ```
@@ -362,11 +453,17 @@ where
             Side::Sell => &self.asks,
         };
 
+        // Collect in the determinism-contract order: ascending price (the
+        // `SkipMap`'s ordered range iteration), and within each level ascending
+        // insertion sequence via `snapshot_by_seq_into` — never the
+        // non-deterministic `iter_orders` view, which would make the journaled
+        // `MassCancelled` payload diverge across processes. One scratch buffer is
+        // reused across levels.
         let mut order_ids = Vec::new();
-
+        let mut level_orders: Vec<Arc<OrderType<()>>> = Vec::new();
         for entry in price_levels.range(min_price..=max_price) {
-            let level = entry.value();
-            for order in level.iter_orders() {
+            entry.value().snapshot_by_seq_into(&mut level_orders);
+            for order in &level_orders {
                 order_ids.push(order.id());
             }
         }
@@ -539,7 +636,16 @@ where
         MassCancelResult::new(count, cancelled_ids)
     }
 
-    /// Collect all order IDs on a given side by iterating price levels.
+    /// Collect all order IDs on a given side by iterating price levels in the
+    /// deterministic sweep order.
+    ///
+    /// Levels are visited in ascending price (the `SkipMap`'s natural key
+    /// order) and orders within a level in ascending insertion sequence via
+    /// `PriceLevel::snapshot_by_seq_into` — the exact order the matching engine
+    /// consumes resting orders. The non-deterministic `iter_orders` view is
+    /// deliberately avoided so the resulting id sequence (which lands in the
+    /// journaled `MassCancelled` payload) is replay-stable across processes. One
+    /// scratch buffer is reused across levels to avoid a per-level allocation.
     fn collect_order_ids_by_side(&self, side: Side) -> Vec<Id> {
         let price_levels = match side {
             Side::Buy => &self.bids,
@@ -547,9 +653,10 @@ where
         };
 
         let mut ids = Vec::new();
+        let mut level_orders: Vec<Arc<OrderType<()>>> = Vec::new();
         for entry in price_levels.iter() {
-            let level = entry.value();
-            for order in level.iter_orders() {
+            entry.value().snapshot_by_seq_into(&mut level_orders);
+            for order in &level_orders {
                 ids.push(order.id());
             }
         }
@@ -912,6 +1019,116 @@ mod tests {
         let book: OrderBook<()> = OrderBook::new("TEST");
         let result = book.cancel_all_orders();
         assert!(result.is_empty());
+    }
+
+    // ---- deterministic result ordering (#190) ----------------------------
+
+    /// A book with two price levels per side and two orders per level, admitted
+    /// in an interleaved order so the `order_locations` / `user_orders` DashMap
+    /// insertion order is scrambled relative to the price-then-insertion-seq
+    /// contract order. Returns the ids labelled `<side><price><a|b>` where `a`
+    /// is the earlier admission at that level.
+    struct InterleavedFixture {
+        book: OrderBook<()>,
+        b90a: Id,
+        b90b: Id,
+        b100a: Id,
+        b100b: Id,
+        a110a: Id,
+        a110b: Id,
+        a120a: Id,
+        a120b: Id,
+    }
+
+    fn interleaved_fixture() -> InterleavedFixture {
+        let book: OrderBook<()> = OrderBook::new("TEST");
+        let b90a = Id::new_uuid();
+        let b90b = Id::new_uuid();
+        let b100a = Id::new_uuid();
+        let b100b = Id::new_uuid();
+        let a110a = Id::new_uuid();
+        let a110b = Id::new_uuid();
+        let a120a = Id::new_uuid();
+        let a120b = Id::new_uuid();
+
+        // Interleaved admission across sides and levels. The `a` order at each
+        // level is admitted before its `b` sibling, so ascending insertion
+        // sequence within a level is `a` then `b`.
+        book.add_limit_order(b100a, 100, 1, Side::Buy, TimeInForce::Gtc, None)
+            .expect("b100a");
+        book.add_limit_order(a120a, 120, 1, Side::Sell, TimeInForce::Gtc, None)
+            .expect("a120a");
+        book.add_limit_order(b90a, 90, 1, Side::Buy, TimeInForce::Gtc, None)
+            .expect("b90a");
+        book.add_limit_order(a110a, 110, 1, Side::Sell, TimeInForce::Gtc, None)
+            .expect("a110a");
+        book.add_limit_order(b100b, 100, 1, Side::Buy, TimeInForce::Gtc, None)
+            .expect("b100b");
+        book.add_limit_order(a110b, 110, 1, Side::Sell, TimeInForce::Gtc, None)
+            .expect("a110b");
+        book.add_limit_order(b90b, 90, 1, Side::Buy, TimeInForce::Gtc, None)
+            .expect("b90b");
+        book.add_limit_order(a120b, 120, 1, Side::Sell, TimeInForce::Gtc, None)
+            .expect("a120b");
+
+        InterleavedFixture {
+            book,
+            b90a,
+            b90b,
+            b100a,
+            b100b,
+            a110a,
+            a110b,
+            a120a,
+            a120b,
+        }
+    }
+
+    #[test]
+    fn test_cancel_orders_by_side_interleaved_returns_price_then_seq_order() {
+        let f = interleaved_fixture();
+
+        let buy = f.book.cancel_orders_by_side(Side::Buy);
+        // Ascending price (90 then 100), FIFO within each level.
+        assert_eq!(
+            buy.cancelled_order_ids(),
+            &[f.b90a, f.b90b, f.b100a, f.b100b]
+        );
+
+        let sell = f.book.cancel_orders_by_side(Side::Sell);
+        assert_eq!(
+            sell.cancelled_order_ids(),
+            &[f.a110a, f.a110b, f.a120a, f.a120b]
+        );
+    }
+
+    #[test]
+    fn test_cancel_orders_by_price_range_interleaved_returns_price_then_seq_order() {
+        let f = interleaved_fixture();
+
+        // Single level: FIFO within the 90 level only.
+        let single = f.book.cancel_orders_by_price_range(Side::Buy, 90, 90);
+        assert_eq!(single.cancelled_order_ids(), &[f.b90a, f.b90b]);
+
+        // Remaining bid level (100) via a wider range that spans it.
+        let rest = f.book.cancel_orders_by_price_range(Side::Buy, 90, 200);
+        assert_eq!(rest.cancelled_order_ids(), &[f.b100a, f.b100b]);
+    }
+
+    #[test]
+    fn test_cancel_all_orders_interleaved_returns_bids_then_asks_order() {
+        let f = interleaved_fixture();
+
+        let all = f.book.cancel_all_orders();
+        // Bids ascending (90, then 100), then asks ascending (110, then 120);
+        // FIFO within every level.
+        assert_eq!(
+            all.cancelled_order_ids(),
+            &[
+                f.b90a, f.b90b, f.b100a, f.b100b, f.a110a, f.a110b, f.a120a, f.a120b,
+            ]
+        );
+        assert_eq!(all.cancelled_count(), 8);
     }
 
     // ---- evict_expired_orders --------------------------------------------

--- a/tests/unit/mass_cancel_determinism_tests.rs
+++ b/tests/unit/mass_cancel_determinism_tests.rs
@@ -1,0 +1,241 @@
+//! Replay byte-identity tests for mass-cancel result ordering (Issue #190).
+//!
+//! A mass-cancel result's `cancelled_order_ids` is journaled inside
+//! [`SequencerResult::MassCancelled`]. Replay must reproduce that payload
+//! byte-for-byte on an independently constructed book, and the post-session
+//! snapshot must match. Before #190 the `cancel_*` ops enumerated orders via
+//! order-unstable structures (the `DashMap` hasher is seeded per instance), so
+//! the replayed payload could diverge from the journaled original across
+//! processes. These tests are the regression guard.
+
+use orderbook_rs::OrderBook;
+use orderbook_rs::orderbook::mass_cancel::MassCancelResult;
+use orderbook_rs::orderbook::sequencer::{
+    InMemoryJournal, Journal, ReplayEngine, SequencerCommand, SequencerEvent, SequencerResult,
+    snapshots_match,
+};
+use pricelevel::{Hash32, Id, OrderType, Price, Quantity, Side, TimeInForce, TimestampMs};
+
+fn order(id: Id, price: u128, qty: u64, side: Side) -> OrderType<()> {
+    OrderType::Standard {
+        id,
+        price: Price::new(price),
+        quantity: Quantity::new(qty),
+        side,
+        time_in_force: TimeInForce::Gtc,
+        user_id: Hash32::zero(),
+        timestamp: TimestampMs::new(0),
+        extra_fields: (),
+    }
+}
+
+/// Extract the `MassCancelResult` from a journaled event, or fail the test.
+fn expect_mass_cancelled(result: &SequencerResult) -> &MassCancelResult {
+    match result {
+        SequencerResult::MassCancelled { result } => result,
+        other => panic!("expected MassCancelled, got {other:?}"),
+    }
+}
+
+/// #190: a session of adds + `CancelBySide` + `CancelByPriceRange` + `CancelAll`
+/// replays with byte-identical `MassCancelled` payloads and a matching snapshot.
+///
+/// The journal is built from a live book. A fresh, independently constructed
+/// book then re-executes the identical command stream read back from the
+/// journal, capturing each mass-cancel result; every replayed
+/// `cancelled_order_ids` vector (ids AND order) must equal the journaled
+/// original. Finally a full `ReplayEngine` pass must produce a snapshot that
+/// `snapshots_match` finds equal to the live book's — with residual orders
+/// surviving so the oracle is load-bearing rather than trivially empty.
+#[test]
+fn test_replay_mass_cancel_payloads_match_journaled_originals() {
+    let symbol = "TEST";
+    let journal: InMemoryJournal<()> = InMemoryJournal::new();
+    let live: OrderBook<()> = OrderBook::new(symbol);
+
+    let mut seq = 0u64;
+    let mut append = |command: SequencerCommand<()>, result: SequencerResult| {
+        let ev = SequencerEvent::<()> {
+            sequence_num: seq,
+            timestamp_ns: 0,
+            command,
+            result,
+        };
+        assert!(journal.append(&ev).is_ok(), "append seq {seq}");
+        seq += 1;
+    };
+
+    // Interleaved admission across two bid levels (90, 100), two ask levels to
+    // be range-cancelled (110, 120), and two surviving ask levels (130, 140) so
+    // the final CancelAll spans multiple levels — a stronger byte-identity probe
+    // than a single-level tail cancel.
+    let b90a = Id::new_uuid();
+    let b90b = Id::new_uuid();
+    let b100a = Id::new_uuid();
+    let b100b = Id::new_uuid();
+    let a110a = Id::new_uuid();
+    let a110b = Id::new_uuid();
+    let a120a = Id::new_uuid();
+    let a120b = Id::new_uuid();
+    let a130a = Id::new_uuid();
+    let a130b = Id::new_uuid();
+    let a140a = Id::new_uuid();
+    let a140b = Id::new_uuid();
+
+    let adds = [
+        order(b100a, 100, 1, Side::Buy),
+        order(a120a, 120, 1, Side::Sell),
+        order(a140a, 140, 1, Side::Sell),
+        order(b90a, 90, 1, Side::Buy),
+        order(a110a, 110, 1, Side::Sell),
+        order(a130a, 130, 1, Side::Sell),
+        order(b100b, 100, 1, Side::Buy),
+        order(a110b, 110, 1, Side::Sell),
+        order(a140b, 140, 1, Side::Sell),
+        order(b90b, 90, 1, Side::Buy),
+        order(a120b, 120, 1, Side::Sell),
+        order(a130b, 130, 1, Side::Sell),
+    ];
+    for ord in &adds {
+        assert!(live.add_order(*ord).is_ok(), "live add");
+        append(
+            SequencerCommand::AddOrder(*ord),
+            SequencerResult::OrderAdded { order_id: ord.id() },
+        );
+    }
+
+    // CancelBySide(Buy): all bids, ascending price then FIFO.
+    let by_side = live.cancel_orders_by_side(Side::Buy);
+    assert_eq!(
+        by_side.cancelled_order_ids(),
+        &[b90a, b90b, b100a, b100b],
+        "live CancelBySide order"
+    );
+    append(
+        SequencerCommand::CancelBySide { side: Side::Buy },
+        SequencerResult::MassCancelled {
+            result: by_side.clone(),
+        },
+    );
+
+    // CancelByPriceRange(Sell, 110, 120): the two mid ask levels.
+    let by_range = live.cancel_orders_by_price_range(Side::Sell, 110, 120);
+    assert_eq!(
+        by_range.cancelled_order_ids(),
+        &[a110a, a110b, a120a, a120b],
+        "live CancelByPriceRange order"
+    );
+    append(
+        SequencerCommand::CancelByPriceRange {
+            side: Side::Sell,
+            min_price: 110,
+            max_price: 120,
+        },
+        SequencerResult::MassCancelled {
+            result: by_range.clone(),
+        },
+    );
+
+    // CancelAll: the surviving 130 and 140 asks, ascending price then FIFO.
+    // Book is empty afterwards.
+    let all = live.cancel_all_orders();
+    assert_eq!(
+        all.cancelled_order_ids(),
+        &[a130a, a130b, a140a, a140b],
+        "live CancelAll order"
+    );
+    append(
+        SequencerCommand::CancelAll,
+        SequencerResult::MassCancelled {
+            result: all.clone(),
+        },
+    );
+
+    // Residual orders so the post-session snapshot is non-empty and the
+    // `snapshots_match` oracle is load-bearing.
+    let r_bid = order(Id::new_uuid(), 100, 3, Side::Buy);
+    let r_ask = order(Id::new_uuid(), 140, 4, Side::Sell);
+    for ord in [r_bid, r_ask] {
+        assert!(live.add_order(ord).is_ok(), "residual add");
+        append(
+            SequencerCommand::AddOrder(ord),
+            SequencerResult::OrderAdded { order_id: ord.id() },
+        );
+    }
+
+    // --- Part A: replayed mass-cancel payloads equal the journaled originals.
+    // Re-execute the journaled command stream on a fresh, independently
+    // constructed book (its own DashMap hasher) and compare every mass-cancel
+    // result to the one recorded live. ReplayEngine discards results, so this
+    // hand-rolled pass is what captures them.
+    let replay_book: OrderBook<()> = OrderBook::new(symbol);
+    let entries = journal.read_from(0).expect("read journal");
+    for item in entries {
+        let entry = item.expect("decode entry");
+        let ev = entry.event;
+        match &ev.command {
+            SequencerCommand::AddOrder(o) => {
+                assert!(replay_book.add_order(*o).is_ok(), "replay add");
+            }
+            SequencerCommand::CancelBySide { side } => {
+                let replayed = replay_book.cancel_orders_by_side(*side);
+                let journaled = expect_mass_cancelled(&ev.result);
+                assert_eq!(
+                    replayed.cancelled_order_ids(),
+                    journaled.cancelled_order_ids(),
+                    "CancelBySide payload divergence at seq {}",
+                    ev.sequence_num
+                );
+                assert_eq!(replayed.cancelled_count(), journaled.cancelled_count());
+            }
+            SequencerCommand::CancelByPriceRange {
+                side,
+                min_price,
+                max_price,
+            } => {
+                let replayed =
+                    replay_book.cancel_orders_by_price_range(*side, *min_price, *max_price);
+                let journaled = expect_mass_cancelled(&ev.result);
+                assert_eq!(
+                    replayed.cancelled_order_ids(),
+                    journaled.cancelled_order_ids(),
+                    "CancelByPriceRange payload divergence at seq {}",
+                    ev.sequence_num
+                );
+                assert_eq!(replayed.cancelled_count(), journaled.cancelled_count());
+            }
+            SequencerCommand::CancelAll => {
+                let replayed = replay_book.cancel_all_orders();
+                let journaled = expect_mass_cancelled(&ev.result);
+                assert_eq!(
+                    replayed.cancelled_order_ids(),
+                    journaled.cancelled_order_ids(),
+                    "CancelAll payload divergence at seq {}",
+                    ev.sequence_num
+                );
+                assert_eq!(replayed.cancelled_count(), journaled.cancelled_count());
+            }
+            _ => {}
+        }
+    }
+
+    // --- Part B: full ReplayEngine pass reproduces the live post-session state.
+    let (replayed, last_seq) =
+        ReplayEngine::<()>::replay_from(&journal, 0, symbol).expect("replay must succeed");
+    // `seq` is the count of appended events; the last event's sequence number
+    // is one less.
+    assert_eq!(last_seq, seq - 1);
+
+    let live_snap = live.create_snapshot(usize::MAX);
+    let replayed_snap = replayed.create_snapshot(usize::MAX);
+    assert!(
+        snapshots_match(&live_snap, &replayed_snap),
+        "post-session live and replayed snapshots must match"
+    );
+
+    // Sanity: exactly the residual bid and ask survived.
+    assert_eq!(replayed_snap.bids.len(), 1, "one residual bid survives");
+    assert_eq!(replayed_snap.asks.len(), 1, "one residual ask survives");
+    assert_eq!(replayed.best_bid(), Some(100));
+    assert_eq!(replayed.best_ask(), Some(140));
+}

--- a/tests/unit/mass_cancel_tests.rs
+++ b/tests/unit/mass_cancel_tests.rs
@@ -749,3 +749,134 @@ fn cancel_all_clears_book_completely() {
     assert_eq!(book.best_bid(), None);
     assert_eq!(book.best_ask(), None);
 }
+
+// ---------------------------------------------------------------------------
+// Cross-instance result determinism (Issue #190)
+//
+// The mass-cancel result order must be identical across independently
+// constructed books fed the same insertion sequence. Before the #190 fix,
+// `cancel_all_orders` collected ids from the `order_locations` DashMap, whose
+// hasher is seeded per instance, so two books with the same orders produced
+// different `cancelled_order_ids` orderings — and thus divergent journaled
+// `SequencerResult::MassCancelled` payloads. This is the regression guard.
+// ---------------------------------------------------------------------------
+
+/// A deterministic, interleaved admission plan: two price levels per side and
+/// two orders per level, admitted in an order that scrambles DashMap insertion
+/// relative to the price-then-insertion-sequence contract order. The `Id`s are
+/// generated once and shared, so every book built from the plan holds the
+/// identical order set.
+fn interleaved_plan() -> Vec<(Id, u128, Side)> {
+    vec![
+        (Id::new_uuid(), 100, Side::Buy),  // b100a
+        (Id::new_uuid(), 120, Side::Sell), // a120a
+        (Id::new_uuid(), 90, Side::Buy),   // b90a
+        (Id::new_uuid(), 110, Side::Sell), // a110a
+        (Id::new_uuid(), 100, Side::Buy),  // b100b
+        (Id::new_uuid(), 110, Side::Sell), // a110b
+        (Id::new_uuid(), 90, Side::Buy),   // b90b
+        (Id::new_uuid(), 120, Side::Sell), // a120b
+    ]
+}
+
+fn book_from_plan(plan: &[(Id, u128, Side)]) -> OrderBook<()> {
+    let book = new_book();
+    for &(id, price, side) in plan {
+        book.add_limit_order(id, price, 1, side, TimeInForce::Gtc, None)
+            .expect("add");
+    }
+    book
+}
+
+/// Build `instances` independent books from the same plan, run `op` on each,
+/// and return every result's id vector. Independent books seed independent
+/// DashMap hashers, so any hasher-order dependence surfaces as divergence.
+fn ids_across_instances<F>(plan: &[(Id, u128, Side)], instances: usize, op: F) -> Vec<Vec<Id>>
+where
+    F: Fn(&OrderBook<()>) -> MassCancelResult,
+{
+    (0..instances)
+        .map(|_| {
+            let book = book_from_plan(plan);
+            op(&book).cancelled_order_ids().to_vec()
+        })
+        .collect()
+}
+
+fn assert_all_identical(runs: &[Vec<Id>]) {
+    let first = runs.first().expect("at least one run");
+    for (i, run) in runs.iter().enumerate() {
+        assert_eq!(run, first, "instance {i} diverged from instance 0");
+    }
+}
+
+#[test]
+fn test_cancel_all_orders_cross_instance_returns_identical_ids() {
+    let plan = interleaved_plan();
+    let runs = ids_across_instances(&plan, 8, |book| book.cancel_all_orders());
+    assert_eq!(runs[0].len(), 8);
+    assert_all_identical(&runs);
+}
+
+#[test]
+fn test_cancel_orders_by_side_cross_instance_returns_identical_ids() {
+    let plan = interleaved_plan();
+    let buy_runs = ids_across_instances(&plan, 8, |book| book.cancel_orders_by_side(Side::Buy));
+    assert_eq!(buy_runs[0].len(), 4);
+    assert_all_identical(&buy_runs);
+
+    let sell_runs = ids_across_instances(&plan, 8, |book| book.cancel_orders_by_side(Side::Sell));
+    assert_eq!(sell_runs[0].len(), 4);
+    assert_all_identical(&sell_runs);
+}
+
+#[test]
+fn test_cancel_orders_by_price_range_cross_instance_returns_identical_ids() {
+    let plan = interleaved_plan();
+    let runs = ids_across_instances(&plan, 8, |book| {
+        book.cancel_orders_by_price_range(Side::Buy, 90, 100)
+    });
+    assert_eq!(runs[0].len(), 4);
+    assert_all_identical(&runs);
+}
+
+#[test]
+fn test_cancel_orders_by_user_cross_instance_returns_identical_ids() {
+    // cancel_orders_by_user was already deterministic (admission-history order);
+    // this pins that it stays stable across independent instances.
+    let user = uid(7);
+    let ids: Vec<Id> = (0..6).map(|_| Id::new_uuid()).collect();
+    let prices = [100u128, 120, 90, 110, 100, 90];
+    let sides = [
+        Side::Buy,
+        Side::Sell,
+        Side::Buy,
+        Side::Sell,
+        Side::Buy,
+        Side::Buy,
+    ];
+
+    let build = || {
+        let book = new_book();
+        for i in 0..ids.len() {
+            book.add_limit_order_with_user(
+                ids[i],
+                prices[i],
+                1,
+                sides[i],
+                TimeInForce::Gtc,
+                user,
+                None,
+            )
+            .expect("add");
+        }
+        book.cancel_orders_by_user(user)
+            .cancelled_order_ids()
+            .to_vec()
+    };
+
+    let runs: Vec<Vec<Id>> = (0..8).map(|_| build()).collect();
+    // Admission-history order: exactly the sequence the ids were added in.
+    assert_eq!(runs[0], ids);
+    assert_all_identical(&runs);
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -11,6 +11,7 @@ mod integration_workflow_tests;
 mod kill_switch_tests;
 mod manager_coverage_tests;
 mod market_order_by_amount_tests;
+mod mass_cancel_determinism_tests;
 mod mass_cancel_tests;
 mod matching_coverage_tests;
 mod matching_coverage_tests_extended;


### PR DESCRIPTION
## Summary

Fixes #190 and releases **0.10.1** (patch — behavior-only, `cargo semver-checks` clean: 196 pass).

### Problem
`cancel_all_orders` collected IDs via the `order_locations` DashMap scan (randomized per-instance hasher); `cancel_orders_by_side` / `cancel_orders_by_price_range` used the unstable `level.iter_orders()` view. That ordering lands in `MassCancelResult.cancelled_order_ids`, which is journaled inside `SequencerResult::MassCancelled` — replay was not byte-identical across processes.

### Fix
All three now use the deterministic traversal introduced by `evict_expired_orders` (0.10.0): bids→asks, ascending price (SkipMap natural order), ascending insertion seq within level (`snapshot_by_seq_into`, reused scratch buffer). Cancelled **sets and counts unchanged** — only ordering became deterministic. `cancel_orders_by_user` untouched: its admission-history order was already replay-stable (documented, incl. the snapshot-restore caveat → follow-up #192).

### Tests
- Exact-order asserts on interleaved multi-level books (co-located).
- Cross-instance determinism over 8 independent books per op — **regression demonstrated: fails 5/5 runs on pre-fix `cancel_all_orders`**.
- Replay byte-identity: journaled `MassCancelled` payloads (ids AND order) equal on re-execution + `ReplayEngine` + `snapshots_match`; runs under default features (uses ungated `InMemoryJournal`).

### Review
Workflow panel: determinism-auditor + architect — zero blockers; nits applied (test un-gated from `journal` feature, by-user doc caveat). Follow-up filed: #192 (`restore_from_snapshot_package` rebuilds `user_orders` in unstable order).

## Gates
`make pre-push` clean; clippy `-D warnings` zero; `cargo test --all-features`: 1326 passed / 0 failed; `cargo semver-checks --baseline-rev main`: patch-compatible.

Closes #190.