### PR TITLE
Bump pricelevel to 0.9.1; upsize demotion survives snapshot restore (#205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.12.0] — 2026-07-14
+
+### Changed (breaking, semver-minor under 0.x)
+
+- **`pricelevel` 0.8.4 → 0.9.1.** Major upstream hardening release
+  (PriceLevel #111–#120): validated admission (duplicate id, counter
+  capacity, price/side topology), atomic PostOnly / fill-or-kill decisions,
+  torn-read-safe execution statistics, and level snapshots materialized in
+  queue-consumption order. 0.9.1 additionally fixes the `MatchResult`
+  bincode round-trip (PriceLevel#135, found by this bump: 0.9.0 serialized
+  a shape its own validated decoder rejected positionally, breaking the
+  `bincode` feature's trade-event round-trip). Ripple on the re-exported
+  surface:
+  `PriceLevel::add_order` returns `Result`, `PriceLevel::matchable_quantity`
+  takes the taker id (the dry run applies the sweep's self-match skip), and
+  `PriceLevelError` gained the `DuplicateOrderId` variant.
+- **`OrderBook::get_bt_bids` / `get_bt_asks` are now fallible**, returning
+  `Result<BTreeMap<u128, PriceLevel>, OrderBookError>` — rebuilding a
+  `PriceLevel` from a snapshot validates admission upstream (`TryFrom`
+  replaced the infallible `From`).
+
+### Fixed
+
+- **The upsize queue-priority demotion survives a snapshot round-trip
+  (#205).** Level snapshots now materialize orders in queue-consumption
+  order (pricelevel 0.9, PriceLevel#109), so
+  `restore_from_snapshot_package` rebuilds the exact queue and a
+  quantity-increased order keeps its back-of-queue position after restore.
+  Locked in by a proptest regression
+  (`tests/unit/props_quantity_update_priority.rs`). **Migration note:**
+  snapshots captured with pricelevel < 0.9 restore a demoted order at its
+  old `(timestamp, seq)` position — re-snapshot after upgrading to pin the
+  corrected order. No orderbook envelope change:
+  `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` stays 2; the embedded statistics
+  gained an optional `stats_degraded` field that legacy snapshots omit.
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orderbook-rs"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."
@@ -147,7 +147,7 @@ members = [
 
 [workspace.dependencies]
 orderbook-rs = { path = "." }
-pricelevel = "0.8.4"
+pricelevel = "0.9.1"
 tracing = "0.1"
 uuid = { version = "1.23", features = ["v4", "v5", "serde"] }
 dashmap = "6.2"
@@ -168,3 +168,4 @@ crc32fast = "1.5"
 memmap2 = "0.9"
 metrics = "0.24"
 zerocopy = { version = "0.8", features = ["derive"]}
+

--- a/README.md
+++ b/README.md
@@ -46,6 +46,35 @@ This order book engine is built with the following design principles:
 - **Research**: Platform for studying market microstructure and order flow
 - **Educational**: Reference implementation for understanding modern exchange architecture
 
+### What's New in Version 0.12.0
+
+#### v0.12.0 — pricelevel 0.9 hardening bump; upsize demotion survives snapshot restore (#205)
+
+- **`pricelevel` 0.8.4 → 0.9.1.** Major upstream hardening release: level
+  admission validates before mutating (duplicate id, counter capacity,
+  price/side topology), PostOnly / fill-or-kill decisions are atomic with
+  the sweep, execution statistics are torn-read-safe, and level snapshots
+  materialize orders in queue-consumption order. 0.9.1 fixes the
+  `MatchResult` bincode round-trip (PriceLevel#135), keeping the
+  `bincode` feature's trade-event round-trip intact.
+- **The upsize queue-priority demotion now survives a snapshot
+  round-trip (#205).** Restoring a snapshot rebuilds each level's queue
+  exactly as matching would consume it, so an order demoted by a quantity
+  increase keeps its back-of-queue position after
+  `restore_from_snapshot_package`. Locked in by a proptest regression
+  (`tests/unit/props_quantity_update_priority.rs`). Snapshots captured
+  with pricelevel < 0.9 restore demoted orders at their old
+  `(timestamp, seq)` position — re-snapshot to pin the corrected order.
+- **Breaking (semver-minor under 0.x):** `get_bt_bids` / `get_bt_asks`
+  now return `Result<BTreeMap<u128, PriceLevel>, OrderBookError>`
+  (snapshot-to-level conversion is validating and fallible upstream), and
+  the re-exported pricelevel surface changed —
+  `PriceLevel::add_order` returns `Result`, `matchable_quantity` takes
+  the taker id, `PriceLevelError` gained `DuplicateOrderId`. No orderbook
+  envelope format change: `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` stays 2;
+  pricelevel statistics gained an optional `stats_degraded` field that
+  old snapshots simply omit.
+
 ### What's New in Version 0.11.0
 
 #### v0.11.0 — replay reproduces the trade-ID stream: namespace in `ReplayBookConfig` (#200)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,35 @@
 //! - **Research**: Platform for studying market microstructure and order flow
 //! - **Educational**: Reference implementation for understanding modern exchange architecture
 //!
+//! ## What's New in Version 0.12.0
+//!
+//! ### v0.12.0 — pricelevel 0.9 hardening bump; upsize demotion survives snapshot restore (#205)
+//!
+//! - **`pricelevel` 0.8.4 → 0.9.1.** Major upstream hardening release: level
+//!   admission validates before mutating (duplicate id, counter capacity,
+//!   price/side topology), PostOnly / fill-or-kill decisions are atomic with
+//!   the sweep, execution statistics are torn-read-safe, and level snapshots
+//!   materialize orders in queue-consumption order. 0.9.1 fixes the
+//!   `MatchResult` bincode round-trip (PriceLevel#135), keeping the
+//!   `bincode` feature's trade-event round-trip intact.
+//! - **The upsize queue-priority demotion now survives a snapshot
+//!   round-trip (#205).** Restoring a snapshot rebuilds each level's queue
+//!   exactly as matching would consume it, so an order demoted by a quantity
+//!   increase keeps its back-of-queue position after
+//!   `restore_from_snapshot_package`. Locked in by a proptest regression
+//!   (`tests/unit/props_quantity_update_priority.rs`). Snapshots captured
+//!   with pricelevel < 0.9 restore demoted orders at their old
+//!   `(timestamp, seq)` position — re-snapshot to pin the corrected order.
+//! - **Breaking (semver-minor under 0.x):** `get_bt_bids` / `get_bt_asks`
+//!   now return `Result<BTreeMap<u128, PriceLevel>, OrderBookError>`
+//!   (snapshot-to-level conversion is validating and fallible upstream), and
+//!   the re-exported pricelevel surface changed —
+//!   `PriceLevel::add_order` returns `Result`, `matchable_quantity` takes
+//!   the taker id, `PriceLevelError` gained `DuplicateOrderId`. No orderbook
+//!   envelope format change: `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` stays 2;
+//!   pricelevel statistics gained an optional `stats_degraded` field that
+//!   old snapshots simply omit.
+//!
 //! ## What's New in Version 0.11.0
 //!
 //! ### v0.11.0 — replay reproduces the trade-ID stream: namespace in `ReplayBookConfig` (#200)

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -3352,27 +3352,37 @@ where
     }
 
     /// Get a BTreeMap of bids with price as key and PriceLevel as value
-    pub fn get_bt_bids(&self) -> BTreeMap<u128, PriceLevel> {
+    ///
+    /// # Errors
+    /// Returns [`OrderBookError::PriceLevelError`] if rebuilding a level
+    /// from its snapshot fails validation (pricelevel 0.9 validates
+    /// snapshot admission instead of trusting it).
+    pub fn get_bt_bids(&self) -> Result<BTreeMap<u128, PriceLevel>, OrderBookError> {
         self.bids
             .iter()
             .map(|entry| {
                 let price = *entry.key();
                 let snapshot = entry.value().snapshot();
-                let price_level = PriceLevel::from(&snapshot);
-                (price, price_level)
+                let price_level = PriceLevel::try_from(&snapshot)?;
+                Ok((price, price_level))
             })
             .collect()
     }
 
     /// Get a BTreeMap of asks with price as key and PriceLevel as value
-    pub fn get_bt_asks(&self) -> BTreeMap<u128, PriceLevel> {
+    ///
+    /// # Errors
+    /// Returns [`OrderBookError::PriceLevelError`] if rebuilding a level
+    /// from its snapshot fails validation (pricelevel 0.9 validates
+    /// snapshot admission instead of trusting it).
+    pub fn get_bt_asks(&self) -> Result<BTreeMap<u128, PriceLevel>, OrderBookError> {
         self.asks
             .iter()
             .map(|entry| {
                 let price = *entry.key();
                 let snapshot = entry.value().snapshot();
-                let price_level = PriceLevel::from(&snapshot);
-                (price, price_level)
+                let price_level = PriceLevel::try_from(&snapshot)?;
+                Ok((price, price_level))
             })
             .collect()
     }

--- a/src/orderbook/error.rs
+++ b/src/orderbook/error.rs
@@ -409,6 +409,9 @@ impl Clone for OrderBookError {
                             actual: actual.clone(),
                         }
                     }
+                    PriceLevelError::DuplicateOrderId(id) => {
+                        PriceLevelError::DuplicateOrderId(id.clone())
+                    }
                 };
                 OrderBookError::PriceLevelError(cloned_err)
             }

--- a/src/orderbook/matching.rs
+++ b/src/orderbook/matching.rs
@@ -904,6 +904,7 @@ where
         quantity: u64,
         price_limit: Option<u128>,
         taker_user_id: Hash32,
+        taker_id: Id,
     ) -> u64 {
         let price_levels = match side {
             Side::Buy => &self.asks,
@@ -966,7 +967,7 @@ where
                 match check_stp_at_level(&orders, taker_user_id, self.stp_mode) {
                     // No self-trade: the whole level is reachable — delegate to the
                     // upstream dry run.
-                    STPAction::NoConflict => (price_level.matchable_quantity(cap), false),
+                    STPAction::NoConflict => (price_level.matchable_quantity(cap, taker_id), false),
                     // Same-user makers are cancelled, not filled: only non-self
                     // resting depth is reachable; the walk continues. The upstream
                     // primitive cannot filter by user, so the non-self matchable
@@ -986,7 +987,7 @@ where
                     | STPAction::CancelBoth { safe_quantity, .. } => (safe_quantity, true),
                 }
             } else {
-                (price_level.matchable_quantity(cap), false)
+                (price_level.matchable_quantity(cap, taker_id), false)
             };
 
             matched = matched.saturating_add(cap.min(reachable));

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -136,13 +136,14 @@ where
     ///   quantity demotes the order to the back of its price level's
     ///   queue. Sizing up loses time priority. The demoted order keeps
     ///   its original admission timestamp — only its insertion sequence
-    ///   is refreshed. **Known limitation:** the demotion does not yet
-    ///   survive a snapshot round-trip — level capture orders by
-    ///   `(timestamp, seq)` without persisting the sequence, and
+    ///   is refreshed. The demotion survives a snapshot round-trip:
+    ///   since pricelevel 0.9 level snapshots materialize orders in
+    ///   queue-consumption order, so
     ///   [`restore_from_snapshot`](OrderBook::restore_from_snapshot)
-    ///   re-enqueues in that order, so a restored book consumes the
-    ///   upsized order at its pre-demotion position (tracked in
-    ///   issue #205, fix upstream in `pricelevel`).
+    ///   rebuilds the exact queue (#205). Snapshots captured with
+    ///   pricelevel < 0.9 restore a demoted order at its old
+    ///   `(timestamp, seq)` position — re-snapshot to pin the corrected
+    ///   order.
     /// - [`OrderUpdate::UpdatePrice`], [`OrderUpdate::UpdatePriceAndQuantity`],
     ///   and [`OrderUpdate::Replace`] are implemented as cancel-then-add:
     ///   the order always re-enters at the back of its (possibly new)
@@ -875,6 +876,7 @@ where
                 order.total_quantity(),
                 Some(order.price().as_u128()),
                 order.user_id(),
+                order.id(),
             );
             if potential_match < order.total_quantity() {
                 return Err(OrderBookError::InsufficientLiquidity {
@@ -969,7 +971,8 @@ where
             }
             // No same-user maker at this level: the taker consumes its full
             // matchable depth (the authoritative upstream dry run), then walks on.
-            remaining = remaining.saturating_sub(level.matchable_quantity(remaining));
+            remaining =
+                remaining.saturating_sub(level.matchable_quantity(remaining, new_order.id()));
         }
         Ok(())
     }
@@ -1273,9 +1276,13 @@ where
             let price_level = price_levels.get_or_insert(price, Arc::new(PriceLevel::new(price)));
             let level = price_level.value();
 
-            // Convert to unit type for PriceLevel compatibility
+            // Convert to unit type for PriceLevel compatibility. Admission
+            // into the level is validated upstream since pricelevel 0.9
+            // (duplicate id, counter capacity); a failure here is an
+            // invariant break — the book-level duplicate check already
+            // passed — so propagate it rather than resting a phantom order.
             let unit_order = self.convert_to_unit_type(&order);
-            let unit_order_arc = price_level.value().add_order(unit_order);
+            let unit_order_arc = price_level.value().add_order(unit_order)?;
             // notify price level changes
             if let Some(ref listener) = self.price_level_changed_listener {
                 let engine_seq = self.next_engine_seq();

--- a/src/orderbook/private.rs
+++ b/src/orderbook/private.rs
@@ -90,7 +90,7 @@ where
 
         // Convert OrderType<T> to OrderType<()> for compatibility with current PriceLevel API
         let unit_order = self.convert_to_unit_type(&*order);
-        let _added_order = price_level.add_order(unit_order);
+        let _added_order = price_level.add_order(unit_order)?;
 
         // notify price level changes
         if let Some(ref listener) = self.price_level_changed_listener {

--- a/src/orderbook/trade.rs
+++ b/src/orderbook/trade.rs
@@ -279,21 +279,36 @@ mod tests {
     use super::*;
     use pricelevel::{Id, MatchResult, Price, Quantity, Trade};
 
+    /// Taker order id shared by every fixture trade: since pricelevel 0.9
+    /// `MatchResult::add_trade` validates that each trade's taker order id
+    /// matches the result's incoming order id, so the fixture threads one
+    /// id through both.
     fn make_match_result_with_trades(trades: Vec<Trade>) -> MatchResult {
-        let order_id = Id::new_uuid();
+        let taker_order_id = trades
+            .first()
+            .map(|t| t.taker_order_id())
+            .unwrap_or_else(Id::new_uuid);
         let total_qty: u64 = trades.iter().map(|t| t.quantity().as_u64()).sum();
         let initial_qty = if trades.is_empty() { 100 } else { total_qty };
-        let mut mr = MatchResult::new(order_id, Quantity::new(initial_qty));
+        let mut mr = MatchResult::new(taker_order_id, Quantity::new(initial_qty));
         for trade in trades {
-            let _ = mr.add_trade(trade);
+            assert!(
+                mr.add_trade(trade).is_ok(),
+                "fixture trade must satisfy the match-result invariants"
+            );
         }
         mr
     }
 
+    /// Taker order id for fixture trades — one shared id so
+    /// `make_match_result_with_trades` can satisfy the taker-identity
+    /// invariant.
+    const FIXTURE_TAKER: u64 = 424_242;
+
     fn make_trade(price: u128, quantity: u64) -> Trade {
         Trade::new(
             Id::new_uuid(),
-            Id::new_uuid(),
+            Id::from_u64(FIXTURE_TAKER),
             Id::new_uuid(),
             Price::new(price),
             Quantity::new(quantity),

--- a/tests/unit/props_quantity_update_priority.rs
+++ b/tests/unit/props_quantity_update_priority.rs
@@ -8,6 +8,8 @@
 //! - `Replace` and `UpdatePriceAndQuantity` always demote to the back of the
 //!   queue, even at an unchanged price and regardless of the quantity
 //!   direction (cancel-then-add semantics).
+//! - The upsize demotion survives a snapshot round-trip (issue #205,
+//!   pricelevel ≥ 0.9).
 //!
 //! All properties are asserted through the public API only: build a level of
 //! resting standard orders, update one, then sweep the level with an
@@ -208,6 +210,45 @@ proptest! {
         let book = book_with_ask_level(&quantities)?;
         resize_order(&book, position, new_quantity)?;
         assert_demoted_to_back(&book, &quantities, position)?;
+    }
+
+    /// The upsize demotion must survive a snapshot round-trip (issue #205,
+    /// fixed upstream in pricelevel 0.9 / PriceLevel#109): after resizing
+    /// up, capture a snapshot package, restore it into a fresh book, and
+    /// the sweep must still consume the demoted order last. Before the fix
+    /// the restored queue was rebuilt in `(timestamp, seq)` order and the
+    /// demoted order regained its pre-demotion position.
+    #[test]
+    fn test_update_quantity_increase_demotion_survives_snapshot_restore(
+        quantities in proptest::collection::vec(1u64..=50, 3..8),
+        position_index in any::<prop::sample::Index>(),
+        delta_index in any::<prop::sample::Index>(),
+    ) {
+        // Pick a position that is not already last, so the demotion is
+        // observable in the fill sequence.
+        let position = position_index.index(quantities.len() - 1);
+        let delta = 1 + delta_index.index(50) as u64;
+        let new_quantity = quantities[position] + delta;
+
+        let book = book_with_ask_level(&quantities)?;
+        resize_order(&book, position, new_quantity)?;
+
+        let package = match book.create_snapshot_package(quantities.len()) {
+            Ok(package) => package,
+            Err(error) => {
+                return Err(TestCaseError::fail(format!(
+                    "snapshot capture failed: {error}"
+                )));
+            }
+        };
+        let mut restored = OrderBook::<()>::new("PROPS");
+        if let Err(error) = restored.restore_from_snapshot_package(package) {
+            return Err(TestCaseError::fail(format!(
+                "snapshot restore failed: {error}"
+            )));
+        }
+
+        assert_demoted_to_back(&restored, &quantities, position)?;
     }
 
     /// A same-price `Replace` must always demote the order to the back of


### PR DESCRIPTION
## Summary

The queue-priority contract (#203) promises a quantity increase demotes the
resting order to the back of its level, but a snapshot round-trip undid the
demotion: level capture ordered by `(timestamp, seq)` without persisting the
sequence, and restore re-enqueued in that order. The fix landed upstream
(PriceLevel#109); this PR bumps `pricelevel` 0.8.4 → 0.9.1 (a breaking
hardening release), migrates the call sites, and pins the restored behavior
with a regression property test.

## Changes

- Bump `pricelevel` to 0.9.1: level snapshots now materialize orders in
  queue-consumption order, so `restore_from_snapshot_package` rebuilds the
  exact queue and the upsize demotion survives restore.
- Migrate to the 0.9 surface: `PriceLevel::add_order` is fallible (validated
  admission — failures propagate instead of resting a phantom order),
  `matchable_quantity` takes the taker id (the FOK dry run and the STP
  modify pre-check now pass it), and the `OrderBookError` clone path covers
  the new `PriceLevelError::DuplicateOrderId` variant.
- New regression proptest: rest N orders, upsize an early one, snapshot
  package → restore into a fresh book → sweep; the demoted order must fill
  last. The `# Queue priority` doc block drops the restore caveat and
  documents the pre-0.9 snapshot migration note.
- Fixed 11 trade-fixture tests that 0.9's `add_trade` taker-identity
  validation exposed (the fixtures silently swallowed the rejection).
- Found and fixed upstream during this bump: `MatchResult` bincode
  round-trip regression in pricelevel 0.9.0 (PriceLevel#135, shipped in
  0.9.1) — caught by `test_bincode_roundtrip_trade`.

## Technical decisions

- `fok_fillable_quantity` gains a `taker_id: Id` parameter instead of a
  sentinel: pricelevel's dry run applies the sweep's self-match skip by
  order id, so feasibility and the real sweep can never diverge.
- A failed level admission on the rest-after-match path propagates as
  `OrderBookError::PriceLevelError` — the book-level duplicate check already
  ran at admission, so a failure there is an invariant break, not a
  recoverable state.
- `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` stays 2: the orderbook envelope is
  unchanged; the embedded pricelevel statistics gained an optional
  `stats_degraded` field that legacy snapshots simply omit.

## Public API impact

- Crate version 0.11.0 → 0.12.0 (breaking, semver-minor under 0.x).
- `get_bt_bids` / `get_bt_asks` now return
  `Result<BTreeMap<u128, PriceLevel>, OrderBookError>` — snapshot-to-level
  conversion is validating (`TryFrom`) upstream.
- Re-exported pricelevel types changed shape (fallible `add_order`,
  two-argument `matchable_quantity`, new `PriceLevelError::DuplicateOrderId`).
- `src/lib.rs` What's New updated; `README.md` regenerated via
  `make readme`; `CHANGELOG.md` carries the 0.12.0 entry including the
  pre-0.9 snapshot migration note.

## Testing

- [x] Unit tests added or updated
- [x] Integration tests under `tests/unit/` added or updated (if applicable)
- [x] Snapshot round-trip covered (for changes to `OrderBook<T>` config fields)
- [x] `make pre-push` run locally and clean

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] No `unsafe` introduced (`#![deny(unsafe_code)]` is on)
- [x] Module boundaries respected (core engine has no deps on `manager`, `nats*`, `sequencer/`)
- [x] No new dependencies added without explicit approval (version bump of the existing `pricelevel` dep)
- [x] `tracing` only for logging — no `println!` / `eprintln!` / `dbg!` / `log` crate
- [x] `src/lib.rs` docs + `README.md` (via `make readme`) + `CHANGELOG.md` updated if user-visible

Closes #205
