### PR TITLE
Make snapshot restoration failure-atomic (#207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   snapshots captured with pricelevel < 0.9 restore a demoted order at its
   old `(timestamp, seq)` position — re-snapshot after upgrading to pin the
   corrected order.
+- **Snapshot restoration is failure-atomic (#207).** `restore_from_snapshot`
+  used to clear the live book before converting each level through
+  pricelevel 0.9's fallible `PriceLevel::from_snapshot`, so an invalid later
+  level destroyed the original state and left a valid prefix of the
+  replacement installed; `restore_from_snapshot_package` additionally
+  installed risk configuration before that fallible work. Restore is now
+  two-phase: every fallible step (level validation, plus a new cross-level
+  duplicate-order-id check that reports `OrderBookError::DuplicateOrderId`)
+  runs against off-book structures, and the live book, indices, risk state,
+  and configuration are only touched after all of it succeeds — any error
+  leaves the pre-restore book byte-identical. The package path rebuilds risk
+  entries during the commit walk (same registration as live admission),
+  replacing the snapshot-based `rebuild_from_snapshot`. Two adjacent fixes
+  ride along: a snapshot carrying two same-side levels at one price is now
+  rejected (the install would keep one level while the index rebuild
+  registered both), and restoring a package without a risk config now also
+  purges any pre-restore risk entries — previously they survived `disable()`
+  and could resurrect stale counters on a later `set_risk_config`.
 - **Snapshot package format bumped to v3 (#206).** The pricelevel 0.9
   statistics schema can serialize a `stats_degraded` field that a
   pricelevel 0.8 reader rejects with `unknown field`, so labelling such

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ This order book engine is built with the following design principles:
   the re-exported pricelevel surface changed —
   `PriceLevel::add_order` returns `Result`, `matchable_quantity` takes
   the taker id, `PriceLevelError` gained `DuplicateOrderId`.
+- **Failure-atomic snapshot restore (#207).** `restore_from_snapshot` and
+  `restore_from_snapshot_package` validate every level (and reject
+  cross-level duplicate order ids with `DuplicateOrderId`) against
+  off-book structures before clearing the live book, so a failed restore
+  leaves the pre-restore state — orders, indices, config, risk,
+  kill-switch, engine sequence — completely untouched.
 - **Snapshot package format v3 (#206).** Pricelevel 0.9 statistics can
   serialize a `stats_degraded` field that 0.8 readers reject, so newly
   written packages are stamped `ORDERBOOK_SNAPSHOT_FORMAT_VERSION = 3`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,12 @@
 //!   the re-exported pricelevel surface changed —
 //!   `PriceLevel::add_order` returns `Result`, `matchable_quantity` takes
 //!   the taker id, `PriceLevelError` gained `DuplicateOrderId`.
+//! - **Failure-atomic snapshot restore (#207).** `restore_from_snapshot` and
+//!   `restore_from_snapshot_package` validate every level (and reject
+//!   cross-level duplicate order ids with `DuplicateOrderId`) against
+//!   off-book structures before clearing the live book, so a failed restore
+//!   leaves the pre-restore state — orders, indices, config, risk,
+//!   kill-switch, engine sequence — completely untouched.
 //! - **Snapshot package format v3 (#206).** Pricelevel 0.9 statistics can
 //!   serialize a `stats_degraded` field that 0.8 readers reject, so newly
 //!   written packages are stamped `ORDERBOOK_SNAPSHOT_FORMAT_VERSION = 3`.

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -2988,6 +2988,15 @@ where
     /// (`ReplayEngine::replay_from*`) starts a fresh book with
     /// `kill_switch_engaged = false`, and operators must engage it
     /// explicitly post-replay if needed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OrderBookError::ChecksumMismatch`] /
+    /// [`OrderBookError::InvalidOperation`] when package validation
+    /// fails, and every error [`restore_from_snapshot`](Self::restore_from_snapshot)
+    /// documents. All of them fire before any live state is mutated
+    /// (#207) — a failed package restore leaves the book, its
+    /// configuration, and its risk state untouched.
     pub fn restore_from_snapshot_package(
         &mut self,
         package: OrderBookSnapshotPackage,
@@ -3005,28 +3014,33 @@ where
         let market_close_timestamp = package.market_close_timestamp;
         let has_market_close = package.has_market_close;
 
-        // Take ownership of the validated snapshot. We hold it locally
-        // so that the per-account risk counters can be rebuilt from
-        // `snapshot.bids` / `snapshot.asks` before
-        // `restore_from_snapshot` consumes the snapshot's level vectors.
+        // Take ownership of the validated snapshot.
         let snapshot = package.into_snapshot()?;
 
+        // Fallible phase (#207): symbol guard + level conversion + the
+        // cross-level duplicate-id check all run before ANY live state —
+        // book, indices, risk, config — is touched, so an invalid package
+        // leaves the complete pre-restore state intact.
+        self.ensure_snapshot_symbol(&snapshot)?;
+        let prepared = Self::prepare_snapshot_levels(snapshot)?;
+
+        // ---- Point of no return: everything below is infallible. ----
+
         // Preserve the persisted risk-installation state exactly:
-        // install + rebuild only when a config was snapshotted,
-        // otherwise explicitly disable risk so a `risk_config()` call
-        // post-restore returns `None` rather than `Some(empty)`. The
-        // rebuild walks the snapshot's resting orders before
-        // `restore_from_snapshot` consumes the snapshot so we avoid
-        // cloning all level snapshots.
+        // install only when a config was snapshotted, otherwise
+        // explicitly disable risk so a `risk_config()` call post-restore
+        // returns `None` rather than `Some(empty)`. Entries and counters
+        // are cleared here and rebuilt during the commit walk below
+        // (`rebuild_risk = true`), which registers every restored resting
+        // order exactly like the live admission path.
         if let Some(risk_config) = risk_config {
             self.risk_state.set_config(risk_config);
-            self.risk_state
-                .rebuild_from_snapshot(&snapshot.bids, &snapshot.asks);
         } else {
             self.risk_state.disable();
         }
+        self.risk_state.clear();
 
-        self.restore_from_snapshot(snapshot)?;
+        self.commit_restored_levels(&prepared, true);
 
         // Apply configuration that was captured in the package.
         self.fee_schedule = fee_schedule;
@@ -3063,6 +3077,13 @@ where
     ///
     /// This restores both order data and configuration fields.
     /// See [`restore_from_snapshot_package`](Self::restore_from_snapshot_package).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OrderBookError::DeserializationError`] on malformed
+    /// JSON, plus every error
+    /// [`restore_from_snapshot_package`](Self::restore_from_snapshot_package)
+    /// documents — all raised before any live state is mutated (#207).
     pub fn restore_from_snapshot_json(&mut self, data: &str) -> Result<(), OrderBookError> {
         let package = OrderBookSnapshotPackage::from_json(data)?;
         self.restore_from_snapshot_package(package)
@@ -3079,7 +3100,37 @@ where
     /// state is lost or re-initialized. The rebuild uses the deterministic
     /// price-then-insertion-sequence traversal so the restore stays
     /// replay-stable (#190 / #192).
+    ///
+    /// # Failure atomicity
+    ///
+    /// The restore is two-phase (#207): every fallible step — level
+    /// conversion through pricelevel's validating
+    /// [`PriceLevel::from_snapshot`] and the cross-level duplicate-id
+    /// check — runs against off-book structures first, and the live book
+    /// is cleared and replaced only after all of them succeed. Any error
+    /// therefore leaves the pre-restore bids, asks, indices, and
+    /// operational state completely untouched.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OrderBookError::InvalidOperation`] when the snapshot's
+    /// symbol does not match this book or when one side carries two
+    /// levels at the same price (the install would keep only one while
+    /// the index rebuild registered both),
+    /// [`OrderBookError::PriceLevelError`] when a level snapshot fails
+    /// pricelevel's validation, and
+    /// [`OrderBookError::DuplicateOrderId`] when the same order id
+    /// appears in more than one level of the snapshot (installing it
+    /// would silently orphan one of the two in `order_locations`).
     pub fn restore_from_snapshot(&self, snapshot: OrderBookSnapshot) -> Result<(), OrderBookError> {
+        self.ensure_snapshot_symbol(&snapshot)?;
+        let prepared = Self::prepare_snapshot_levels(snapshot)?;
+        self.commit_restored_levels(&prepared, false);
+        Ok(())
+    }
+
+    /// Symbol guard shared by the snapshot restore entry points.
+    fn ensure_snapshot_symbol(&self, snapshot: &OrderBookSnapshot) -> Result<(), OrderBookError> {
         if snapshot.symbol != self.symbol {
             return Err(OrderBookError::InvalidOperation {
                 message: format!(
@@ -3088,7 +3139,94 @@ where
                 ),
             });
         }
+        Ok(())
+    }
 
+    /// Fallible phase of a snapshot restore (#207): converts every level
+    /// through pricelevel's validating [`PriceLevel::from_snapshot`] and
+    /// rejects order ids that appear in more than one level — all against
+    /// local structures, without touching the live book. Levels are
+    /// returned sorted ascending by price so the commit phase's index
+    /// rebuild keeps the deterministic price-then-insertion-sequence
+    /// traversal (#192).
+    fn prepare_snapshot_levels(
+        snapshot: OrderBookSnapshot,
+    ) -> Result<PreparedSnapshotLevels, OrderBookError> {
+        let convert = |levels: Vec<pricelevel::PriceLevelSnapshot>,
+                       side: &str|
+         -> Result<Vec<(u128, Arc<PriceLevel>)>, OrderBookError> {
+            let mut converted = Vec::with_capacity(levels.len());
+            for level_snapshot in levels {
+                let price = level_snapshot.price().as_u128();
+                let price_level = PriceLevel::from_snapshot(level_snapshot)
+                    .map_err(OrderBookError::PriceLevelError)?;
+                converted.push((price, Arc::new(price_level)));
+            }
+            converted.sort_by_key(|(price, _)| *price);
+            // Reject duplicate prices within a side: the SkipMap install
+            // would keep only the last level at that key while the index
+            // rebuild below would still register the discarded level's
+            // orders, leaving `order_locations` / `user_orders` pointing at
+            // orders the live book does not hold. The old SkipMap-sourced
+            // rebuild silently dropped one level; neither outcome is
+            // acceptable, so the snapshot is rejected up front.
+            if let Some(window) = converted.windows(2).find(|pair| pair[0].0 == pair[1].0) {
+                return Err(OrderBookError::InvalidOperation {
+                    message: format!(
+                        "Snapshot contains two {side} levels at the same price {}",
+                        window[0].0
+                    ),
+                });
+            }
+            Ok(converted)
+        };
+
+        let bids = convert(snapshot.bids, "bid")?;
+        let asks = convert(snapshot.asks, "ask")?;
+
+        // Cross-level duplicate-id check. Per-level duplicates are already
+        // rejected by `PriceLevel::from_snapshot` (pricelevel 0.9); an id
+        // resting at two prices would silently orphan one of them in
+        // `order_locations`, so reject the snapshot before any mutation.
+        // A HashSet is safe here: only membership is consulted, no
+        // iteration order can leak into book state.
+        let mut seen: std::collections::HashSet<Id> = std::collections::HashSet::new();
+        let mut level_orders: Vec<Arc<OrderType<()>>> = Vec::new();
+        for (_, level) in bids.iter().chain(asks.iter()) {
+            level.snapshot_by_seq_into(&mut level_orders);
+            for order in &level_orders {
+                if !seen.insert(order.id()) {
+                    return Err(OrderBookError::DuplicateOrderId {
+                        order_id: order.id(),
+                    });
+                }
+            }
+        }
+
+        Ok(PreparedSnapshotLevels { bids, asks })
+    }
+
+    /// Infallible commit phase of a snapshot restore (#207): clears the
+    /// live book and installs the pre-validated levels, then rebuilds the
+    /// `order_locations` and `user_orders` indices, the special-order
+    /// tracker (under `special_orders`), and — when `rebuild_risk` is set
+    /// (the package-restore path) — the per-account risk entries via
+    /// [`RiskState::on_admission`]-equivalent registration.
+    ///
+    /// The index rebuild runs in one fixed, replay-stable pass: bids
+    /// ascending price then asks ascending price (the prepared vectors are
+    /// pre-sorted), and within each level ascending insertion sequence via
+    /// [`PriceLevel::snapshot_by_seq_into`] — never the `DashMap`-backed
+    /// `iter_orders` view, whose per-instance-hashed order would leak into
+    /// the `user_orders` `Vec<Id>` layout and make a subsequent
+    /// `cancel_orders_by_user` diverge across restores of the same package
+    /// (#192). This is NOT the original admission history — a snapshot
+    /// cannot recover that — but it is deterministic. `order_locations`,
+    /// the tracker's `DashSet`s, and the risk maps are order-insensitive,
+    /// so their rebuild order does not leak; only `user_orders`, whose
+    /// per-user `Vec` order is consumed by `cancel_orders_by_user`, needs
+    /// the fixed traversal. One scratch buffer is reused across levels.
+    fn commit_restored_levels(&self, prepared: &PreparedSnapshotLevels, rebuild_risk: bool) {
         self.cache.invalidate();
 
         // Clear all existing data
@@ -3110,61 +3248,42 @@ where
         self.has_market_close.store(false, Ordering::Relaxed);
         self.market_close_timestamp.store(0, Ordering::Relaxed);
 
-        for level_snapshot in snapshot.bids {
-            let price = level_snapshot.price().as_u128();
-            let price_level = PriceLevel::from_snapshot(level_snapshot)
-                .map_err(OrderBookError::PriceLevelError)?;
-            let arc_level = Arc::new(price_level);
-            self.bids.insert(price, arc_level);
+        for (price, level) in &prepared.bids {
+            self.bids.insert(*price, level.clone());
+        }
+        for (price, level) in &prepared.asks {
+            self.asks.insert(*price, level.clone());
         }
 
-        for level_snapshot in snapshot.asks {
-            let price = level_snapshot.price().as_u128();
-            let price_level = PriceLevel::from_snapshot(level_snapshot)
-                .map_err(OrderBookError::PriceLevelError)?;
-            let arc_level = Arc::new(price_level);
-            self.asks.insert(price, arc_level);
-        }
-
-        // Rebuild the `order_locations` and `user_orders` indices, and (under
-        // `special_orders`) re-register pegged / trailing-stop orders with the
-        // special-order tracker, in one fixed, replay-stable pass: bids
-        // ascending price then asks ascending price (the `SkipMap`'s natural key
-        // order), and within each level ascending insertion sequence via
-        // `PriceLevel::snapshot_by_seq_into` — never the `DashMap`-backed
-        // `iter_orders` view, whose per-instance-hashed order would leak into the
-        // `user_orders` `Vec<Id>` layout and make a subsequent
-        // `cancel_orders_by_user` diverge across restores of the same package
-        // (#192). This is NOT the original admission history — a snapshot cannot
-        // recover that — but it is deterministic. `order_locations` and the
-        // tracker's `DashSet`s are order-insensitive, so their rebuild order does
-        // not leak; only `user_orders`, whose per-user `Vec` order is consumed by
-        // `cancel_orders_by_user`, needs the fixed traversal. One scratch buffer
-        // is reused across levels.
         let mut level_orders: Vec<Arc<OrderType<()>>> = Vec::new();
-        for item in self.bids.iter() {
-            let price = *item.key();
-            item.value().snapshot_by_seq_into(&mut level_orders);
-            for order in &level_orders {
-                self.order_locations.insert(order.id(), (price, Side::Buy));
-                self.track_user_order(order.user_id(), order.id());
-                #[cfg(feature = "special_orders")]
-                self.reregister_special_order(order.as_ref());
+        let mut rebuild_side = |levels: &[(u128, Arc<PriceLevel>)], side: Side| {
+            for (price, level) in levels {
+                level.snapshot_by_seq_into(&mut level_orders);
+                for order in &level_orders {
+                    self.order_locations.insert(order.id(), (*price, side));
+                    self.track_user_order(order.user_id(), order.id());
+                    #[cfg(feature = "special_orders")]
+                    self.reregister_special_order(order.as_ref());
+                    if rebuild_risk {
+                        // Same per-order registration the live admission
+                        // path uses; keeps the saturating remaining-qty
+                        // semantics of the previous snapshot-based rebuild.
+                        let remaining_qty = order
+                            .visible_quantity()
+                            .as_u64()
+                            .saturating_add(order.hidden_quantity().as_u64());
+                        self.risk_state.on_admission(
+                            order.id(),
+                            order.user_id(),
+                            *price,
+                            remaining_qty,
+                        );
+                    }
+                }
             }
-        }
-
-        for item in self.asks.iter() {
-            let price = *item.key();
-            item.value().snapshot_by_seq_into(&mut level_orders);
-            for order in &level_orders {
-                self.order_locations.insert(order.id(), (price, Side::Sell));
-                self.track_user_order(order.user_id(), order.id());
-                #[cfg(feature = "special_orders")]
-                self.reregister_special_order(order.as_ref());
-            }
-        }
-
-        Ok(())
+        };
+        rebuild_side(&prepared.bids, Side::Buy);
+        rebuild_side(&prepared.asks, Side::Sell);
     }
 
     /// Re-register a restored resting order with the special-order tracker
@@ -3957,4 +4076,16 @@ where
     pub fn trailing_stop_ids(&self) -> Vec<Id> {
         self.special_order_tracker.trailing_stop_ids()
     }
+}
+
+/// Off-book output of the fallible phase of a snapshot restore (#207):
+/// fully converted price levels, sorted ascending by price per side, ready
+/// for the infallible commit phase
+/// ([`OrderBook::commit_restored_levels`]). Holding these outside the book
+/// is what makes a failed restore leave the live book untouched.
+struct PreparedSnapshotLevels {
+    /// `(price, level)` pairs for the bid side, ascending by price.
+    bids: Vec<(u128, Arc<PriceLevel>)>,
+    /// `(price, level)` pairs for the ask side, ascending by price.
+    asks: Vec<(u128, Arc<PriceLevel>)>,
 }

--- a/src/orderbook/risk.rs
+++ b/src/orderbook/risk.rs
@@ -30,7 +30,7 @@
 use crate::orderbook::error::OrderBookError;
 use crossbeam::atomic::AtomicCell;
 use dashmap::DashMap;
-use pricelevel::{Hash32, Id, PriceLevelSnapshot};
+use pricelevel::{Hash32, Id};
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tracing::warn;
@@ -623,43 +623,6 @@ impl RiskState {
     pub(super) fn clear(&self) {
         self.orders.clear();
         self.counters.clear();
-    }
-
-    /// Rebuild the per-order map and per-account counters by walking
-    /// the supplied bid and ask snapshots.
-    ///
-    /// Called by `OrderBook::restore_from_snapshot_package` after the
-    /// snapshot's resting orders have been re-installed into the book.
-    /// Iteration is in input-vector order, which is deterministic and
-    /// does not affect outbound emissions.
-    pub(super) fn rebuild_from_snapshot(
-        &self,
-        bids: &[PriceLevelSnapshot],
-        asks: &[PriceLevelSnapshot],
-    ) {
-        self.clear();
-        for level in bids.iter().chain(asks.iter()) {
-            let price = level.price().as_u128();
-            for order in level.orders() {
-                let account = order.user_id();
-                let remaining_qty = order
-                    .visible_quantity()
-                    .as_u64()
-                    .saturating_add(order.hidden_quantity().as_u64());
-                self.orders.insert(
-                    order.id(),
-                    RiskEntry {
-                        account,
-                        price,
-                        remaining_qty,
-                    },
-                );
-                let counters = self.counters.entry(account).or_default();
-                counters.open_count.fetch_add(1, Ordering::Relaxed);
-                let notional_delta = (remaining_qty as u128).saturating_mul(price);
-                counters.resting_notional.fetch_add(notional_delta);
-            }
-        }
     }
 }
 

--- a/tests/unit/snapshot_restore_tests.rs
+++ b/tests/unit/snapshot_restore_tests.rs
@@ -302,3 +302,252 @@ mod tests_snapshot_restore {
         assert_eq!(restored.max_order_size(), Some(999));
     }
 }
+
+/// #207: a failed restore must be atomic — any error during the fallible
+/// phase (level validation, cross-level duplicate ids) leaves the complete
+/// pre-restore book, configuration, and operational state untouched.
+#[cfg(test)]
+mod tests_restore_failure_atomicity {
+    use orderbook_rs::orderbook::risk::RiskConfig;
+    use orderbook_rs::{DefaultOrderBook, OrderBook, OrderBookError, OrderBookSnapshot};
+    use pricelevel::{
+        Hash32, Id, OrderType, Price, PriceLevel, Quantity, Side, TimeInForce, TimestampMs,
+    };
+
+    fn standard_order(id: u64, price: u128, quantity: u64) -> OrderType<()> {
+        OrderType::Standard {
+            id: Id::from_u64(id),
+            price: Price::new(price),
+            quantity: Quantity::new(quantity),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_700_000_000_000),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        }
+    }
+
+    /// Builds a snapshot whose two bid levels are individually valid but
+    /// share order id 42 — pricelevel accepts each level, the book-level
+    /// cross-level check must reject the snapshot as a whole.
+    fn cross_level_duplicate_snapshot(symbol: &str) -> OrderBookSnapshot {
+        let level_a = PriceLevel::new(9_000);
+        assert!(
+            level_a.add_order(standard_order(42, 9_000, 5)).is_ok(),
+            "level A admits id 42"
+        );
+        let level_b = PriceLevel::new(9_100);
+        assert!(
+            level_b.add_order(standard_order(42, 9_100, 7)).is_ok(),
+            "level B admits id 42"
+        );
+
+        OrderBookSnapshot {
+            symbol: symbol.to_string(),
+            timestamp: 1_700_000_000_000,
+            bids: vec![level_a.snapshot(), level_b.snapshot()],
+            asks: Vec::new(),
+        }
+    }
+
+    fn populate(book: &OrderBook<()>) {
+        book.add_limit_order(
+            Id::from_u64(1),
+            10_000,
+            5,
+            Side::Buy,
+            TimeInForce::Gtc,
+            None,
+        )
+        .expect("add bid");
+        book.add_limit_order(
+            Id::from_u64(2),
+            10_100,
+            4,
+            Side::Sell,
+            TimeInForce::Gtc,
+            None,
+        )
+        .expect("add ask");
+    }
+
+    /// Serializes the book's level state (bids + asks, orders and
+    /// statistics included) for byte-level before/after comparison. The
+    /// top-level snapshot timestamp is deliberately excluded (wall clock).
+    fn level_state_json(book: &OrderBook<()>) -> (String, String) {
+        let snapshot = book.create_snapshot(usize::MAX);
+        let bids = serde_json::to_string(&snapshot.bids).expect("serialize bids");
+        let asks = serde_json::to_string(&snapshot.asks).expect("serialize asks");
+        (bids, asks)
+    }
+
+    #[test]
+    fn failed_direct_restore_preserves_book() {
+        let book = DefaultOrderBook::new("ATOM");
+        populate(&book);
+        let before = level_state_json(&book);
+
+        let bad = cross_level_duplicate_snapshot("ATOM");
+        let err = book
+            .restore_from_snapshot(bad)
+            .expect_err("cross-level duplicate ids must be rejected");
+        match err {
+            OrderBookError::DuplicateOrderId { order_id } => {
+                assert_eq!(order_id, Id::from_u64(42), "the duplicated id is reported");
+            }
+            other => panic!("expected DuplicateOrderId, got {other:?}"),
+        }
+
+        assert_eq!(
+            level_state_json(&book),
+            before,
+            "a failed restore must leave every level byte-identical"
+        );
+        assert_eq!(book.best_bid(), Some(10_000), "best bid untouched");
+        assert_eq!(book.best_ask(), Some(10_100), "best ask untouched");
+        assert!(
+            book.get_order(Id::from_u64(1)).is_some(),
+            "pre-restore order 1 still resolvable by id"
+        );
+        assert!(
+            book.get_order(Id::from_u64(42)).is_none(),
+            "no order from the rejected snapshot leaked in"
+        );
+    }
+
+    #[test]
+    fn failed_package_restore_preserves_config_and_state() {
+        let mut book = DefaultOrderBook::new("ATOMP");
+        populate(&book);
+        for _ in 0..7 {
+            let _ = book.next_engine_seq();
+        }
+        let before = level_state_json(&book);
+
+        // A duplicate-bearing snapshot checksums fine: aggregate refresh
+        // does not enforce id uniqueness, so package validation alone is
+        // not a sufficient guard (the issue's repro).
+        let bad = cross_level_duplicate_snapshot("ATOMP");
+        let mut package = orderbook_rs::orderbook::OrderBookSnapshotPackage::new(bad)
+            .expect("duplicate-bearing snapshot still checksums");
+        package.engine_seq = 999;
+        package.kill_switch_engaged = true;
+        package.risk_config = Some(RiskConfig::default());
+
+        let err = book
+            .restore_from_snapshot_package(package)
+            .expect_err("package restore must reject the duplicate ids");
+        assert!(
+            matches!(err, OrderBookError::DuplicateOrderId { .. }),
+            "expected DuplicateOrderId, got {err:?}"
+        );
+
+        assert_eq!(
+            level_state_json(&book),
+            before,
+            "levels byte-identical after failed package restore"
+        );
+        assert_eq!(book.engine_seq(), 7, "engine_seq not clobbered");
+        assert!(
+            !book.is_kill_switch_engaged(),
+            "kill switch not clobbered by the failed package"
+        );
+        assert!(
+            book.risk_config().is_none(),
+            "risk config not installed by the failed package"
+        );
+    }
+
+    /// The success path is unchanged: a valid package still restores and
+    /// the restored book's levels match the source byte-for-byte.
+    #[test]
+    fn successful_restore_still_round_trips() {
+        let book = DefaultOrderBook::new("OKRT");
+        populate(&book);
+        let before = level_state_json(&book);
+
+        let package = book.create_snapshot_package(10).expect("build package");
+        let mut restored = DefaultOrderBook::new("OKRT");
+        restored
+            .restore_from_snapshot_package(package)
+            .expect("valid package restores");
+
+        assert_eq!(
+            level_state_json(&restored),
+            before,
+            "restored levels match the source"
+        );
+    }
+}
+
+/// #207 follow-up (determinism audit): two same-price levels on one side
+/// with disjoint order ids would silently corrupt the indices — the
+/// SkipMap install keeps only one level while the rebuild registers both.
+/// The snapshot must be rejected up front, atomically.
+#[cfg(test)]
+mod tests_restore_duplicate_price_levels {
+    use orderbook_rs::{DefaultOrderBook, OrderBook, OrderBookError, OrderBookSnapshot};
+    use pricelevel::{
+        Hash32, Id, OrderType, Price, PriceLevel, Quantity, Side, TimeInForce, TimestampMs,
+    };
+
+    #[test]
+    fn duplicate_price_levels_rejected_and_book_preserved() {
+        let book: OrderBook<()> = DefaultOrderBook::new("DUPP");
+        book.add_limit_order(
+            Id::from_u64(1),
+            10_000,
+            5,
+            Side::Buy,
+            TimeInForce::Gtc,
+            None,
+        )
+        .expect("seed bid");
+
+        let make_level = |order_id: u64| {
+            let level = PriceLevel::new(9_000);
+            let admitted = level.add_order(OrderType::Standard {
+                id: Id::from_u64(order_id),
+                price: Price::new(9_000),
+                quantity: Quantity::new(5),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(1_700_000_000_000),
+                time_in_force: TimeInForce::Gtc,
+                extra_fields: (),
+            });
+            assert!(admitted.is_ok(), "level admits order {order_id}");
+            level.snapshot()
+        };
+
+        let bad = OrderBookSnapshot {
+            symbol: "DUPP".to_string(),
+            timestamp: 1_700_000_000_000,
+            bids: vec![make_level(70), make_level(71)],
+            asks: Vec::new(),
+        };
+
+        let err = book
+            .restore_from_snapshot(bad)
+            .expect_err("duplicate-price levels must be rejected");
+        match err {
+            OrderBookError::InvalidOperation { message } => {
+                assert!(
+                    message.contains("same price"),
+                    "error names the duplicate-price condition, got: {message}"
+                );
+                assert!(
+                    message.contains("9000"),
+                    "error carries the offending price, got: {message}"
+                );
+            }
+            other => panic!("expected InvalidOperation, got {other:?}"),
+        }
+
+        assert_eq!(book.best_bid(), Some(10_000), "pre-restore book untouched");
+        assert!(
+            book.get_order(Id::from_u64(70)).is_none(),
+            "no rejected-snapshot order leaked into the indices"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`restore_from_snapshot` cleared the live book before converting each level
through pricelevel 0.9's fallible `PriceLevel::from_snapshot`; an invalid
later level destroyed the original state and left a valid prefix of the
replacement installed. `restore_from_snapshot_package` additionally
installed risk configuration before that fallible work. Restore is now
two-phase and failure-atomic.

## Changes

- Two-phase restore: `prepare_snapshot_levels` (fallible, off-book) converts
  every level, rejects cross-level duplicate order ids
  (`OrderBookError::DuplicateOrderId`) and same-side duplicate-price levels
  (`InvalidOperation`), then `commit_restored_levels` (infallible) clears
  and installs. Any error leaves the pre-restore book byte-identical.
- `restore_from_snapshot_package` applies risk config, book config,
  `engine_seq`, kill switch, and market close only after the fallible phase.
  Risk entries are rebuilt during the commit walk with the same registration
  as live admission (`on_admission`), replacing the removed
  `RiskState::rebuild_from_snapshot`; a package without a risk config now
  also purges pre-restore risk entries (previously they survived `disable()`
  and could resurrect stale counters).
- `# Errors` documented on all three restore entry points.

## Technical decisions

- Index rebuild traversal preserved exactly (#192): bids ascending price
  then asks ascending, insertion-seq within level — the prepared vectors are
  pre-sorted, replacing the SkipMap iteration source with identical order.
- The duplicate-price rejection replaces the old silent last-write-wins
  SkipMap install (which the new vector-driven index rebuild would have
  turned into index corruption — caught by the determinism audit).

## Testing

- Regressions: cross-level duplicate id (direct + checksummed package —
  the package checksums fine, proving package validation alone is no
  guard), duplicate-price levels, and a success-path byte-identity check.
  Failed restores assert byte-identical levels, untouched `engine_seq`,
  kill switch, and risk config.
- Reviewed by `architect` and `determinism-auditor` agents; both findings
  (duplicate-price gap, risk-clear CHANGELOG note) addressed.
- Full suite: 807 lib + 486 integration, 0 failed. `make pre-push` clean.

## Stack

- Base branch: `stack/1-206-snapshot-format-v3` (merged as #213)
- Stack: #206 → **#207 (this)** → #208 → #210 → #211 → #209

Closes #207
