### PR TITLE
Document and property-test the queue-priority contract (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   time priority — were previously documented only inside the embedded
   `pricelevel` engine. External conformance tooling (Tracebook) now consumes
   this contract, so it is promoted to the public `update_order` docs and
-  locked in by two proptest invariants
+  locked in by four proptest invariants
   (`tests/unit/props_quantity_update_priority.rs`) driven through the public
-  API. No behavior change.
+  API: quantity decrease keeps the queue position, quantity increase demotes,
+  and same-price `Replace` / `UpdatePriceAndQuantity` always demote. The docs
+  also state a known limitation: the upsize demotion does not yet survive a
+  snapshot restore (#205, upstream fix in `pricelevel`). No behavior change.
 
 ## [0.11.0] — 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Queue-priority contract documented and property-tested (#203).** The
+  price-time-priority semantics of `OrderBook::update_order` — an in-place
+  quantity decrease keeps the maker's queue position, a quantity increase
+  demotes to the back of the level, and `UpdatePrice` /
+  `UpdatePriceAndQuantity` / `Replace` are cancel-then-add and always lose
+  time priority — were previously documented only inside the embedded
+  `pricelevel` engine. External conformance tooling (Tracebook) now consumes
+  this contract, so it is promoted to the public `update_order` docs and
+  locked in by two proptest invariants
+  (`tests/unit/props_quantity_update_priority.rs`) driven through the public
+  API. No behavior change.
+
 ## [0.11.0] — 2026-07-13
 
 ### Added

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -122,6 +122,28 @@ where
 {
     /// Update an order's price and/or quantity
     ///
+    /// # Queue priority
+    ///
+    /// The update variants follow conventional exchange price-time-priority
+    /// rules. This is a public contract — external conformance tooling
+    /// depends on it (see issue #203):
+    ///
+    /// - [`OrderUpdate::UpdateQuantity`] with a **decreased or unchanged**
+    ///   total quantity (visible + hidden) updates the resting order in
+    ///   place at its existing insertion sequence: the maker keeps its
+    ///   queue position. Reducing size never forfeits time priority.
+    /// - [`OrderUpdate::UpdateQuantity`] with an **increased** total
+    ///   quantity demotes the order to the back of its price level's
+    ///   queue. Sizing up loses time priority. The demoted order keeps
+    ///   its original admission timestamp — only its insertion sequence
+    ///   is refreshed — so snapshot views sorted by `(timestamp, seq)`
+    ///   may show it ahead of where matching will actually consume it.
+    /// - [`OrderUpdate::UpdatePrice`], [`OrderUpdate::UpdatePriceAndQuantity`],
+    ///   and [`OrderUpdate::Replace`] are implemented as cancel-then-add:
+    ///   the order always re-enters at the back of its (possibly new)
+    ///   price level and loses time priority — for `Replace` and
+    ///   `UpdatePriceAndQuantity` even when the price is unchanged.
+    ///
     /// # Errors
     /// Returns [`OrderBookError::KillSwitchActive`] when the kill switch
     /// is engaged and the update is anything other than

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -136,8 +136,13 @@ where
     ///   quantity demotes the order to the back of its price level's
     ///   queue. Sizing up loses time priority. The demoted order keeps
     ///   its original admission timestamp — only its insertion sequence
-    ///   is refreshed — so snapshot views sorted by `(timestamp, seq)`
-    ///   may show it ahead of where matching will actually consume it.
+    ///   is refreshed. **Known limitation:** the demotion does not yet
+    ///   survive a snapshot round-trip — level capture orders by
+    ///   `(timestamp, seq)` without persisting the sequence, and
+    ///   [`restore_from_snapshot`](OrderBook::restore_from_snapshot)
+    ///   re-enqueues in that order, so a restored book consumes the
+    ///   upsized order at its pre-demotion position (tracked in
+    ///   issue #205, fix upstream in `pricelevel`).
     /// - [`OrderUpdate::UpdatePrice`], [`OrderUpdate::UpdatePriceAndQuantity`],
     ///   and [`OrderUpdate::Replace`] are implemented as cancel-then-add:
     ///   the order always re-enters at the back of its (possibly new)

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -21,6 +21,7 @@ mod operations_coverage_tests;
 mod operations_coverage_tests_extended;
 mod order_state_tests;
 mod private_coverage_tests;
+mod props_quantity_update_priority;
 mod reject_reason_tests;
 mod replay_config_tests;
 mod replay_coverage_tests;

--- a/tests/unit/props_quantity_update_priority.rs
+++ b/tests/unit/props_quantity_update_priority.rs
@@ -1,17 +1,20 @@
 //! Property tests for the queue-priority contract of
-//! `OrderBook::update_order(OrderUpdate::UpdateQuantity { .. })` (issue #203):
+//! `OrderBook::update_order` (issue #203):
 //!
-//! - A quantity **decrease** (or unchanged total) keeps the maker's queue
-//!   position — reducing size never forfeits time priority.
-//! - A quantity **increase** demotes the order to the back of its price
-//!   level's queue.
+//! - `UpdateQuantity` with a **decrease** (or unchanged total) keeps the
+//!   maker's queue position — reducing size never forfeits time priority.
+//! - `UpdateQuantity` with an **increase** demotes the order to the back of
+//!   its price level's queue.
+//! - `Replace` and `UpdatePriceAndQuantity` always demote to the back of the
+//!   queue, even at an unchanged price and regardless of the quantity
+//!   direction (cancel-then-add semantics).
 //!
-//! Both properties are asserted through the public API only: build a level of
-//! resting standard orders, resize one, then sweep the level with an
+//! All properties are asserted through the public API only: build a level of
+//! resting standard orders, update one, then sweep the level with an
 //! aggressive market order and check the maker-id sequence of the fills.
 
 use orderbook_rs::OrderBook;
-use pricelevel::{Hash32, Id, MatchResult, OrderUpdate, Quantity, Side, TimeInForce};
+use pricelevel::{Hash32, Id, MatchResult, OrderUpdate, Price, Quantity, Side, TimeInForce};
 use proptest::prelude::*;
 
 /// Price level shared by every resting order; the market order sweeps it.
@@ -48,6 +51,24 @@ fn book_with_ask_level(quantities: &[u64]) -> Result<OrderBook<()>, TestCaseErro
     Ok(book)
 }
 
+/// Applies `update` to the resting order at `position` and asserts it was
+/// applied to a live order.
+fn apply_update(
+    book: &OrderBook<()>,
+    position: usize,
+    update: OrderUpdate,
+) -> Result<(), TestCaseError> {
+    match book.update_order(update) {
+        Ok(Some(_)) => Ok(()),
+        Ok(None) => Err(TestCaseError::fail(format!(
+            "order at position {position} not found for update"
+        ))),
+        Err(error) => Err(TestCaseError::fail(format!(
+            "update at position {position} failed: {error}"
+        ))),
+    }
+}
+
 /// Resizes the resting order at `position` to `new_quantity` and asserts the
 /// update was applied to a live order.
 fn resize_order(
@@ -55,18 +76,14 @@ fn resize_order(
     position: usize,
     new_quantity: u64,
 ) -> Result<(), TestCaseError> {
-    match book.update_order(OrderUpdate::UpdateQuantity {
-        order_id: resting_id(position),
-        new_quantity: Quantity::new(new_quantity),
-    }) {
-        Ok(Some(_)) => Ok(()),
-        Ok(None) => Err(TestCaseError::fail(format!(
-            "order at position {position} not found for quantity update"
-        ))),
-        Err(error) => Err(TestCaseError::fail(format!(
-            "quantity update at position {position} failed: {error}"
-        ))),
-    }
+    apply_update(
+        book,
+        position,
+        OrderUpdate::UpdateQuantity {
+            order_id: resting_id(position),
+            new_quantity: Quantity::new(new_quantity),
+        },
+    )
 }
 
 /// Sweeps the ask level with a market buy of `quantity` units and returns the
@@ -83,6 +100,45 @@ fn sweep(book: &OrderBook<()>, quantity: u64) -> Result<MatchResult, TestCaseErr
             "market sweep of {quantity} units failed: {error}"
         ))),
     }
