### PR TITLE
fix: deterministic user_orders rebuild on snapshot restore — 0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] — 2026-07-11
+
+### Fixed
+
+- **Deterministic `user_orders` rebuild on snapshot restore (#192).**
+  `OrderBook::restore_from_snapshot_package` (and `restore_from_snapshot`)
+  rebuilt the `user_orders` index by walking each level's order-unstable
+  `iter_orders()` view, whose `DashMap` hasher is seeded per instance. As a
+  result the per-user `Vec<Id>` was rebuilt in a different order on each fresh
+  book, and a `cancel_orders_by_user` issued after the restore returned a
+  `MassCancelResult::cancelled_order_ids` sequence that diverged across restores
+  of the same package. The rebuild now walks price levels in the same fixed
+  price-then-insertion-sequence order the mass-cancel and eviction sweeps use
+  (bids ascending price, then asks ascending price; within each level ascending
+  insertion sequence via `PriceLevel::snapshot_by_seq_into`), so the restored
+  `user_orders` index — and therefore any subsequent by-user cancel — is
+  byte-identical across every restore of the same package. This order reflects
+  the resting book at snapshot time, not the original admission history (a
+  snapshot cannot recover that), but it is now fully deterministic. Pure journal
+  replay was unaffected and is unchanged. `order_locations` is a map, so its
+  rebuild order never leaked into emitted output.
+- No wire-format or public-API change: no new fields, no event-shape change, and
+  no `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump.
+
 ## [0.10.1] — 2026-07-10
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orderbook-rs"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."

--- a/README.md
+++ b/README.md
@@ -46,6 +46,24 @@ This order book engine is built with the following design principles:
 - **Research**: Platform for studying market microstructure and order flow
 - **Educational**: Reference implementation for understanding modern exchange architecture
 
+### What's New in Version 0.10.2
+
+#### v0.10.2 — deterministic `user_orders` rebuild on snapshot restore (#192)
+
+- **`cancel_orders_by_user` is now byte-identical across restores.**
+  `restore_from_snapshot_package` rebuilt the `user_orders` index from each
+  level's order-unstable `iter_orders()` view, so the per-user `Vec<Id>` came
+  back in a different order on every fresh book (the `DashMap` hasher is seeded
+  per instance) and a post-restore `cancel_orders_by_user` diverged across
+  restores of the same package. The rebuild now walks price levels in the same
+  fixed price-then-insertion-sequence order the mass-cancel sweeps use
+  (`PriceLevel::snapshot_by_seq_into`), so the restored index — and any
+  subsequent by-user cancel — is deterministic across every restore. The order
+  reflects the resting book at snapshot time, not the original admission
+  history (a snapshot cannot recover that). Pure journal replay was unaffected.
+- No wire-format or public-API change: no new fields, no event-shape change,
+  and no `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump.
+
 ### What's New in Version 0.10.1
 
 #### v0.10.1 — replay-stable mass-cancel result ordering (#190)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,24 @@
 //! - **Research**: Platform for studying market microstructure and order flow
 //! - **Educational**: Reference implementation for understanding modern exchange architecture
 //!
+//! ## What's New in Version 0.10.2
+//!
+//! ### v0.10.2 — deterministic `user_orders` rebuild on snapshot restore (#192)
+//!
+//! - **`cancel_orders_by_user` is now byte-identical across restores.**
+//!   `restore_from_snapshot_package` rebuilt the `user_orders` index from each
+//!   level's order-unstable `iter_orders()` view, so the per-user `Vec<Id>` came
+//!   back in a different order on every fresh book (the `DashMap` hasher is seeded
+//!   per instance) and a post-restore `cancel_orders_by_user` diverged across
+//!   restores of the same package. The rebuild now walks price levels in the same
+//!   fixed price-then-insertion-sequence order the mass-cancel sweeps use
+//!   (`PriceLevel::snapshot_by_seq_into`), so the restored index — and any
+//!   subsequent by-user cancel — is deterministic across every restore. The order
+//!   reflects the resting book at snapshot time, not the original admission
+//!   history (a snapshot cannot recover that). Pure journal replay was unaffected.
+//! - No wire-format or public-API change: no new fields, no event-shape change,
+//!   and no `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump.
+//!
 //! ## What's New in Version 0.10.1
 //!
 //! ### v0.10.1 — replay-stable mass-cancel result ordering (#190)

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -3061,11 +3061,23 @@ where
             self.asks.insert(price, arc_level);
         }
 
