### PR TITLE
fix: special_order_tracker survives snapshot restore — 0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.3] — 2026-07-11
+
+### Fixed
+
+- **Special-order tracker now survives snapshot restore (#194).**
+  `OrderBook::restore_from_snapshot` (the shared rebuild path behind
+  `restore_from_snapshot_package` and the JSON entry points) rebuilt the resting
+  bids / asks, `order_locations`, and `user_orders`, but left the
+  `special_order_tracker` (`special_orders` feature) freshly-initialized. A
+  restored resting pegged or trailing-stop order was therefore never
+  re-registered with the tracker, so `reprice_pegged_orders` /
+  `reprice_trailing_stops` never visited it and the order stayed stuck at its
+  snapshotted price. The rebuild now re-registers every restored resting special
+  order in the same fixed price-then-insertion-sequence walk that repopulates
+  `order_locations` / `user_orders` (a single pass, no extra traversal), so
+  re-pricing resumes after restore. The tracker holds only order ids; the
+  trailing-stop watermark (`last_reference_price`) and the pegged / stop price
+  are part of the order data and survive the snapshot round-trip, so no
+  re-pricing state is lost or re-initialized. `restore_from_snapshot` clears the
+  tracker before the rebuild so a restore is a full replacement. Non-special
+  orders and books with no special orders are unaffected.
+- No wire-format or public-API change: no new fields, no event-shape change, and
+  no `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump.
+
 ## [0.10.2] — 2026-07-11
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orderbook-rs"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."

--- a/README.md
+++ b/README.md
@@ -46,6 +46,23 @@ This order book engine is built with the following design principles:
 - **Research**: Platform for studying market microstructure and order flow
 - **Educational**: Reference implementation for understanding modern exchange architecture
 
+### What's New in Version 0.10.3
+
+#### v0.10.3 — special-order tracker survives snapshot restore (#194)
+
+- **Restored pegged / trailing-stop orders re-price again.**
+  `restore_from_snapshot` rebuilt the resting book but left the
+  `special_order_tracker` (the `special_orders` feature) freshly-initialized,
+  so a restored pegged or trailing-stop order was never re-registered and
+  never re-priced after a snapshot restore. The shared rebuild pass now
+  re-registers every restored resting special order in the same deterministic
+  price-then-insertion-sequence walk that repopulates `order_locations` /
+  `user_orders`. The tracker holds only order ids — the trailing-stop
+  watermark (`last_reference_price`) and the pegged / stop price live in the
+  order data and survive the round-trip, so no re-pricing state is lost.
+- No wire-format or public-API change: no new fields, no event-shape change,
+  and no `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump.
+
 ### What's New in Version 0.10.2
 
 #### v0.10.2 — deterministic `user_orders` rebuild on snapshot restore (#192)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,23 @@
 //! - **Research**: Platform for studying market microstructure and order flow
 //! - **Educational**: Reference implementation for understanding modern exchange architecture
 //!
+//! ## What's New in Version 0.10.3
+//!
+//! ### v0.10.3 — special-order tracker survives snapshot restore (#194)
+//!
+//! - **Restored pegged / trailing-stop orders re-price again.**
+//!   `restore_from_snapshot` rebuilt the resting book but left the
+//!   `special_order_tracker` (the `special_orders` feature) freshly-initialized,
+//!   so a restored pegged or trailing-stop order was never re-registered and
+//!   never re-priced after a snapshot restore. The shared rebuild pass now
+//!   re-registers every restored resting special order in the same deterministic
+//!   price-then-insertion-sequence walk that repopulates `order_locations` /
+//!   `user_orders`. The tracker holds only order ids — the trailing-stop
+//!   watermark (`last_reference_price`) and the pegged / stop price live in the
+//!   order data and survive the round-trip, so no re-pricing state is lost.
+//! - No wire-format or public-API change: no new fields, no event-shape change,
+//!   and no `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump.
+//!
 //! ## What's New in Version 0.10.2
 //!
 //! ### v0.10.2 — deterministic `user_orders` rebuild on snapshot restore (#192)

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -3019,6 +3019,16 @@ where
     }
 
     /// Restore the book state from a snapshot, without checksum validation.