+}
+
+/// Sweeps every unit not belonging to the updated order at `position`
+/// (per the original `quantities`) plus one unit, and asserts the updated
+/// order fills last — after every other order, in insertion order. The
+/// final unit can only come from the updated order if the update demoted
+/// it behind every other resting order.
+fn assert_demoted_to_back(
+    book: &OrderBook<()>,
+    quantities: &[u64],
+    position: usize,
+) -> Result<(), TestCaseError> {
+    let others: u64 = quantities
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| *index != position)
+        .map(|(_, quantity)| *quantity)
+        .sum();
+    let result = sweep(book, others + 1)?;
+
+    let trades = result.trades().as_vec();
+    prop_assert_eq!(
+        trades.len(),
+        quantities.len(),
+        "sweep must fill every other order fully and the updated order once"
+    );
+
+    let expected_makers: Vec<Id> = (0..quantities.len())
+        .filter(|index| *index != position)
+        .map(resting_id)
+        .chain(std::iter::once(resting_id(position)))
+        .collect();
+    let actual_makers: Vec<Id> = trades.iter().map(|trade| trade.maker_order_id()).collect();
+    prop_assert_eq!(
+        actual_makers,
+        expected_makers,
+        "demoted order must fill last, all others in insertion order"
+    );
+    Ok(())
 }
 
 proptest! {
@@ -151,35 +207,59 @@ proptest! {
 
         let book = book_with_ask_level(&quantities)?;
         resize_order(&book, position, new_quantity)?;
+        assert_demoted_to_back(&book, &quantities, position)?;
+    }
 
-        // Every unit not belonging to the resized order, plus one unit that
-        // must come from it — and can only be the final fill if the resize
-        // demoted it behind every other resting order.
-        let others: u64 = quantities
-            .iter()
-            .enumerate()
-            .filter(|(index, _)| *index != position)
-            .map(|(_, quantity)| *quantity)
-            .sum();
-        let result = sweep(&book, others + 1)?;
+    /// A same-price `Replace` must always demote the order to the back of
+    /// the queue, regardless of whether its quantity shrinks, grows, or is
+    /// unchanged — replace is cancel-then-add.
+    #[test]
+    fn test_replace_same_price_demotes_to_back_of_queue(
+        quantities in proptest::collection::vec(1u64..=50, 3..8),
+        position_index in any::<prop::sample::Index>(),
+        new_quantity in 1u64..=100,
+    ) {
+        // Pick a position that is not already last, so the demotion is
+        // observable in the fill sequence.
+        let position = position_index.index(quantities.len() - 1);
 
-        let trades = result.trades().as_vec();
-        prop_assert_eq!(
-            trades.len(),
-            quantities.len(),
-            "sweep must fill every other order fully and the resized order once"
-        );
+        let book = book_with_ask_level(&quantities)?;
+        apply_update(
+            &book,
+            position,
+            OrderUpdate::Replace {
+                order_id: resting_id(position),
+                price: Price::new(LEVEL_PRICE),
+                quantity: Quantity::new(new_quantity),
+                side: Side::Sell,
+            },
+        )?;
+        assert_demoted_to_back(&book, &quantities, position)?;
+    }
 
-        let expected_makers: Vec<Id> = (0..quantities.len())
-            .filter(|index| *index != position)
-            .map(resting_id)
-            .chain(std::iter::once(resting_id(position)))
-            .collect();
-        let actual_makers: Vec<Id> = trades.iter().map(|trade| trade.maker_order_id()).collect();
-        prop_assert_eq!(
-            actual_makers,
-            expected_makers,
-            "demoted order must fill last, all others in insertion order"
-        );
+    /// A same-price `UpdatePriceAndQuantity` must always demote the order to
+    /// the back of the queue, regardless of the quantity direction — it is
+    /// cancel-then-add even when the price does not change.
+    #[test]
+    fn test_update_price_and_quantity_same_price_demotes_to_back_of_queue(
+        quantities in proptest::collection::vec(1u64..=50, 3..8),
+        position_index in any::<prop::sample::Index>(),
+        new_quantity in 1u64..=100,
+    ) {
+        // Pick a position that is not already last, so the demotion is
+        // observable in the fill sequence.
+        let position = position_index.index(quantities.len() - 1);
+
+        let book = book_with_ask_level(&quantities)?;
+        apply_update(
+            &book,
+            position,
+            OrderUpdate::UpdatePriceAndQuantity {
+                order_id: resting_id(position),
+                new_price: Price::new(LEVEL_PRICE),
+                new_quantity: Quantity::new(new_quantity),
+            },
+        )?;
+        assert_demoted_to_back(&book, &quantities, position)?;
     }
 }

