### PR TITLE
Make the trade-ID namespace injectable on OrderBook (#199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.5] — 2026-07-13
+
+### Added
+
+- **Injectable trade-ID namespace (#199).** Every `OrderBook` constructor
+  minted its trade/transaction-ID namespace internally with
+  `Uuid::new_v4()`, so trade IDs differed between a live run and its replay
+  even when the command stream, the injected `Clock`, and the matching were
+  identical — the namespace was the only entropy left in the trade-ID
+  stream (`pricelevel::UuidGenerator` derives UUID v5 from namespace +
+  atomic counter). `OrderBook::set_trade_id_namespace(&mut self, namespace)`
+  is a pre-publication setter symmetric with `set_clock`: it replaces the
+  generator (the counter restarts at 0, so call it before any orders are
+  submitted) and composes with every existing constructor.
+  `OrderBook::with_clock_and_namespace(symbol, clock, namespace)` covers the
+  common deterministic-venue setup in one call; a deterministically chosen
+  namespace (e.g. UUID v5 of the symbol under a venue root) then yields
+  byte-identical trade IDs across live/replay. Default constructors are
+  unchanged (fresh random namespace per book). No wire-format or snapshot
+  change, and no `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump.
+
 ## [0.10.4] — 2026-07-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   namespace (e.g. UUID v5 of the symbol under a venue root) then yields
   byte-identical trade IDs across live/replay. Default constructors are
   unchanged (fresh random namespace per book). No wire-format or snapshot
-  change, and no `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump.
+  change, and no `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump. The guarantee
+  currently applies to books constructed by the caller; the sequencer's
+  `ReplayEngine` entry points still build their books with a random
+  namespace — wiring the seam into `ReplayBookConfig` is tracked in #200.
 
 ## [0.10.4] — 2026-07-12
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orderbook-rs"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."

--- a/README.md
+++ b/README.md
@@ -67,7 +67,11 @@ This order book engine is built with the following design principles:
   gives every book a stable, distinct stream.
 - Default constructors are unchanged: without injection each book still
   gets a fresh random namespace. No wire-format or snapshot change, no
-  `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump.
+  `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump. Note the guarantee currently
+  applies to books you construct yourself; the sequencer's
+  `ReplayEngine` entry points still build their books with a random
+  namespace — wiring the seam into `ReplayBookConfig` is tracked in
+  issue #200.
 
 ### What's New in Version 0.10.4
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,29 @@ This order book engine is built with the following design principles:
 - **Research**: Platform for studying market microstructure and order flow
 - **Educational**: Reference implementation for understanding modern exchange architecture
 
+### What's New in Version 0.10.5
+
+#### v0.10.5 — injectable trade-ID namespace (#199)
+
+- **`OrderBook::set_trade_id_namespace(&mut self, namespace: Uuid)`.**
+  Every constructor used to mint the trade-ID namespace internally with
+  `Uuid::new_v4()`, so trade IDs differed between a live run and its
+  replay even with an injected `Clock` and an identical command stream —
+  the namespace was the only entropy left in the trade-ID stream
+  (`pricelevel::UuidGenerator` is UUID v5 over namespace + counter).
+  The new setter, symmetric with `set_clock`, replaces the generator
+  (counter restarts at 0) and composes with every existing constructor.
+  Call it before any orders are submitted.
+- **`OrderBook::with_clock_and_namespace(symbol, clock, namespace)`.**
+  Convenience constructor for the fully deterministic setup (injected
+  clock + injected namespace): the same command stream then produces
+  byte-identical trade IDs across live/replay. A deterministic
+  namespace choice such as UUID v5 of the symbol under a venue root
+  gives every book a stable, distinct stream.
+- Default constructors are unchanged: without injection each book still
+  gets a fresh random namespace. No wire-format or snapshot change, no
+  `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump.
+
 ### What's New in Version 0.10.4
 
 #### v0.10.4 — exact-fee API: `try_calculate_fee` + published guaranteed-exact bound (#197)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,29 @@
 //! - **Research**: Platform for studying market microstructure and order flow
 //! - **Educational**: Reference implementation for understanding modern exchange architecture
 //!
+//! ## What's New in Version 0.10.5
+//!
+//! ### v0.10.5 — injectable trade-ID namespace (#199)
+//!
+//! - **`OrderBook::set_trade_id_namespace(&mut self, namespace: Uuid)`.**
+//!   Every constructor used to mint the trade-ID namespace internally with
+//!   `Uuid::new_v4()`, so trade IDs differed between a live run and its
+//!   replay even with an injected `Clock` and an identical command stream —
+//!   the namespace was the only entropy left in the trade-ID stream
+//!   (`pricelevel::UuidGenerator` is UUID v5 over namespace + counter).
+//!   The new setter, symmetric with `set_clock`, replaces the generator
+//!   (counter restarts at 0) and composes with every existing constructor.
+//!   Call it before any orders are submitted.
+//! - **`OrderBook::with_clock_and_namespace(symbol, clock, namespace)`.**
+//!   Convenience constructor for the fully deterministic setup (injected
+//!   clock + injected namespace): the same command stream then produces
+//!   byte-identical trade IDs across live/replay. A deterministic
+//!   namespace choice such as UUID v5 of the symbol under a venue root
+//!   gives every book a stable, distinct stream.
+//! - Default constructors are unchanged: without injection each book still
+//!   gets a fresh random namespace. No wire-format or snapshot change, no
+//!   `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump.
+//!
 //! ## What's New in Version 0.10.4
 //!
 //! ### v0.10.4 — exact-fee API: `try_calculate_fee` + published guaranteed-exact bound (#197)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,11 @@
 //!   gives every book a stable, distinct stream.
 //! - Default constructors are unchanged: without injection each book still
 //!   gets a fresh random namespace. No wire-format or snapshot change, no
-//!   `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump.
+//!   `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump. Note the guarantee currently
+//!   applies to books you construct yourself; the sequencer's
+//!   `ReplayEngine` entry points still build their books with a random
+//!   namespace — wiring the seam into `ReplayBookConfig` is tracked in
+//!   issue #200.
 //!
 //! ## What's New in Version 0.10.4
 //!

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -454,6 +454,34 @@ where
         }
     }
 