+    ///
+    /// Rebuilds the resting bids / asks, the `order_locations` and
+    /// `user_orders` indices, and — under the `special_orders` feature — the
+    /// special-order tracker, so restored pegged / trailing-stop orders resume
+    /// re-pricing (#194). The tracker holds only order ids; the trailing-stop
+    /// watermark (`last_reference_price`) and the pegged / stop price are part
+    /// of the order data and survive the snapshot round-trip, so no watermark
+    /// state is lost or re-initialized. The rebuild uses the deterministic
+    /// price-then-insertion-sequence traversal so the restore stays
+    /// replay-stable (#190 / #192).
     pub fn restore_from_snapshot(&self, snapshot: OrderBookSnapshot) -> Result<(), OrderBookError> {
         if snapshot.symbol != self.symbol {
             return Err(OrderBookError::InvalidOperation {
@@ -3040,6 +3050,11 @@ where
         }
         self.order_locations.clear();
         self.user_orders.clear();
+        // The special-order tracker is a full replacement on restore: clear it
+        // here and rebuild it below from the restored resting orders, mirroring
+        // the `user_orders` / `order_locations` rebuild (#194).
+        #[cfg(feature = "special_orders")]
+        self.special_order_tracker.clear();
         self.has_traded.store(false, Ordering::Relaxed);
         self.last_trade_price.store(0);
         self.has_market_close.store(false, Ordering::Relaxed);
@@ -3061,18 +3076,21 @@ where
             self.asks.insert(price, arc_level);
         }
 
-        // Rebuild the `order_locations` and `user_orders` indices in one fixed,
-        // replay-stable order: bids ascending price then asks ascending price
-        // (the `SkipMap`'s natural key order), and within each level ascending
-        // insertion sequence via `PriceLevel::snapshot_by_seq_into` — never the
-        // `DashMap`-backed `iter_orders` view, whose per-instance-hashed order
-        // would leak into the `user_orders` `Vec<Id>` layout and make a
-        // subsequent `cancel_orders_by_user` diverge across restores of the same
-        // package (#192). This is NOT the original admission history — a snapshot
-        // cannot recover that — but it is deterministic. `order_locations` is a
-        // map, so its rebuild order does not leak; only `user_orders`, whose
-        // per-user `Vec` order is consumed by `cancel_orders_by_user`, needs the
-        // fixed traversal. One scratch buffer is reused across levels.
+        // Rebuild the `order_locations` and `user_orders` indices, and (under
+        // `special_orders`) re-register pegged / trailing-stop orders with the
+        // special-order tracker, in one fixed, replay-stable pass: bids
+        // ascending price then asks ascending price (the `SkipMap`'s natural key
+        // order), and within each level ascending insertion sequence via
+        // `PriceLevel::snapshot_by_seq_into` — never the `DashMap`-backed
+        // `iter_orders` view, whose per-instance-hashed order would leak into the
+        // `user_orders` `Vec<Id>` layout and make a subsequent
+        // `cancel_orders_by_user` diverge across restores of the same package
+        // (#192). This is NOT the original admission history — a snapshot cannot
+        // recover that — but it is deterministic. `order_locations` and the
+        // tracker's `DashSet`s are order-insensitive, so their rebuild order does
+        // not leak; only `user_orders`, whose per-user `Vec` order is consumed by
+        // `cancel_orders_by_user`, needs the fixed traversal. One scratch buffer
+        // is reused across levels.
         let mut level_orders: Vec<Arc<OrderType<()>>> = Vec::new();
         for item in self.bids.iter() {
             let price = *item.key();
@@ -3080,6 +3098,8 @@ where
             for order in &level_orders {
                 self.order_locations.insert(order.id(), (price, Side::Buy));
                 self.track_user_order(order.user_id(), order.id());
+                #[cfg(feature = "special_orders")]
+                self.reregister_special_order(order.as_ref());
             }
         }
 
@@ -3089,10 +3109,40 @@ where
             for order in &level_orders {
                 self.order_locations.insert(order.id(), (price, Side::Sell));
                 self.track_user_order(order.user_id(), order.id());
+                #[cfg(feature = "special_orders")]
+                self.reregister_special_order(order.as_ref());
             }
         }
 
         Ok(())
+    }
+
+    /// Re-register a restored resting order with the special-order tracker
+    /// when it is a pegged or trailing-stop order.
+    ///
+    /// Mirrors the admission-time registration in
+    /// [`add_order`](Self::add_order) so restored pegged / trailing-stop
+    /// orders resume re-pricing after a snapshot restore (#194). Called once
+    /// per restored resting order from the deterministic price-then-sequence
+    /// rebuild pass in [`restore_from_snapshot`](Self::restore_from_snapshot),
+    /// so any tracker mutation stays replay-stable.
+    ///
+    /// The tracker holds only order ids — the trailing-stop watermark
+    /// (`last_reference_price`) and the pegged / stop price live in the
+    /// order data itself and survive the snapshot round-trip, so nothing is
+    /// re-initialized here; re-registering the id fully restores re-pricing.
+    #[cfg(feature = "special_orders")]
+    #[inline]
+    fn reregister_special_order(&self, order: &OrderType<()>) {
+        match order {
+            OrderType::PeggedOrder { id, .. } => {
+                self.special_order_tracker.register_pegged_order(*id);
+            }
+            OrderType::TrailingStop { id, .. } => {
+                self.special_order_tracker.register_trailing_stop(*id);
+            }
+            _ => {}
+        }
     }
 
     /// Creates an enriched snapshot with pre-calculated metrics

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -32,4 +32,6 @@ mod restore_user_orders_determinism_tests;
 mod risk_layer_tests;
 mod sequencer_types_tests;
 mod snapshot_restore_tests;