--- a/tests/unit/props_quantity_update_priority.rs
+++ b/tests/unit/props_quantity_update_priority.rs
@@ -1,0 +1,185 @@
+//! Property tests for the queue-priority contract of
+//! `OrderBook::update_order(OrderUpdate::UpdateQuantity { .. })` (issue #203):
+//!
+//! - A quantity **decrease** (or unchanged total) keeps the maker's queue
+//!   position — reducing size never forfeits time priority.
+//! - A quantity **increase** demotes the order to the back of its price
+//!   level's queue.
+//!
+//! Both properties are asserted through the public API only: build a level of
+//! resting standard orders, resize one, then sweep the level with an
+//! aggressive market order and check the maker-id sequence of the fills.
+
+use orderbook_rs::OrderBook;
+use pricelevel::{Hash32, Id, MatchResult, OrderUpdate, Quantity, Side, TimeInForce};
+use proptest::prelude::*;
+
+/// Price level shared by every resting order; the market order sweeps it.
+const LEVEL_PRICE: u128 = 100;
+
+/// Id used by the aggressive market order — outside the resting-id range.
+const TAKER_ID: u64 = 9_999;
+
+/// Resting order `i` (zero-based insertion position) gets id `i + 1`.
+fn resting_id(position: usize) -> Id {
+    Id::from_u64(position as u64 + 1)
+}
+
+/// Builds a book with one ask level holding `quantities.len()` standard GTC
+/// sell orders admitted in index order, so insertion position `i` has id
+/// `i + 1` and quantity `quantities[i]`.
+fn book_with_ask_level(quantities: &[u64]) -> Result<OrderBook<()>, TestCaseError> {
+    let book = OrderBook::<()>::new("PROPS");
+    for (position, quantity) in quantities.iter().enumerate() {
+        if let Err(error) = book.add_limit_order_with_user(
+            resting_id(position),
+            LEVEL_PRICE,
+            *quantity,
+            Side::Sell,
+            TimeInForce::Gtc,
+            Hash32::zero(),
+            None,
+        ) {
+            return Err(TestCaseError::fail(format!(
+                "failed to rest order at position {position}: {error}"
+            )));
+        }
+    }
+    Ok(book)
+}
+
+/// Resizes the resting order at `position` to `new_quantity` and asserts the
+/// update was applied to a live order.
+fn resize_order(
+    book: &OrderBook<()>,
+    position: usize,
+    new_quantity: u64,
+) -> Result<(), TestCaseError> {
+    match book.update_order(OrderUpdate::UpdateQuantity {
+        order_id: resting_id(position),
+        new_quantity: Quantity::new(new_quantity),
+    }) {
+        Ok(Some(_)) => Ok(()),
+        Ok(None) => Err(TestCaseError::fail(format!(
+            "order at position {position} not found for quantity update"
+        ))),
+        Err(error) => Err(TestCaseError::fail(format!(
+            "quantity update at position {position} failed: {error}"
+        ))),
+    }
+}
+
+/// Sweeps the ask level with a market buy of `quantity` units and returns the
+/// match result.
+fn sweep(book: &OrderBook<()>, quantity: u64) -> Result<MatchResult, TestCaseError> {
+    match book.submit_market_order_with_user(
+        Id::from_u64(TAKER_ID),
+        quantity,
+        Side::Buy,
+        Hash32::zero(),
+    ) {
+        Ok(result) => Ok(result),
+        Err(error) => Err(TestCaseError::fail(format!(
+            "market sweep of {quantity} units failed: {error}"
+        ))),
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 256,
+        max_shrink_iters: 50_000,
+        ..ProptestConfig::default()
+    })]
+
+    /// Reducing (or keeping) an order's quantity must preserve its queue
+    /// position: a sweep that reaches exactly one unit into the resized
+    /// order's original position must fill the orders ahead of it in
+    /// insertion order and then partially fill the resized order itself.
+    #[test]
+    fn test_update_quantity_decrease_preserves_queue_position(
+        quantities in proptest::collection::vec(1u64..=50, 3..8),
+        position_index in any::<prop::sample::Index>(),
+        target_index in any::<prop::sample::Index>(),
+    ) {
+        // Pick a position with at least one order resting behind it, so a
+        // lost queue position would visibly reroute the final fill.
+        let position = position_index.index(quantities.len() - 1);
+        // New total in 1..=original: strict decrease or unchanged, both of
+        // which the contract requires to keep the queue position.
+        let new_quantity = 1 + target_index.index(quantities[position] as usize) as u64;
+
+        let book = book_with_ask_level(&quantities)?;
+        resize_order(&book, position, new_quantity)?;
+
+        // One unit past the (unchanged) orders ahead of the resized order.
+        let ahead: u64 = quantities[..position].iter().sum();
+        let result = sweep(&book, ahead + 1)?;
+
+        let trades = result.trades().as_vec();
+        prop_assert_eq!(
+            trades.len(),
+            position + 1,
+            "sweep must fill every order ahead plus the resized order"
+        );
+        for (fill_index, trade) in trades.iter().enumerate() {
+            prop_assert_eq!(
+                trade.maker_order_id(),
+                resting_id(fill_index),
+                "fill {} must consume insertion position {}",
+                fill_index,
+                fill_index
+            );
+        }
+    }
+
+    /// Increasing an order's quantity must demote it to the back of the
+    /// queue: a sweep that consumes every other order plus one unit must
+    /// fill all other orders in insertion order first and hit the resized
+    /// order last.
+    #[test]
+    fn test_update_quantity_increase_demotes_to_back_of_queue(
+        quantities in proptest::collection::vec(1u64..=50, 3..8),
+        position_index in any::<prop::sample::Index>(),
+        delta_index in any::<prop::sample::Index>(),
+    ) {
+        // Pick a position that is not already last, so the demotion is
+        // observable in the fill sequence.
+        let position = position_index.index(quantities.len() - 1);
+        let delta = 1 + delta_index.index(50) as u64;
+        let new_quantity = quantities[position] + delta;
+
+        let book = book_with_ask_level(&quantities)?;
+        resize_order(&book, position, new_quantity)?;
+
+        // Every unit not belonging to the resized order, plus one unit that
+        // must come from it — and can only be the final fill if the resize
+        // demoted it behind every other resting order.
+        let others: u64 = quantities
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| *index != position)
+            .map(|(_, quantity)| *quantity)
+            .sum();
+        let result = sweep(&book, others + 1)?;
+
+        let trades = result.trades().as_vec();
+        prop_assert_eq!(
+            trades.len(),
+            quantities.len(),
+            "sweep must fill every other order fully and the resized order once"
+        );
+
+        let expected_makers: Vec<Id> = (0..quantities.len())
+            .filter(|index| *index != position)
+            .map(resting_id)
+            .chain(std::iter::once(resting_id(position)))
+            .collect();
+        let actual_makers: Vec<Id> = trades.iter().map(|trade| trade.maker_order_id()).collect();
+        prop_assert_eq!(
+            actual_makers,
+            expected_makers,
+            "demoted order must fill last, all others in insertion order"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Issue #203 (Tracebook, an external conformance toolkit) revealed that the queue-priority semantics of `OrderBook::update_order` are consumed as a public contract, yet they were documented only inside the embedded `pricelevel` engine and had no regression coverage in this crate. This PR promotes the contract to the public docs and locks it in with property-based tests. No behavior change.

## Changes

- Documented the queue-priority contract on `OrderBook::update_order`: an in-place quantity decrease (or unchanged total) keeps the maker's queue position; a quantity increase demotes the order to the back of its price level; `UpdatePrice` / `UpdatePriceAndQuantity` / `Replace` are cancel-then-add and always lose time priority — for `Replace` and `UpdatePriceAndQuantity` even when the price is unchanged.
- Documented the snapshot caveat: a demoted order keeps its original admission timestamp (only its insertion sequence is refreshed), so `(timestamp, seq)`-sorted snapshot views can show it ahead of where matching will consume it.
- Added `tests/unit/props_quantity_update_priority.rs` with two proptest invariants (256 cases each) driven purely through the public API: a market-order sweep after an in-place decrease must fill the resized order at its original queue position, and a sweep after an increase must fill it last.
- `CHANGELOG.md` entry under Unreleased.

## Testing

- [x] Unit tests added or updated
- [x] Integration tests under `tests/unit/` added or updated
- [x] Pre-submission checks run locally and clean (`cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, `cargo test --all-features`, `cargo build --release`)

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Checked arithmetic on protocol counters — no `saturating_*` / `wrapping_*`
- [x] No `unsafe` introduced (`#![deny(unsafe_code)]` is on)
- [x] Module boundaries respected (core engine has no deps on `manager`, `nats*`, `sequencer/`)
- [x] No new dependencies added without explicit approval
- [x] `tracing` only for logging — no `println!` / `eprintln!` / `dbg!` / `log` crate
- [x] `CHANGELOG.md` updated (`src/lib.rs` module docs untouched, so no `README.md` regeneration needed)

Closes #203