+    /// Create a new order book with a caller-provided [`Clock`] and
+    /// trade-ID namespace.
+    ///
+    /// Convenience constructor for the fully deterministic setup: the
+    /// injected clock pins timestamps and the injected namespace pins the
+    /// trade-ID stream (see [`Self::set_trade_id_namespace`]), so a live
+    /// run and its replay over the same command stream produce
+    /// byte-identical trades.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use orderbook_rs::OrderBook;
+    /// use orderbook_rs::prelude::{Clock, StubClock};
+    /// use uuid::Uuid;
+    ///
+    /// let namespace = Uuid::new_v5(&Uuid::NAMESPACE_OID, b"VENUE/AAPL");
+    /// let clock = Arc::new(StubClock::new()) as Arc<dyn Clock>;
+    /// let book: OrderBook<()> = OrderBook::with_clock_and_namespace("AAPL", clock, namespace);
+    /// assert_eq!(book.symbol(), "AAPL");
+    /// ```
+    pub fn with_clock_and_namespace(symbol: &str, clock: Arc<dyn Clock>, namespace: Uuid) -> Self {
+        let mut book = Self::with_clock(symbol, clock);
+        book.set_trade_id_namespace(namespace);
+        book
+    }
+
     /// Replace the clock used by this book.
     ///
     /// This takes `&mut self` and is intended for cold configuration
@@ -461,6 +489,28 @@ where
     /// construction via [`Self::with_clock`].
     pub fn set_clock(&mut self, clock: Arc<dyn Clock>) {
         self.clock = clock;
+    }
+
+    /// Replace the trade/transaction-ID namespace used by this book.
+    ///
+    /// Trade IDs are UUID v5 values derived from this namespace plus an
+    /// atomic counter ([`pricelevel::UuidGenerator`]), so the namespace is
+    /// the only entropy in the trade-ID stream: with an injected namespace
+    /// (and an injected [`Clock`]) the same command stream produces
+    /// byte-identical trade IDs across a live run and its replay. A
+    /// deterministic choice such as UUID v5 of the symbol under a venue
+    /// root namespace gives every book a stable, distinct stream.
+    ///
+    /// Call this **before any orders are submitted**: replacing the
+    /// generator restarts its counter at 0, so a book that has already
+    /// traded would re-issue the earliest IDs of the new namespace
+    /// (duplicate trade IDs from a consumer's perspective). Like
+    /// [`Self::set_clock`], this takes `&mut self` and is intended for
+    /// cold configuration paths right after construction; it composes
+    /// with every constructor without multiplying variants — or use
+    /// [`Self::with_clock_and_namespace`] directly.
+    pub fn set_trade_id_namespace(&mut self, namespace: Uuid) {
+        self.transaction_id_generator = UuidGenerator::new(namespace);
     }
 
     /// Access the currently-installed clock.