+#[cfg(feature = "special_orders")]
+mod special_order_restore_tests;
 mod validation_tests;

--- a/tests/unit/special_order_restore_tests.rs
+++ b/tests/unit/special_order_restore_tests.rs
@@ -1,0 +1,288 @@
+//! Restore-path re-registration of special orders with the re-pricing tracker
+//! (Issue #194).
+//!
+//! `restore_from_snapshot` (the shared rebuild path behind both
+//! `restore_from_snapshot_package` and the JSON entry points) rebuilds the
+//! resting book but, before #194, left the `special_order_tracker`
+//! freshly-initialized. A restored pegged / trailing-stop order was therefore
+//! never re-registered and never re-priced again after a snapshot restore. The
+//! fix re-registers every restored resting special order from the same
+//! deterministic price-then-insertion-sequence rebuild pass that repopulates
+//! `order_locations` / `user_orders`.
+//!
+//! The tracker holds only order ids; the trailing-stop watermark
+//! (`last_reference_price`) and the pegged / stop price live in the order data
+//! itself and survive the snapshot round-trip, so nothing is lost or
+//! re-initialized — re-registering the id fully restores re-pricing.
+//!
+//! These tests are gated on `special_orders`, the only configuration in which
+//! the tracker and the re-pricing path exist.
+
+#![cfg(feature = "special_orders")]
+
+use orderbook_rs::orderbook::repricing::RepricingOperations;
+use orderbook_rs::{OrderBook, OrderBookSnapshot, snapshots_match};
+use pricelevel::{
+    Hash32, Id, OrderType, PegReferenceType, Price, Quantity, Side, TimeInForce, TimestampMs,
+};
+
+/// Build a two-sided book with best bid 100 / best ask 105 plus a passive Buy
+/// pegged order resting at 90 that tracks best bid with a +20 offset. On a
+/// re-price the peg would clamp to `best_ask - 1 = 104`.
+fn book_with_passive_pegged(pegged_id: Id) -> OrderBook<()> {
+    let book = OrderBook::<()>::new("PEG/USD");
+
+    // Two-sided liquidity: best bid 100, best ask 105.
+    let _ = book.add_limit_order(Id::from_u64(1), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+    let _ = book.add_limit_order(Id::from_u64(2), 99, 10, Side::Buy, TimeInForce::Gtc, None);
+    let _ = book.add_limit_order(Id::from_u64(3), 105, 10, Side::Sell, TimeInForce::Gtc, None);
+    let _ = book.add_limit_order(Id::from_u64(4), 106, 10, Side::Sell, TimeInForce::Gtc, None);
+
+    // Passive pegged buy resting at 90 (below the ask, does not cross).
+    book.add_order(OrderType::PeggedOrder {
+        id: pegged_id,
+        price: Price::new(90),
+        quantity: Quantity::new(5),
+        side: Side::Buy,
+        user_id: Hash32::zero(),
+        timestamp: TimestampMs::new(1),
+        time_in_force: TimeInForce::Gtc,
+        reference_price_offset: 20,
+        reference_price_type: PegReferenceType::BestBid,
+        extra_fields: (),
+    })
+    .expect("passive pegged order rests");
+
+    book
+}
+
+/// #194: a pegged order restored from a snapshot package must be re-registered
+/// with the tracker and actually re-price after restore.
+///
+/// Against the unfixed code the restored book's `pegged_order_count()` is 0,
+/// `reprice_pegged_orders()` returns 0, and the order stays stuck at its
+/// snapshotted price of 90 — so every assertion below fails.
+#[test]
+fn test_restore_reregisters_pegged_and_reprices_issue_194() {
+    let pegged_id = Id::from_u64(1000);
+    let book = book_with_passive_pegged(pegged_id);
+    assert_eq!(book.pegged_order_count(), 1, "peg registered pre-snapshot");
+
+    let json = match book.snapshot_to_json(usize::MAX) {
+        Ok(j) => j,
+        Err(e) => panic!("snapshot_to_json must succeed: {e}"),
+    };
+
+    let mut restored = OrderBook::<()>::new("PEG/USD");
+    match restored.restore_from_snapshot_json(&json) {
+        Ok(()) => {}
+        Err(e) => panic!("restore must succeed: {e}"),
+    }
+
+    // The tracker is repopulated from the restored resting order (#194).
+    assert_eq!(
+        restored.pegged_order_count(),
+        1,
+        "restored book must re-register the pegged order with the tracker"
+    );
+    assert_eq!(restored.pegged_order_ids(), vec![pegged_id]);
+    assert_eq!(
+        restored.trailing_stop_count(),
+        0,
+        "no trailing stops present"
+    );
+
+    // The order rests at its snapshotted price before the re-price.
+    let before = restored.get_order(pegged_id).expect("peg restored");
+    assert_eq!(before.price().as_u128(), 90);
+
+    // Firing the re-price now actually visits and moves the restored peg.
+    let repriced = restored
+        .reprice_pegged_orders()
+        .expect("reprice runs on the restored book");
+    assert_eq!(repriced, 1, "the restored peg must actually re-price");
+
+    let after = restored.get_order(pegged_id).expect("peg still resting");
+    let best_ask = restored.best_ask().expect("best ask present");
+    assert_eq!(
+        after.price().as_u128(),
+        best_ask - 1,
+        "restored peg clamps to best_ask - 1 = 104 after re-price"
+    );
+    assert!(after.price().as_u128() > 90, "the peg moved off 90");
+}
+
+/// #194: a trailing-stop order recovered from a snapshot must be re-registered
+/// and re-price after restore, reading its watermark (`last_reference_price`)
+/// straight from the restored order data.
+///
+/// A trailing stop only re-prices when its stop price sits inside the market
+/// (a Sell stop below the bid), which the live matching path never lets rest —
+/// it would trade on admission. A recovered snapshot legitimately holds one,
+/// so we build the snapshot by merging a bid-only book with a stop-only book,
+/// exactly the disaster-recovery shape #194 targets.
+#[test]
+fn test_restore_reregisters_trailing_stop_and_reprices_issue_194() {
+    let stop_id = Id::from_u64(2000);
+
+    // Market book: best bid 110 only.
+    let market = OrderBook::<()>::new("TS/USD");
+    let _ = market.add_limit_order(Id::from_u64(1), 110, 10, Side::Buy, TimeInForce::Gtc, None);
+    let market_snapshot = market.create_snapshot(usize::MAX);
+
+    // Stop book: a lone Sell trailing stop resting at 100 (empty book, so no
+    // crossing on admission). Watermark 90, trail 5.
+    let stop_book = OrderBook::<()>::new("TS/USD");
+    stop_book
+        .add_order(OrderType::TrailingStop {
+            id: stop_id,
+            price: Price::new(100),
+            quantity: Quantity::new(5),
+            side: Side::Sell,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1),
+            time_in_force: TimeInForce::Gtc,
+            trail_amount: Quantity::new(5),
+            last_reference_price: Price::new(90),
+            extra_fields: (),
+        })
+        .expect("lone trailing stop rests");
+    let stop_snapshot = stop_book.create_snapshot(usize::MAX);
+
+    // Merge: bid 110 from the market book, the Sell stop at 100 from the stop
+    // book — a book that could not be built through live matching but is a valid
+    // recovered snapshot.
+    let merged = OrderBookSnapshot {
+        symbol: "TS/USD".to_string(),
+        timestamp: 0,
+        bids: market_snapshot.bids,
+        asks: stop_snapshot.asks,
+    };
+
+    let restored = OrderBook::<()>::new("TS/USD");
+    match restored.restore_from_snapshot(merged) {
+        Ok(()) => {}
+        Err(e) => panic!("restore must succeed: {e}"),
+    }
+
+    // The tracker is repopulated from the restored resting stop (#194).
+    assert_eq!(
+        restored.trailing_stop_count(),
+        1,
+        "restored book must re-register the trailing stop with the tracker"
+    );
+    assert_eq!(restored.trailing_stop_ids(), vec![stop_id]);
+    assert_eq!(restored.pegged_order_count(), 0, "no pegged orders present");
+    assert_eq!(restored.best_bid(), Some(110), "bid liquidity restored");
+
+    let before = restored.get_order(stop_id).expect("stop restored");
+    assert_eq!(before.price().as_u128(), 100);
+
+    // best_bid 110 > watermark 90, so the Sell stop trails up to
+    // best_bid - trail = 105 and is re-priced. A trailing stop always trails
+    // *toward* the market, so the re-priced 105 sits inside the bid (110) and
+    // triggers — the re-price is validate-first modify + re-add, which matches
+    // the now-marketable stop against the bid. The count returning 1 is the
+    // #194 proof: the loop only visits (and re-prices) the stop because restore
+    // re-registered it. Against the unfixed code the tracker is empty, so this
+    // returns 0.
+    let repriced = restored
+        .reprice_trailing_stops()
+        .expect("reprice runs on the restored book");
+    assert_eq!(
+        repriced, 1,
+        "the restored trailing stop must actually re-price"
+    );
+
+    // The stop trailed into the bid and executed, so it no longer rests at its
+    // stale price of 100 — the re-price genuinely acted on the restored order.
+    assert!(
+        restored.get_order(stop_id).is_none(),
+        "the trailing stop trailed into the market and triggered on re-price"
+    );
+    assert_eq!(
+        restored.best_bid(),
+        Some(110),
+        "the bid absorbed the triggered stop and is still the best bid"
+    );
+}
+
+/// #194: a book with no special orders restores with an empty tracker, and a
+/// mixed book re-registers only the special order — never the plain limits.
+#[test]
+fn test_restore_no_special_orders_leaves_tracker_empty_issue_194() {
+    // Plain limit-only book.
+    let plain = OrderBook::<()>::new("PLAIN/USD");
+    let _ = plain.add_limit_order(Id::from_u64(1), 100, 10, Side::Buy, TimeInForce::Gtc, None);
+    let _ = plain.add_limit_order(Id::from_u64(2), 105, 10, Side::Sell, TimeInForce::Gtc, None);
+
+    let json = match plain.snapshot_to_json(usize::MAX) {
+        Ok(j) => j,
+        Err(e) => panic!("snapshot_to_json must succeed: {e}"),
+    };
+    let mut restored_plain = OrderBook::<()>::new("PLAIN/USD");
+    restored_plain
+        .restore_from_snapshot_json(&json)
+        .expect("restore plain book");
+
+    assert_eq!(restored_plain.pegged_order_count(), 0);
+    assert_eq!(restored_plain.trailing_stop_count(), 0);
+    assert_eq!(restored_plain.best_bid(), Some(100));
+    assert_eq!(restored_plain.best_ask(), Some(105));
+
+    // Mixed book: a pegged order plus plain limits. Only the peg is tracked.
+    let pegged_id = Id::from_u64(1000);
+    let mixed = book_with_passive_pegged(pegged_id);
+    let mixed_json = match mixed.snapshot_to_json(usize::MAX) {
+        Ok(j) => j,
+        Err(e) => panic!("snapshot_to_json must succeed: {e}"),
+    };
+    let mut restored_mixed = OrderBook::<()>::new("PEG/USD");
+    restored_mixed
+        .restore_from_snapshot_json(&mixed_json)
+        .expect("restore mixed book");
+
+    assert_eq!(restored_mixed.pegged_order_ids(), vec![pegged_id]);
+    assert_eq!(restored_mixed.trailing_stop_count(), 0);
+    // The plain limit orders are present but not tracked as special.
+    assert!(restored_mixed.get_order(Id::from_u64(1)).is_some());
+    assert!(restored_mixed.get_order(Id::from_u64(3)).is_some());
+}
+
+/// #194: the snapshot round-trip oracle still holds for a book that contains a
+/// special order — re-registering the tracker must not perturb the resting book
+/// structure the way `snapshots_match` compares it.
+#[test]
+fn test_restore_special_order_snapshot_round_trip_holds_issue_194() {
+    let pegged_id = Id::from_u64(1000);
+    let book = book_with_passive_pegged(pegged_id);
+    let original = book.create_snapshot(usize::MAX);
+
+    let mut restored = OrderBook::<()>::new("PEG/USD");
+    let json = book.snapshot_to_json(usize::MAX).expect("snapshot json");
+    restored
+        .restore_from_snapshot_json(&json)
+        .expect("restore succeeds");
+
+    let round_trip = restored.create_snapshot(usize::MAX);
+    assert!(
+        snapshots_match(&round_trip, &original),
+        "snapshot round-trip must hold for a book containing a special order"
+    );
+
+    // Re-pricing the restored peg and snapshotting again keeps the structure a
+    // valid snapshot (the peg moved to 104, which the oracle sees as one bid
+    // level relocating) — the tracker rebuild did not corrupt resting state.
+    let repriced = restored.reprice_pegged_orders().expect("reprice runs");
+    assert_eq!(repriced, 1);
+    let after = restored.create_snapshot(usize::MAX);
+    // The moved peg now rests at 104; the original snapshot had it at 90.
+    assert!(
+        !snapshots_match(&after, &original),
+        "the re-price genuinely moved the peg, so the oracle now differs"
+    );
+    assert!(
+        after.bids.iter().any(|l| l.price().as_u128() == 104),
+        "the re-priced peg rests at 104 in the post-reprice snapshot"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #194 and releases **0.10.3** (patch — `cargo semver-checks`: 196 pass).

### Problem
`restore_from_snapshot` / `restore_from_snapshot_package` never rebuilt the `special_order_tracker` (`special_orders` feature): restored resting pegged / trailing-stop orders silently stopped repricing.

### Fix
- Tracker cleared in the restore reset block (stale ids impossible on restore-into-non-fresh-book).
- Every restored special order re-registered via a helper that mirrors admission-time registration exactly, **folded into the same deterministic price-then-seq rebuild pass** from #192 — no second traversal.
- No tracker-only state existed to lose: the trailing-stop watermark (`last_reference_price`) is a serialized `OrderType` field round-tripped by the snapshot — verified against pricelevel 0.8.4.

### Tests (all fail pre-fix — verified by stash-revert: 0/4 → 4/4)
Pegged restore+reprice; trailing-stop restore, trail and trigger (disaster-recovery snapshot shape); plain/mixed book tracker contents; `snapshots_match` round-trip.

### Review
determinism-auditor: **CLEAN** — registration inline in the existing deterministic pass; reprice iteration already sorts ids (pre-existing); feature-gating verified both ways.

## Gates
`make pre-push` clean; clippy `-D warnings` zero; `cargo test --all-features`: 783 lib + 475 integration, 0 failed; semver patch-compatible.

Closes #194.