### PR TITLE
Bump snapshot package format to v3 for pricelevel 0.9 statistics (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`tests/unit/props_quantity_update_priority.rs`). **Migration note:**
   snapshots captured with pricelevel < 0.9 restore a demoted order at its
   old `(timestamp, seq)` position — re-snapshot after upgrading to pin the
-  corrected order. No orderbook envelope change:
-  `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` stays 2; the embedded statistics
-  gained an optional `stats_degraded` field that legacy snapshots omit.
+  corrected order.
+- **Snapshot package format bumped to v3 (#206).** The pricelevel 0.9
+  statistics schema can serialize a `stats_degraded` field that a
+  pricelevel 0.8 reader rejects with `unknown field`, so labelling such
+  payloads `version: 2` (as #205 initially shipped) mislabelled them as
+  0.11-compatible. Newly written packages are stamped `3`; reads accept
+  `2..=3` (`ORDERBOOK_SNAPSHOT_MIN_READ_VERSION`), so legacy v2 packages
+  with the 8-field statistics shape still restore; `1` and future versions
+  are rejected with the existing typed error, and the checksum is
+  validated for both supported versions. Covered by a legacy-v2 restore
+  fixture and a real-engine degraded-statistics (notional > `u64::MAX`)
+  round-trip.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,13 @@ This order book engine is built with the following design principles:
   (snapshot-to-level conversion is validating and fallible upstream), and
   the re-exported pricelevel surface changed —
   `PriceLevel::add_order` returns `Result`, `matchable_quantity` takes
-  the taker id, `PriceLevelError` gained `DuplicateOrderId`. No orderbook
-  envelope format change: `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` stays 2;
-  pricelevel statistics gained an optional `stats_degraded` field that
-  old snapshots simply omit.
+  the taker id, `PriceLevelError` gained `DuplicateOrderId`.
+- **Snapshot package format v3 (#206).** Pricelevel 0.9 statistics can
+  serialize a `stats_degraded` field that 0.8 readers reject, so newly
+  written packages are stamped `ORDERBOOK_SNAPSHOT_FORMAT_VERSION = 3`.
+  Reads accept `ORDERBOOK_SNAPSHOT_MIN_READ_VERSION (2)..=3` — legacy v2
+  packages still restore — while `1` and future versions stay rejected
+  with the existing typed error.
 
 ### What's New in Version 0.11.0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,10 +56,13 @@
 //!   (snapshot-to-level conversion is validating and fallible upstream), and
 //!   the re-exported pricelevel surface changed —
 //!   `PriceLevel::add_order` returns `Result`, `matchable_quantity` takes
-//!   the taker id, `PriceLevelError` gained `DuplicateOrderId`. No orderbook
-//!   envelope format change: `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` stays 2;
-//!   pricelevel statistics gained an optional `stats_degraded` field that
-//!   old snapshots simply omit.
+//!   the taker id, `PriceLevelError` gained `DuplicateOrderId`.
+//! - **Snapshot package format v3 (#206).** Pricelevel 0.9 statistics can
+//!   serialize a `stats_degraded` field that 0.8 readers reject, so newly
+//!   written packages are stamped `ORDERBOOK_SNAPSHOT_FORMAT_VERSION = 3`.
+//!   Reads accept `ORDERBOOK_SNAPSHOT_MIN_READ_VERSION (2)..=3` — legacy v2
+//!   packages still restore — while `1` and future versions stay rejected
+//!   with the existing typed error.
 //!
 //! ## What's New in Version 0.11.0
 //!

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -96,7 +96,7 @@ pub use sequencer::{JournalError, SequencerCommand, SequencerEvent, SequencerRes
 pub use serialization::BincodeEventSerializer;
 pub use serialization::{EventSerializer, JsonEventSerializer, SerializationError};
 pub use snapshot::{
-    EnrichedSnapshot, MetricFlags, ORDERBOOK_SNAPSHOT_FORMAT_VERSION, OrderBookSnapshot,
-    OrderBookSnapshotPackage,
+    EnrichedSnapshot, MetricFlags, ORDERBOOK_SNAPSHOT_FORMAT_VERSION,
+    ORDERBOOK_SNAPSHOT_MIN_READ_VERSION, OrderBookSnapshot, OrderBookSnapshotPackage,
 };
 pub use statistics::{DepthStats, DistributionBin};

--- a/src/orderbook/snapshot.rs
+++ b/src/orderbook/snapshot.rs
@@ -140,12 +140,27 @@ impl OrderBookSnapshot {
 
 /// Format version used for checksum-enabled order book snapshots.
 ///
-/// Bumped to `2` to accompany the addition of [`OrderBookSnapshotPackage::engine_seq`],
-/// which persists the engine's outbound monotonic counter across snapshot/restore.
-/// `version: 1` payloads are rejected by [`OrderBookSnapshotPackage::validate`]
-/// with the existing `Unsupported snapshot version` error — the format break is
+/// Bumped to `3` for the pricelevel 0.9 statistics schema: embedded
+/// level statistics may now carry a `stats_degraded` field (serialized
+/// only when `true`), which a pricelevel 0.8 reader rejects with
+/// `unknown field`. Newly written packages are stamped `3` so an old
+/// reader fails fast on the version check instead of deep inside
+/// statistics deserialization (#206).
+///
+/// Reads accept [`ORDERBOOK_SNAPSHOT_MIN_READ_VERSION`]`..=`this:
+/// `version: 2` payloads (written by 0.11 / pricelevel 0.8) contain the
+/// legacy 8-field statistics shape, which pricelevel 0.9 still decodes.
+/// `version: 1` payloads (no `engine_seq`) remain rejected by
+/// [`OrderBookSnapshotPackage::validate`] with the existing
+/// `Unsupported snapshot version` error — that format break is
 /// intentional, with no special-case migration path.
-pub const ORDERBOOK_SNAPSHOT_FORMAT_VERSION: u32 = 2;
+pub const ORDERBOOK_SNAPSHOT_FORMAT_VERSION: u32 = 3;
+
+/// Oldest package format version [`OrderBookSnapshotPackage::validate`]
+/// still accepts on read. Version `2` packages predate the pricelevel
+/// 0.9 `stats_degraded` statistics field and restore cleanly — the field
+/// simply defaults to `false`.
+pub const ORDERBOOK_SNAPSHOT_MIN_READ_VERSION: u32 = 2;
 
 /// Wrapper that provides checksum validation for `OrderBookSnapshot` instances.
 ///
@@ -287,12 +302,25 @@ impl OrderBookSnapshotPackage {
     }
 
     /// Validates the checksum and version.
+    ///
+    /// Accepts package versions
+    /// [`ORDERBOOK_SNAPSHOT_MIN_READ_VERSION`]`..=`[`ORDERBOOK_SNAPSHOT_FORMAT_VERSION`]
+    /// — the current format plus the pre-pricelevel-0.9 legacy format —
+    /// and rejects anything older or newer with a typed error. The
+    /// checksum covers the snapshot payload only (not the version
+    /// field), and its algorithm is identical for every supported
+    /// version.
+    #[must_use = "an unchecked snapshot package must not be restored"]
     pub fn validate(&self) -> Result<(), OrderBookError> {
-        if self.version != ORDERBOOK_SNAPSHOT_FORMAT_VERSION {
+        if self.version < ORDERBOOK_SNAPSHOT_MIN_READ_VERSION
+            || self.version > ORDERBOOK_SNAPSHOT_FORMAT_VERSION
+        {
             return Err(OrderBookError::InvalidOperation {
                 message: format!(
-                    "Unsupported snapshot version: {} (expected {})",
-                    self.version, ORDERBOOK_SNAPSHOT_FORMAT_VERSION
+                    "Unsupported snapshot version: {} (supported {}..={})",
+                    self.version,
+                    ORDERBOOK_SNAPSHOT_MIN_READ_VERSION,
+                    ORDERBOOK_SNAPSHOT_FORMAT_VERSION
                 ),
             });
         }
@@ -309,6 +337,7 @@ impl OrderBookSnapshotPackage {
     }
 
     /// Consumes the package and returns the validated snapshot.
+    #[must_use = "the validated snapshot (or the validation error) must be handled"]
     pub fn into_snapshot(self) -> Result<OrderBookSnapshot, OrderBookError> {
         self.validate()?;
         Ok(self.snapshot)

--- a/src/orderbook/tests/snapshot.rs
+++ b/src/orderbook/tests/snapshot.rs
@@ -708,8 +708,8 @@ mod test_snapshot_engine_seq {
 
     /// `version: 1` payloads — the legacy format that lacked `engine_seq`
     /// — must be rejected by `validate()` with the existing
-    /// `Unsupported snapshot version` error after the bump to v2. No
-    /// special-casing.
+    /// `Unsupported snapshot version` error. Unlike `version: 2` (which
+    /// stays readable after the v3 bump, #206), v1 has no migration path.
     #[test]
     fn test_snapshot_package_v1_payload_rejected_by_validate() {
         let payload = serde_json::json!({
@@ -753,8 +753,8 @@ mod test_snapshot_engine_seq {
                     "error message must mention version 1, got: {message}"
                 );
                 assert!(
-                    message.contains('2'),
-                    "error message must mention expected version 2, got: {message}"
+                    message.contains("2..=3"),
+                    "error message must state the supported range, got: {message}"
                 );
             }
             other => panic!("expected InvalidOperation, got {other:?}"),
@@ -851,6 +851,198 @@ mod test_snapshot_engine_seq {
             restored.market_close_timestamp.load(Ordering::Relaxed),
             1_700_000_000_000,
             "market_close_timestamp must survive the round trip"
+        );
+    }
+}
+
+#[cfg(test)]
+mod test_snapshot_format_v3 {
+    use crate::DefaultOrderBook;
+    use crate::orderbook::error::OrderBookError;
+    use crate::orderbook::{
+        ORDERBOOK_SNAPSHOT_FORMAT_VERSION, ORDERBOOK_SNAPSHOT_MIN_READ_VERSION,
+        OrderBookSnapshotPackage,
+    };
+    use pricelevel::{Hash32, Id, Side, TimeInForce};
+
+    /// New packages are stamped with the current (v3) format version, and a
+    /// non-degraded book's payload carries no `stats_degraded` key at all
+    /// (pricelevel serializes it only when `true`), which is exactly the
+    /// shape a legacy v2 payload has.
+    #[test]
+    fn test_new_package_is_v3_and_omits_stats_degraded_when_clean() {
+        let book = DefaultOrderBook::new("V3");
+        let added = book.add_limit_order_with_user(
+            Id::from_u64(1),
+            1_000,
+            10,
+            Side::Sell,
+            TimeInForce::Gtc,
+            Hash32::zero(),
+            None,
+        );
+        assert!(added.is_ok(), "resting order must be admitted");
+
+        let package = book.create_snapshot_package(10).expect("build package");
+        assert_eq!(
+            package.version, ORDERBOOK_SNAPSHOT_FORMAT_VERSION,
+            "new packages carry the current format version"
+        );
+        assert_eq!(ORDERBOOK_SNAPSHOT_FORMAT_VERSION, 3, "current version is 3");
+
+        let json = package.to_json().expect("serialize package");
+        assert!(
+            !json.contains("stats_degraded"),
+            "clean statistics must omit the stats_degraded key: {json}"
+        );
+    }
+
+    /// A genuine pricelevel-0.8.4 `version: 2` package must validate and
+    /// restore under 0.9. The fixture below was produced by pricelevel
+    /// 0.8.4 itself (`PriceLevel::add_order` + `snapshot()`, one resting
+    /// standard buy of 25 @ 2000): 8-field statistics shape, no
+    /// `stats_degraded` key, and a checksum computed over 0.8.4's
+    /// serialization bytes. `validate()` recomputes the checksum by
+    /// re-serializing the deserialized snapshot with pricelevel 0.9, so
+    /// this test pins the guarantee the version range relies on: 0.9
+    /// re-serializes a clean legacy payload byte-identically.
+    #[test]
+    fn test_genuine_v2_fixture_from_pricelevel_08_validates_and_restores() {
+        let fixture = r#"{"checksum":"1ebecd15260955cc949817f9faa90cfb097effcdd758c5ba5233b7bd5b6f3322","engine_seq":5,"fee_schedule":null,"lot_size":null,"max_order_size":null,"min_order_size":null,"snapshot":{"asks":[],"bids":[{"hidden_quantity":0,"order_count":1,"orders":[{"Standard":{"extra_fields":null,"id":"00000000-0000-0007-0000-000000000000","price":2000,"quantity":25,"side":"BUY","time_in_force":"GTC","timestamp":1700000000000,"user_id":"0000000000000000000000000000000000000000000000000000000000000000"}}],"price":2000,"statistics":{"first_arrival_time":1784087691896,"last_execution_time":0,"orders_added":1,"orders_executed":0,"orders_removed":0,"quantity_executed":0,"sum_waiting_time":0,"value_executed":0},"visible_quantity":25}],"symbol":"V2FIX","timestamp":1700000000000},"stp_mode":"None","tick_size":null,"version":2}"#;
+
+        let package =
+            OrderBookSnapshotPackage::from_json(fixture).expect("0.8.4 payload must deserialize");
+        assert_eq!(package.version, 2, "fixture is a legacy v2 package");
+        assert_eq!(package.engine_seq, 5, "engine_seq decodes");
+        assert!(
+            package.validate().is_ok(),
+            "the 0.8.4-computed checksum must revalidate under pricelevel 0.9"
+        );
+
+        let mut restored = DefaultOrderBook::new("V2FIX");
+        restored
+            .restore_from_snapshot_package(package)
+            .expect("genuine v2 package must restore");
+        assert_eq!(
+            restored.best_bid(),
+            Some(2_000),
+            "restored book carries the 0.8.4 resting order"
+        );
+        assert_eq!(restored.engine_seq(), 5, "engine_seq restored verbatim");
+    }
+
+    /// A `version: 2`-labelled package with 0.9-produced content must also
+    /// stay readable (the version range check, independent of wire-shape
+    /// fidelity — the genuine 0.8.4 fixture above covers that). The
+    /// checksum covers the snapshot payload only, so relabelling keeps it
+    /// valid.
+    #[test]
+    fn test_v2_package_still_validates_and_restores() {
+        let book = DefaultOrderBook::new("V2C");
+        let added = book.add_limit_order_with_user(
+            Id::from_u64(7),
+            2_000,
+            25,
+            Side::Buy,
+            TimeInForce::Gtc,
+            Hash32::zero(),
+            None,
+        );
+        assert!(added.is_ok(), "resting order must be admitted");
+
+        let mut package = book.create_snapshot_package(10).expect("build package");
+        package.version = ORDERBOOK_SNAPSHOT_MIN_READ_VERSION;
+
+        // Full wire round-trip of the v2-labelled package.
+        let json = package.to_json().expect("serialize v2 package");
+        let parsed = OrderBookSnapshotPackage::from_json(&json).expect("parse v2 package");
+        assert_eq!(parsed.version, 2, "payload keeps the legacy version");
+        assert!(parsed.validate().is_ok(), "v2 packages must stay readable");
+
+        let mut restored = DefaultOrderBook::new("V2C");
+        restored
+            .restore_from_snapshot_package(parsed)
+            .expect("v2 package must restore");
+        assert_eq!(
+            restored.best_bid(),
+            Some(2_000),
+            "restored book carries the legacy package's resting order"
+        );
+    }
+
+    /// Versions newer than the current format must be rejected with the
+    /// same typed error as v1 — a reader must never guess at a future
+    /// schema.
+    #[test]
+    fn test_future_version_rejected_by_validate() {
+        let book = DefaultOrderBook::new("V4");
+        let mut package = book.create_snapshot_package(10).expect("build package");
+        package.version = ORDERBOOK_SNAPSHOT_FORMAT_VERSION + 1;
+
+        let err = package
+            .validate()
+            .expect_err("future versions must be rejected");
+        match err {
+            OrderBookError::InvalidOperation { message } => {
+                assert!(
+                    message.contains("Unsupported snapshot version"),
+                    "error must mention the unsupported version, got: {message}"
+                );
+            }
+            other => panic!("expected InvalidOperation, got {other:?}"),
+        }
+    }
+
+    /// The #206 repro: a fill whose notional overflows pricelevel's u64
+    /// statistics counter sets the sticky `stats_degraded` flag. The
+    /// resulting snapshot must serialize the flag, be stamped v3, and
+    /// round-trip — including the flag — through the checksummed package.
+    #[test]
+    fn test_degraded_statistics_round_trip_is_v3() {
+        let book = DefaultOrderBook::new("DEG");
+        // Price above u64::MAX: one executed unit already overflows the
+        // u64 value-executed counter, degrading the level statistics.
+        let price = u128::from(u64::MAX) + 1;
+        let added = book.add_limit_order_with_user(
+            Id::from_u64(1),
+            price,
+            2,
+            Side::Sell,
+            TimeInForce::Gtc,
+            Hash32::zero(),
+            None,
+        );
+        assert!(added.is_ok(), "resting order must be admitted");
+
+        let swept =
+            book.submit_market_order_with_user(Id::from_u64(9_999), 1, Side::Buy, Hash32::zero());
+        assert!(swept.is_ok(), "market sweep must execute one unit");
+
+        let json = book.snapshot_to_json(10).expect("serialize package");
+        assert!(
+            json.contains("\"stats_degraded\":true"),
+            "degraded flag must be serialized: {json}"
+        );
+
+        let package = OrderBookSnapshotPackage::from_json(&json).expect("parse package");
+        assert_eq!(package.version, 3, "degraded payload is stamped v3");
+        assert!(package.validate().is_ok(), "checksum must hold");
+
+        let mut restored = DefaultOrderBook::new("DEG");
+        restored
+            .restore_from_snapshot_package(package)
+            .expect("degraded package must restore");
+
+        // The sticky flag survives the round-trip: re-snapshotting the
+        // restored book still reports the degradation.
+        let resnapshot = restored.create_snapshot(10);
+        let level = resnapshot
+            .asks
+            .first()
+            .expect("restored book keeps the ask level");
+        assert!(
+            level.statistics().stats_degraded(),
+            "stats_degraded must survive restore"
         );
     }
 }


### PR DESCRIPTION
## Summary

pricelevel 0.9 statistics can serialize a `stats_degraded` field that a
pricelevel 0.8 reader rejects with `unknown field`, yet #212 kept the
snapshot package at `version: 2` — mislabelling such payloads as
0.11-compatible. This bumps the envelope to v3 while keeping legacy v2
packages readable.

## Changes

- `ORDERBOOK_SNAPSHOT_FORMAT_VERSION` 2 → 3; new
  `ORDERBOOK_SNAPSHOT_MIN_READ_VERSION = 2`. `validate()` accepts `2..=3`,
  rejects `1` and future versions with the existing typed error, and
  validates the checksum for both supported versions (the checksum covers
  the snapshot payload only and its algorithm is unchanged).
- `#[must_use]` on `validate()` and `into_snapshot()`.
- Corrected the #212 CHANGELOG / lib.rs claim that no envelope bump was
  needed.

## Testing

- Genuine pricelevel-0.8.4 v2 fixture (produced by 0.8.4's own
  `PriceLevel::snapshot()`, 8-field statistics, 0.8.4-computed checksum)
  deserializes, revalidates byte-identically under 0.9, and restores.
- v2-labelled 0.9 content restores (range check); v1 and v4 rejected typed.
- Real-engine degraded round-trip: notional > `u64::MAX` sets
  `stats_degraded: true`, package stamped v3, flag survives restore.
- Full suite: 807 lib + 482 integration, 0 failed. `make pre-push` clean.

## Stack

- Base branch: `main`
- Stack: **#206 (this)** → #207 → #208 → #210 → #211 → #209

Closes #206