--- a/src/orderbook/tests/book.rs
+++ b/src/orderbook/tests/book.rs
@@ -1539,4 +1539,129 @@ mod test_book_specific {
         assert_eq!(book.total_quantity_at_price(99, Side::Buy), Some(20));
         assert_eq!(book.order_count_at_price(99, Side::Buy), Some(1));
     }
+
+    // --- injectable trade-ID namespace (#199) -------------------------------
+
+    /// Drives a fixed command stream (three seed-then-sweep rounds) and
+    /// returns the emitted trade IDs in order. Order IDs are random on
+    /// purpose — trade IDs must derive only from the book's namespace +
+    /// counter, never from the order IDs.
+    fn run_fixed_stream_trade_ids(book: &OrderBook<()>) -> Vec<String> {
+        let mut trade_ids = Vec::new();
+        for _ in 0..3 {
+            let resting = create_order_id();
+            book.add_limit_order(resting, 1000, 10, Side::Sell, TimeInForce::Gtc, None)
+                .expect("seed resting sell");
+            let taker = create_order_id();
+            let result = book
+                .match_market_order(taker, 10, Side::Buy)
+                .expect("market buy fills");
+            for tx in result.trades().as_vec() {
+                trade_ids.push(tx.trade_id().to_string());
+            }
+        }
+        trade_ids
+    }
+
+    fn deterministic_book(symbol: &str, namespace: uuid::Uuid) -> OrderBook<()> {
+        use crate::orderbook::clock::{Clock, StubClock};
+        use std::sync::Arc;
+        OrderBook::with_clock_and_namespace(
+            symbol,
+            Arc::new(StubClock::new()) as Arc<dyn Clock>,
+            namespace,
+        )
+    }
+
+    #[test]
+    fn test_with_clock_and_namespace_same_namespace_same_stream_identical_trade_ids() {
+        let namespace = uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, b"VENUE/TEST");
+        let live = deterministic_book("TEST", namespace);
+        let replay = deterministic_book("TEST", namespace);
+
+        let live_ids = run_fixed_stream_trade_ids(&live);
+        let replay_ids = run_fixed_stream_trade_ids(&replay);
+
+        assert!(!live_ids.is_empty(), "stream must emit trades");
+        assert_eq!(
+            live_ids, replay_ids,
+            "same namespace + same command stream must yield identical trade IDs"
+        );
+    }
+
+    #[test]
+    fn test_with_clock_and_namespace_different_namespaces_diverging_trade_ids() {
+        let ns_a = uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, b"VENUE/A");
+        let ns_b = uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, b"VENUE/B");
+
+        let ids_a = run_fixed_stream_trade_ids(&deterministic_book("TEST", ns_a));
+        let ids_b = run_fixed_stream_trade_ids(&deterministic_book("TEST", ns_b));
+
+        assert_ne!(
+            ids_a, ids_b,
+            "different namespaces must yield different trade-ID streams"
+        );
+    }
+
+    #[test]
+    fn test_set_trade_id_namespace_equals_constructor_injection() {
+        use crate::orderbook::clock::{Clock, StubClock};
+        use std::sync::Arc;
+
+        let namespace = uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, b"VENUE/TEST");
+        let constructed = deterministic_book("TEST", namespace);
+
+        let mut via_setter: OrderBook<()> =
+            OrderBook::with_clock("TEST", Arc::new(StubClock::new()) as Arc<dyn Clock>);
+        via_setter.set_trade_id_namespace(namespace);
+
+        assert_eq!(
+            run_fixed_stream_trade_ids(&constructed),
+            run_fixed_stream_trade_ids(&via_setter),
+            "with_clock_and_namespace must equal with_clock + set_trade_id_namespace"
+        );
+    }
+
+    #[test]
+    fn test_set_trade_id_namespace_after_trades_restarts_counter() {
+        let namespace = uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, b"VENUE/TEST");
+
+        // Fresh book with the namespace: capture the first trade ID.
+        let fresh = deterministic_book("TEST", namespace);
+        let fresh_ids = run_fixed_stream_trade_ids(&fresh);
+        let Some(first_fresh_id) = fresh_ids.first() else {
+            panic!("fresh stream must emit trades");
+        };
+
+        // A book that already traded, then has the namespace injected:
+        // the generator counter restarts at 0, so its next trade ID is the
+        // namespace's first ID again — the documented reason the setter
+        // must be called before any orders are submitted.
+        let mut reused = deterministic_book("TEST", uuid::Uuid::NAMESPACE_DNS);
+        let _ = run_fixed_stream_trade_ids(&reused);
+        reused.set_trade_id_namespace(namespace);
+        let post_reset_ids = run_fixed_stream_trade_ids(&reused);
+
+        assert_eq!(
+            post_reset_ids.first(),
+            Some(first_fresh_id),
+            "re-injecting a namespace must restart the ID counter at 0"
+        );
+    }
+
+    #[test]
+    fn test_default_constructors_keep_random_distinct_namespaces() {
+        // OrderBook::new must keep minting a random namespace per book:
+        // two default books over the same stream diverge in trade IDs.
+        let book_a: OrderBook<()> = OrderBook::new("TEST");
+        let book_b: OrderBook<()> = OrderBook::new("TEST");
+
+        let ids_a = run_fixed_stream_trade_ids(&book_a);
+        let ids_b = run_fixed_stream_trade_ids(&book_b);
+
+        assert_ne!(
+            ids_a, ids_b,
+            "default construction must keep per-book random namespaces"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Every `OrderBook` constructor minted its trade/transaction-ID namespace internally with `Uuid::new_v4()`, so trade IDs differed between a live run and its replay even when the command stream, the injected `Clock`, and the matching were identical — the namespace is the only entropy in the trade-ID stream, since `pricelevel::UuidGenerator` derives UUID v5 from namespace + atomic counter. Downstream determinism oracles (fauxchange, IronCondor, Option-Chain-OrderBook#147) had to exclude or remap upstream trade IDs. This PR makes the namespace injectable.

## Changes

- `OrderBook::set_trade_id_namespace(&mut self, namespace: Uuid)` — pre-publication setter symmetric with `set_clock`: replaces the transaction-ID generator with `UuidGenerator::new(namespace)`. The counter restarts at 0, so the documented contract is to call it before any orders are submitted; it composes with every existing constructor without multiplying variants.
- `OrderBook::with_clock_and_namespace(symbol, clock, namespace)` — convenience constructor for the fully deterministic setup (injected clock + injected namespace); delegates to `with_clock` + the setter, no third struct-literal copy.
- Default behavior unchanged: without injection each book still gets a fresh random namespace (pinned by test).

## Technical decisions

- **`&mut self` setter, not new constructor variants**: matches the existing `set_clock` seam, keeps the three struct-literal constructors untouched, and Rust's aliasing rules statically fence it out of the concurrent `&self` matching path (determinism-auditor verified).
- **No `ReplayBookConfig` change here**: the sequencer's `ReplayEngine` entry points still construct books with a random namespace, so the byte-identical-trade-ID guarantee currently applies to caller-constructed books. Wiring the seam into `ReplayBookConfig` / `ReplayEngine` is tracked in follow-up #200 (found by the determinism audit of this branch); the What's New / CHANGELOG text states this scope explicitly.
- **No getter**: `UuidGenerator`'s namespace field is private upstream in `pricelevel`; not needed for the admission/replay use case.

## Public API impact

- New: `OrderBook::set_trade_id_namespace`, `OrderBook::with_clock_and_namespace` (inherent methods on the already-exported `OrderBook`). No re-export or `prelude.rs` change. No removals or renames.
- `src/lib.rs` What's New updated for 0.10.5; `README.md` regenerated via `make readme`; `CHANGELOG.md` entry added; crate version bumped `0.10.4 → 0.10.5`.
- No snapshot/replay format impact: the namespace is construction state, never serialized; no `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` bump.

## Testing

- [x] Unit tests added in `src/orderbook/tests/book.rs`: same namespace + same command stream → identical trade-ID sequences (live/replay parity); different namespaces diverge; constructor ≡ setter composition; setter after trades restarts the counter (pins the "call before any orders" contract); default constructors keep random distinct namespaces. Order IDs are deliberately random in the fixture to prove trade IDs derive only from namespace + counter.
- [x] Doctest on `with_clock_and_namespace` (StubClock + UUID v5 venue namespace)
- [x] `make pre-push` run locally and clean (1351 tests passed, 0 failed; clippy `-D warnings` clean; release build clean)
- [x] determinism-auditor: no hazards introduced; seam correctly cold-path-only. architect: OK across all areas.

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] No `unsafe` introduced (`#![deny(unsafe_code)]` is on)
- [x] Module boundaries respected (book.rs only; no deps on `manager`, `nats*`, `sequencer/`)
- [x] No new dependencies added
- [x] `tracing` only for logging — no `println!` / `eprintln!` / `dbg!` / `log` crate
- [x] `src/lib.rs` docs + `README.md` (via `make readme`) + `CHANGELOG.md` updated

Closes #199