-        // Rebuild order location and user_orders maps
+        // Rebuild the `order_locations` and `user_orders` indices in one fixed,
+        // replay-stable order: bids ascending price then asks ascending price
+        // (the `SkipMap`'s natural key order), and within each level ascending
+        // insertion sequence via `PriceLevel::snapshot_by_seq_into` — never the
+        // `DashMap`-backed `iter_orders` view, whose per-instance-hashed order
+        // would leak into the `user_orders` `Vec<Id>` layout and make a
+        // subsequent `cancel_orders_by_user` diverge across restores of the same
+        // package (#192). This is NOT the original admission history — a snapshot
+        // cannot recover that — but it is deterministic. `order_locations` is a
+        // map, so its rebuild order does not leak; only `user_orders`, whose
+        // per-user `Vec` order is consumed by `cancel_orders_by_user`, needs the
+        // fixed traversal. One scratch buffer is reused across levels.
+        let mut level_orders: Vec<Arc<OrderType<()>>> = Vec::new();
         for item in self.bids.iter() {
             let price = *item.key();
-            let level = item.value();
-            for order in level.iter_orders() {
+            item.value().snapshot_by_seq_into(&mut level_orders);
+            for order in &level_orders {
                 self.order_locations.insert(order.id(), (price, Side::Buy));
                 self.track_user_order(order.user_id(), order.id());
             }
@@ -3073,8 +3085,8 @@ where
 
         for item in self.asks.iter() {
             let price = *item.key();
-            let level = item.value();
-            for order in level.iter_orders() {
+            item.value().snapshot_by_seq_into(&mut level_orders);
+            for order in &level_orders {
                 self.order_locations.insert(order.id(), (price, Side::Sell));
                 self.track_user_order(order.user_id(), order.id());
             }

--- a/src/orderbook/mass_cancel.rs
+++ b/src/orderbook/mass_cancel.rs
@@ -336,10 +336,19 @@ where
     /// used by [`Self::cancel_all_orders`] and [`Self::cancel_orders_by_side`],
     /// but is equally deterministic.
     ///
-    /// Caveat: the guarantee is scoped to *pure journal replay*. After a
-    /// snapshot restore (`restore_from_snapshot_package`) the `user_orders`
-    /// index is rebuilt by level iteration, so a by-user cancel issued after a
-    /// restore follows the rebuild order, not admission history.
+    /// After a snapshot restore (`restore_from_snapshot_package`) the
+    /// `user_orders` index is rebuilt from the resting-order layout rather than
+    /// replayed from admission events, so a by-user cancel issued post-restore
+    /// does **not** follow the original admission history. It is still fully
+    /// deterministic: the rebuild walks price levels in the same fixed
+    /// price-then-insertion-sequence order as [`Self::cancel_all_orders`] (bids
+    /// ascending price, then asks ascending price; within each level ascending
+    /// insertion sequence via `PriceLevel::snapshot_by_seq_into`), so the
+    /// per-user `Vec<Id>` — and therefore this method's
+    /// [`MassCancelResult::cancelled_order_ids`] — is byte-identical across every
+    /// restore of the same package (#192). The order simply reflects the resting
+    /// book at snapshot time, not the sequence in which the user's orders were
+    /// originally admitted.
     ///
     /// # Examples
     ///

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -28,6 +28,7 @@ mod replay_coverage_tests;
 mod replay_determinism;
 #[cfg(feature = "special_orders")]
 mod repricing_determinism_tests;
+mod restore_user_orders_determinism_tests;
 mod risk_layer_tests;
 mod sequencer_types_tests;
 mod snapshot_restore_tests;

--- a/tests/unit/restore_user_orders_determinism_tests.rs
+++ b/tests/unit/restore_user_orders_determinism_tests.rs
@@ -1,0 +1,196 @@
+//! Cross-instance determinism of `cancel_orders_by_user` after a snapshot
+//! restore (Issue #192).
+//!
+//! `restore_from_snapshot_package` rebuilds the `user_orders`
+//! (`DashMap<Hash32, Vec<Id>>`) index by walking the restored resting orders.
+//! Before #192 that walk used the `DashMap`-backed, order-unstable
+//! `iter_orders()` view, so each freshly constructed book (its own per-instance
+//! hasher) rebuilt the per-user `Vec<Id>` in a different order. A
+//! `cancel_orders_by_user` issued after the restore then returned a
+//! `cancelled_order_ids` sequence that diverged across restores of the *same*
+//! package — which would break replay if that payload were journaled.
+//!
+//! The fix walks price levels in a fixed price-then-insertion-sequence order
+//! (bids ascending price, then asks ascending price; within each level ascending
+//! insertion sequence via `PriceLevel::snapshot_by_seq_into`), so the rebuild —
+//! and therefore the by-user cancel — is byte-identical across every restore of
+//! the same package. It is NOT the original admission history (a snapshot cannot
+//! recover that), but it is deterministic. These tests are the regression guard.
+
+use orderbook_rs::OrderBook;
+use pricelevel::{Hash32, Id, Side, TimeInForce};
+
+/// User A — the user whose orders we assert on. Spread across two bid levels
+/// (one with two orders) and two ask levels (one with two orders).
+fn user_a() -> Hash32 {
+    Hash32::new([0xAA; 32])
+}
+
+/// User B — interleaving noise so the admission stream, and hence the
+/// `DashMap` insertion order, is scrambled relative to the price-then-seq
+/// contract order.
+fn user_b() -> Hash32 {
+    Hash32::new([0xBB; 32])
+}
+
+/// Ids for user A's six orders, labelled `<side><price>[_n]`. Within a shared
+/// level, the lower suffix is admitted first (so ascending insertion sequence
+/// at that level is `_1` then `_2`).
+struct UserAOrders {
+    b90: Id,
+    b100_1: Id,
+    b100_2: Id,
+    a110: Id,
+    a120_1: Id,
+    a120_2: Id,
+}
+
+/// Build a book, admit user A's and user B's orders in a deliberately scrambled
+/// order across sides and levels, and return the book plus user A's ids.
+///
+/// The intra-level relative admission order of A's paired orders is preserved
+/// (`b100_1` before `b100_2`, `a120_1` before `a120_2`) so the expected
+/// price-then-insertion-sequence order is unambiguous.
+fn build_scrambled_book() -> (OrderBook<()>, UserAOrders) {
+    let book: OrderBook<()> = OrderBook::new("TEST");
+    let a = user_a();
+    let b = user_b();
+
+    let ids = UserAOrders {
+        b90: Id::new_uuid(),
+        b100_1: Id::new_uuid(),
+        b100_2: Id::new_uuid(),
+        a110: Id::new_uuid(),
+        a120_1: Id::new_uuid(),
+        a120_2: Id::new_uuid(),
+    };
+
+    let b_b90 = Id::new_uuid();
+    let b_b100 = Id::new_uuid();
+    let b_a110 = Id::new_uuid();
+    let b_a120 = Id::new_uuid();
+
+    let add = |id: Id, price: u128, side: Side, user: Hash32| {
+        assert!(
+            book.add_limit_order_with_user(id, price, 1, side, TimeInForce::Gtc, user, None)
+                .is_ok(),
+            "add order at price {price}"
+        );
+    };
+
+    // Interleaved admission across users, sides, and levels. The admission
+    // sequence is intentionally unrelated to the price-then-seq contract order,
+    // but A's paired orders keep their relative order within each level.
+    add(ids.b100_1, 100, Side::Buy, a);
+    add(b_a120, 120, Side::Sell, b);
+    add(ids.a120_1, 120, Side::Sell, a);
+    add(b_b90, 90, Side::Buy, b);
+    add(ids.b90, 90, Side::Buy, a);
+    add(ids.a110, 110, Side::Sell, a);
+    add(b_b100, 100, Side::Buy, b);
+    add(ids.b100_2, 100, Side::Buy, a);
+    add(b_a110, 110, Side::Sell, b);
+    add(ids.a120_2, 120, Side::Sell, a);
+
+    (book, ids)
+}
+
+/// The documented order a post-restore `cancel_orders_by_user(user_a)` returns:
+/// bids ascending price, then asks ascending price; within each level ascending
+/// insertion sequence (oldest first).
+fn expected_user_a_order(ids: &UserAOrders) -> Vec<Id> {
+    vec![
+        ids.b90,    // bid 90
+        ids.b100_1, // bid 100, oldest
+        ids.b100_2, // bid 100, next
+        ids.a110,   // ask 110
+        ids.a120_1, // ask 120, oldest
+        ids.a120_2, // ask 120, next
+    ]
+}
+
+/// Restore the same JSON-serialized package into `n` freshly constructed books
+/// (each with its own randomised `DashMap` hasher) and return each restored
+/// book's `cancel_orders_by_user(user_a)` id vector.
+fn restore_and_cancel_by_user(json: &str, n: usize) -> Vec<Vec<Id>> {
+    let mut results = Vec::with_capacity(n);
+    for _ in 0..n {
+        let mut restored: OrderBook<()> = OrderBook::new("TEST");
+        match restored.restore_from_snapshot_json(json) {
+            Ok(()) => {}
+            Err(e) => panic!("restore must succeed: {e}"),
+        }
+        let result = restored.cancel_orders_by_user(user_a());
+        results.push(result.cancelled_order_ids().to_vec());
+    }
+    results
+}
+
+/// #192: restoring the same package into several fresh books and cancelling by
+/// user must yield a byte-identical `cancelled_order_ids` vector every time.
+///
+/// Each restore targets an independently constructed book, so its `user_orders`
+/// `DashMap` is seeded with a distinct hasher. If the rebuild observed that
+/// hasher's iteration order (the pre-#192 `iter_orders` path), the vectors would
+/// disagree across restores with high probability. With the price-then-seq
+/// rebuild they must all be equal.
+#[test]
+fn test_restore_then_cancel_by_user_cross_instance_returns_identical_order() {
+    let (book, ids) = build_scrambled_book();
+    let json = match book.snapshot_to_json(usize::MAX) {
+        Ok(j) => j,
+        Err(e) => panic!("snapshot_to_json must succeed: {e}"),
+    };
+
+    let results = restore_and_cancel_by_user(&json, 8);
+
+    // Every restore cancelled exactly user A's six orders.
+    for (i, r) in results.iter().enumerate() {
+        assert_eq!(r.len(), 6, "restore {i} cancelled the wrong count");
+    }
+
+    // All restores agree byte-for-byte with the first.
+    let first = &results[0];
+    for (i, r) in results.iter().enumerate().skip(1) {
+        assert_eq!(
+            r, first,
+            "restore {i} produced a different by-user cancel order than restore 0 — \
+             user_orders rebuild is not deterministic across instances"
+        );
+    }
+
+    // And the agreed order is the documented price-then-seq order, not merely
+    // some arbitrary-but-stable permutation.
+    assert_eq!(*first, expected_user_a_order(&ids));
+}
+
+/// #192: the restored book's by-user cancel returns the exact documented
+/// price-then-insertion-sequence order — bids ascending, then asks ascending,
+/// oldest-first within each level.
+#[test]
+fn test_restore_then_cancel_by_user_returns_price_then_seq_order() {
+    let (book, ids) = build_scrambled_book();
+    let json = match book.snapshot_to_json(usize::MAX) {
+        Ok(j) => j,
+        Err(e) => panic!("snapshot_to_json must succeed: {e}"),
+    };
+
+    let mut restored: OrderBook<()> = OrderBook::new("TEST");
+    match restored.restore_from_snapshot_json(&json) {
+        Ok(()) => {}
+        Err(e) => panic!("restore must succeed: {e}"),
+    }
+
+    let result = restored.cancel_orders_by_user(user_a());
+    assert_eq!(result.cancelled_count(), 6);
+    assert_eq!(
+        result.cancelled_order_ids(),
+        expected_user_a_order(&ids).as_slice(),
+    );
+
+    // User B's orders are untouched by the user-A cancel.
+    assert_eq!(
+        restored.cancel_orders_by_user(user_b()).cancelled_count(),
+        4
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #192 and releases **0.10.2** (patch — behavior-only, `cargo semver-checks`: 196 pass).

### Problem
`restore_from_snapshot` rebuilt `user_orders` from each level's order-unstable `iter_orders()` view. Two restores of the same package produced differently-ordered per-user `Vec<Id>`s (per-instance DashMap hasher), so a post-restore `cancel_orders_by_user` — whose result order is journaled in `SequencerResult::MassCancelled` — diverged across restores. Pure journal replay was unaffected.

### Fix
Both rebuild loops now use the fixed price-then-insertion-seq traversal (`snapshot_by_seq_into`, reused scratch buffer — same contract as #190's mass-cancel sweeps). The rebuilt order is deterministic across every restore; it reflects the resting book at snapshot time, not admission history (unrecoverable from a snapshot) — the `cancel_orders_by_user` docs state this honestly. `order_locations` and risk-counter rebuilds verified order-independent.

### Tests
- Cross-instance: identical JSON package restored into **8** fresh books → byte-identical `cancelled_order_ids`.
- Exact-order assert on a deliberately admission-scrambled book.
- **Both fail against the pre-fix code** (verified by temporarily reverting the rebuild loop).

### Review
determinism-auditor: **CLEAN** — zero findings. Observation out of scope filed as #194 (`special_order_tracker` state doesn't survive restore).

## Gates
`make pre-push` clean; clippy `-D warnings` zero; `cargo test --all-features`: 783 lib + 471 integration + doctests, 0 failed; `cargo semver-checks --baseline-rev main`: patch-compatible.

Closes #192.