### PR TITLE
Compare full maker state and FIFO in snapshots_match (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`snapshots_match` is a full replay oracle (#208).** The replay equality
+  check compared only per-level aggregates (price, visible/hidden quantity,
+  order count), so two books with the same aggregates but reversed maker
+  FIFO — or different maker ids, users, order variants, or time-in-force —
+  certified as equal while emitting different trades on the next sweep. It
+  now compares every level's complete order vector in queue-consumption
+  order (pricelevel ≥ 0.9 materializes it that way) via full `OrderType`
+  equality, plus the deterministic statistics counters including
+  `stats_degraded`. Intentionally excluded and documented:
+  `first_arrival_time` (pricelevel stamps it from raw `SystemTime::now()`,
+  outside the injectable clock), `last_execution_time` /
+  `sum_waiting_time` (live ingestion and replay consume different
+  clock-tick budgets by design, so these wall-time aggregates diverge even
+  under identically-seeded injected clocks), and the top-level capture
+  timestamp. Order admission timestamps participate — the journal carries
+  the admitted order verbatim and replay never re-stamps it. **Contract
+  note:** this tightens the public `snapshots_match` /
+  `ReplayEngine::verify` pass condition; aggregate-equal books with
+  different maker identity or FIFO no longer certify as equal.
 - **The upsize queue-priority demotion survives a snapshot round-trip
   (#205).** Level snapshots now materialize orders in queue-consumption
   order (pricelevel 0.9, PriceLevel#109), so

--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ This order book engine is built with the following design principles:
   the re-exported pricelevel surface changed —
   `PriceLevel::add_order` returns `Result`, `matchable_quantity` takes
   the taker id, `PriceLevelError` gained `DuplicateOrderId`.
+- **`snapshots_match` compares full maker state and FIFO (#208).** The
+  replay oracle now checks every level's order vector in
+  queue-consumption order (ids, variants, users, quantities,
+  timestamps, TIF, type-specific fields) and the deterministic
+  statistics counters including `stats_degraded`; only the wall-time
+  statistics aggregates (`first_arrival_time`, `last_execution_time`,
+  `sum_waiting_time` — see the `snapshots_match` docs for why each is
+  inherently divergent) and the capture timestamp stay excluded.
+  Contract tightening: aggregate-equal books with reversed FIFO or
+  different maker identity no longer certify as replay-equal.
 - **Failure-atomic snapshot restore (#207).** `restore_from_snapshot` and
   `restore_from_snapshot_package` validate every level (and reject
   cross-level duplicate order ids with `DuplicateOrderId`) against

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,16 @@
 //!   the re-exported pricelevel surface changed —
 //!   `PriceLevel::add_order` returns `Result`, `matchable_quantity` takes
 //!   the taker id, `PriceLevelError` gained `DuplicateOrderId`.
+//! - **`snapshots_match` compares full maker state and FIFO (#208).** The
+//!   replay oracle now checks every level's order vector in
+//!   queue-consumption order (ids, variants, users, quantities,
+//!   timestamps, TIF, type-specific fields) and the deterministic
+//!   statistics counters including `stats_degraded`; only the wall-time
+//!   statistics aggregates (`first_arrival_time`, `last_execution_time`,
+//!   `sum_waiting_time` — see the `snapshots_match` docs for why each is
+//!   inherently divergent) and the capture timestamp stay excluded.
+//!   Contract tightening: aggregate-equal books with reversed FIFO or
+//!   different maker identity no longer certify as replay-equal.
 //! - **Failure-atomic snapshot restore (#207).** `restore_from_snapshot` and
 //!   `restore_from_snapshot_package` validate every level (and reject
 //!   cross-level duplicate order ids with `DuplicateOrderId`) against

--- a/src/orderbook/sequencer/replay.rs
+++ b/src/orderbook/sequencer/replay.rs
@@ -739,63 +739,108 @@ where
 ///
 /// Two snapshots are considered equal when:
 /// - `symbol` is identical
-/// - The sorted bid price levels match (by price, **visible** quantity, **hidden**
-///   quantity, and **order count**)
-/// - The sorted ask price levels match (same four fields)
+/// - The sorted bid price levels match, and the sorted ask price levels
+///   match — where "match" means the **complete** per-level state (#208):
+///   price, visible quantity, hidden quantity, order count, the full order
+///   vector in queue-consumption order, and the deterministic execution
+///   statistics.
 ///
-/// This is the equality oracle for replay correctness, so it compares the full
-/// per-level state — not just visible quantity. Comparing visible quantity alone
-/// would be a subset check that misses divergences in hidden iceberg / reserve
-/// liquidity or in how the same visible depth is split across orders at a price
-/// (#102).
+/// This is the equality oracle for replay correctness. Aggregate-only
+/// comparison (price / quantities / order count, #102) was a subset check:
+/// two books with the same aggregates but reversed maker FIFO — or the same
+/// FIFO with different maker ids, users, order variants, quantities, or
+/// time-in-force — would emit different trades on the next sweep yet still
+/// compare equal. Since pricelevel 0.9 the snapshot's `orders()` vector is
+/// materialized in queue-consumption order, so element-wise [`OrderType`]
+/// equality pins maker identity and FIFO exactly.
 ///
-/// Timestamps are intentionally excluded from comparison because replayed
-/// books may be created at a different wall-clock time than the original.
+/// Order equality includes the admission timestamp: the journal carries the
+/// admitted order verbatim — timestamp baked in — and replay re-installs it
+/// without re-stamping, so a faithful replay reproduces order timestamps
+/// byte-identically (under any clock). Verifying against a book whose
+/// orders were constructed and clock-stamped independently of the journal
+/// will (correctly) report a mismatch.
+///
+/// Statistics comparison covers the deterministic counters — orders added /
+/// removed / executed, quantity executed, value executed, and the sticky
+/// `stats_degraded` flag. Intentionally excluded:
+/// - `first_arrival_time` — pricelevel derives it from a raw
+///   `SystemTime::now()` at level creation, outside the injectable `Clock`,
+///   so it can never match between two runs;
+/// - `last_execution_time` / `sum_waiting_time` — clock-derived, but live
+///   ingestion and replay consume different clock-tick budgets by design
+///   (the live submission API stamps each order with a fresh tick; replay
+///   reuses the journal's pre-stamped order), so these wall-time aggregates
+///   diverge even under identically-seeded injected clocks;
+/// - the top-level snapshot capture timestamp, as before.
+///
+/// Note this tightening is a contract change for external consumers: two
+/// independently built books with equal aggregates but different maker
+/// identity or FIFO used to compare equal (pre-#208) and no longer do —
+/// that laxity was the #102/#208 correctness gap, not a feature.
 #[must_use]
 pub fn snapshots_match(actual: &OrderBookSnapshot, expected: &OrderBookSnapshot) -> bool {
     if actual.symbol != expected.symbol {
         return false;
     }
 
-    // Compare bids sorted by price descending (highest bid first)
-    let mut actual_bids: Vec<_> = actual.bids.iter().collect();
-    let mut expected_bids: Vec<_> = expected.bids.iter().collect();
-    actual_bids.sort_by_key(|b| std::cmp::Reverse(b.price()));
-    expected_bids.sort_by_key(|b| std::cmp::Reverse(b.price()));
+    sides_match(&actual.bids, &expected.bids) && sides_match(&actual.asks, &expected.asks)
+}
 
-    if actual_bids.len() != expected_bids.len() {
+/// Compares one side's levels, sorted ascending by price. The sort
+/// direction is irrelevant for an equality check as long as both inputs use
+/// the same one.
+#[must_use]
+fn sides_match(
+    actual: &[pricelevel::PriceLevelSnapshot],
+    expected: &[pricelevel::PriceLevelSnapshot],
+) -> bool {
+    if actual.len() != expected.len() {
         return false;
     }
-    for (a, b) in actual_bids.iter().zip(expected_bids.iter()) {
-        if a.price() != b.price()
-            || a.visible_quantity() != b.visible_quantity()
-            || a.hidden_quantity() != b.hidden_quantity()
-            || a.order_count() != b.order_count()
-        {
-            return false;
-        }
-    }
+    let mut actual_sorted: Vec<_> = actual.iter().collect();
+    let mut expected_sorted: Vec<_> = expected.iter().collect();
+    actual_sorted.sort_by_key(|level| level.price());
+    expected_sorted.sort_by_key(|level| level.price());
 
-    // Compare asks sorted by price ascending (lowest ask first)
-    let mut actual_asks: Vec<_> = actual.asks.iter().collect();
-    let mut expected_asks: Vec<_> = expected.asks.iter().collect();
-    actual_asks.sort_by_key(|l| l.price());
-    expected_asks.sort_by_key(|l| l.price());
+    actual_sorted
+        .iter()
+        .zip(expected_sorted.iter())
+        .all(|(a, b)| levels_match(a, b))
+}
 
-    if actual_asks.len() != expected_asks.len() {
+/// Complete per-level equality (#208): aggregates, the full order vector in
+/// queue-consumption order, and the deterministic statistics counters.
+#[must_use]
+fn levels_match(a: &pricelevel::PriceLevelSnapshot, b: &pricelevel::PriceLevelSnapshot) -> bool {
+    if a.price() != b.price()
+        || a.visible_quantity() != b.visible_quantity()
+        || a.hidden_quantity() != b.hidden_quantity()
+        || a.order_count() != b.order_count()
+    {
         return false;
     }
-    for (a, b) in actual_asks.iter().zip(expected_asks.iter()) {
-        if a.price() != b.price()
-            || a.visible_quantity() != b.visible_quantity()
-            || a.hidden_quantity() != b.hidden_quantity()
-            || a.order_count() != b.order_count()
-        {
-            return false;
-        }
+
+    // Element-wise order comparison in queue-consumption order (pricelevel
+    // ≥ 0.9 materializes `orders()` that way). `OrderType`'s derived
+    // `PartialEq` covers id, variant, side, price, visible / hidden
+    // quantity, user, admission timestamp, time-in-force, and every
+    // type-specific field (peg reference, trailing offset, replenish
+    // config, ...).
+    if a.orders() != b.orders() {
+        return false;
     }
 
-    true
+    // Deterministic statistics only — see the `snapshots_match` doc for the
+    // intentionally excluded wall-clock-derived fields.
+    let stats_a = a.statistics();
+    let stats_b = b.statistics();
+    stats_a.orders_added() == stats_b.orders_added()
+        && stats_a.orders_removed() == stats_b.orders_removed()
+        && stats_a.orders_executed() == stats_b.orders_executed()
+        && stats_a.quantity_executed() == stats_b.quantity_executed()
+        && stats_a.value_executed() == stats_b.value_executed()
+        && stats_a.stats_degraded() == stats_b.stats_degraded()
 }
 
 #[cfg(test)]
@@ -879,6 +924,171 @@ mod tests {
         assert!(
             !snapshots_match(&base, &diff_count),
             "an order-count divergence must not be reported equal"
+        );
+    }
+
+    /// Builds a one-level snapshot from real pricelevel levels for the #208
+    /// oracle tests: `orders` are admitted in the given sequence, so the
+    /// snapshot's order vector reflects exactly that FIFO.
+    fn ask_level_snapshot(price: u128, orders: &[OrderType<()>]) -> pricelevel::PriceLevelSnapshot {
+        let level = pricelevel::PriceLevel::new(price);
+        for order in orders {
+            assert!(
+                level.add_order(*order).is_ok(),
+                "fixture order must be admitted"
+            );
+        }
+        level.snapshot()
+    }
+
+    fn fixture_order(id: u64, price: u128, quantity: u64, tif: TimeInForce) -> OrderType<()> {
+        OrderType::Standard {
+            id: Id::from_u64(id),
+            price: Price::new(price),
+            quantity: Quantity::new(quantity),
+            side: Side::Sell,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_700_000_000_000),
+            time_in_force: tif,
+            extra_fields: (),
+        }
+    }
+
+    fn one_ask_snapshot(symbol: &str, level: pricelevel::PriceLevelSnapshot) -> OrderBookSnapshot {
+        OrderBookSnapshot {
+            symbol: symbol.to_string(),
+            timestamp: 0,
+            bids: Vec::new(),
+            asks: vec![level],
+        }
+    }
+
+    /// #208: equal aggregates with reversed maker FIFO must NOT compare
+    /// equal — and the two snapshots demonstrably produce different first
+    /// makers when restored and swept.
+    #[test]
+    fn test_snapshots_match_detects_reversed_fifo() {
+        let first = fixture_order(1, 100, 10, TimeInForce::Gtc);
+        let second = fixture_order(2, 100, 10, TimeInForce::Gtc);
+
+        let forward = one_ask_snapshot("FIFO", ask_level_snapshot(100, &[first, second]));
+        let reversed = one_ask_snapshot("FIFO", ask_level_snapshot(100, &[second, first]));
+
+        assert!(
+            snapshots_match(&forward, &forward.clone()),
+            "identical FIFO must match"
+        );
+        assert!(
+            !snapshots_match(&forward, &reversed),
+            "reversed maker FIFO with equal aggregates must not match"
+        );
+
+        // The divergence is real: restoring each snapshot and sweeping one
+        // unit consumes a different maker first.
+        let sweep_first_maker = |snapshot: OrderBookSnapshot| -> Id {
+            let book: OrderBook<()> = OrderBook::new("FIFO");
+            book.restore_from_snapshot(snapshot).expect("restore");
+            let result = book
+                .submit_market_order_with_user(Id::from_u64(9_999), 1, Side::Buy, Hash32::zero())
+                .expect("sweep");
+            let trades = result.trades().as_vec();
+            assert_eq!(trades.len(), 1, "one unit fills one maker");
+            trades[0].maker_order_id()
+        };
+        let forward_maker = sweep_first_maker(forward);
+        let reversed_maker = sweep_first_maker(reversed);
+        assert_ne!(
+            forward_maker, reversed_maker,
+            "the previously-accepted snapshots produce different first makers"
+        );
+        assert_eq!(forward_maker, Id::from_u64(1));
+        assert_eq!(reversed_maker, Id::from_u64(2));
+    }
+
+    /// #208: same aggregates, different order identity / fields — maker id,
+    /// time-in-force — must not compare equal.
+    #[test]
+    fn test_snapshots_match_detects_order_identity_divergence() {
+        let base = one_ask_snapshot(
+            "IDENT",
+            ask_level_snapshot(100, &[fixture_order(1, 100, 10, TimeInForce::Gtc)]),
+        );
+
+        let different_id = one_ask_snapshot(
+            "IDENT",
+            ask_level_snapshot(100, &[fixture_order(2, 100, 10, TimeInForce::Gtc)]),
+        );
+        assert!(
+            !snapshots_match(&base, &different_id),
+            "different maker id with equal aggregates must not match"
+        );
+
+        let different_tif = one_ask_snapshot(
+            "IDENT",
+            ask_level_snapshot(100, &[fixture_order(1, 100, 10, TimeInForce::Day)]),
+        );
+        assert!(
+            !snapshots_match(&base, &different_tif),
+            "different time-in-force with equal aggregates must not match"
+        );
+    }
+
+    /// #208: a `stats_degraded` divergence is a replay-relevant signal (an
+    /// under-counted statistics stream) and must not compare equal; the
+    /// wall-clock statistics aggregates stay excluded.
+    #[test]
+    fn test_snapshots_match_compares_deterministic_statistics() {
+        fn lvl_with_stats(degraded: bool, first_arrival: u64) -> pricelevel::PriceLevelSnapshot {
+            serde_json::from_value(serde_json::json!({
+                "price": 100,
+                "visible_quantity": 10,
+                "hidden_quantity": 0,
+                "order_count": 0,
+                "orders": [],
+                "statistics": {
+                    "orders_added": 1,
+                    "orders_removed": 0,
+                    "orders_executed": 0,
+                    "quantity_executed": 0,
+                    "value_executed": 0,
+                    "last_execution_time": 0,
+                    "first_arrival_time": first_arrival,
+                    "sum_waiting_time": 0,
+                    "stats_degraded": degraded
+                }
+            }))
+            .expect("valid snapshot JSON")
+        }
+
+        let clean = OrderBookSnapshot {
+            symbol: "STATS".to_string(),
+            timestamp: 0,
+            bids: vec![lvl_with_stats(false, 1_000)],
+            asks: Vec::new(),
+        };
+        let degraded = OrderBookSnapshot {
+            symbol: "STATS".to_string(),
+            timestamp: 7,
+            bids: vec![lvl_with_stats(true, 1_000)],
+            asks: Vec::new(),
+        };
+        assert!(
+            !snapshots_match(&clean, &degraded),
+            "a stats_degraded divergence must not be reported equal"
+        );
+
+        // Wall-clock-derived statistics and the top-level capture timestamp
+        // remain excluded: same deterministic state, different arrival time
+        // and snapshot timestamp still match.
+        let different_clock = OrderBookSnapshot {
+            symbol: "STATS".to_string(),
+            timestamp: 42,
+            bids: vec![lvl_with_stats(false, 2_000)],
+            asks: Vec::new(),
+        };
+        assert!(
+            snapshots_match(&clean, &different_clock),
+            "wall-clock-derived fields must stay excluded from the oracle"
         );
     }
 
@@ -999,9 +1209,13 @@ mod tests {
         let journal: InMemoryJournal<()> = InMemoryJournal::new();
         let mut seq = 0u64;
 
-        // Three asks at 100, 101, 102 — each size 10.
-        for price in [100u128, 101, 102] {
-            let ev = make_add_event(seq, Id::new_uuid(), price, 10, Side::Sell);
+        // Three asks at 100, 101, 102 — each size 10. The ids are shared
+        // with the live book below: since #208 `snapshots_match` compares
+        // full order identity and FIFO, the ground-truth book must be
+        // seeded with the exact orders the journal carries.
+        let maker_ids = [Id::from_u64(1), Id::from_u64(2), Id::from_u64(3)];
+        for (maker_id, price) in maker_ids.iter().zip([100u128, 101, 102]) {
+            let ev = make_add_event(seq, *maker_id, price, 10, Side::Sell);
             assert!(journal.append(&ev).is_ok());
             seq += 1;
         }
@@ -1037,10 +1251,10 @@ mod tests {
         // Drive the live book through the same sequence so we have a
         // ground-truth snapshot.
         let live_book: crate::OrderBook<()> = crate::OrderBook::new("TEST");
-        for price in [100u128, 101, 102] {
+        for (maker_id, price) in maker_ids.iter().zip([100u128, 101, 102]) {
             live_book
                 .add_order(OrderType::Standard {
-                    id: Id::new_uuid(),
+                    id: *maker_id,
                     price: Price::new(price),
                     quantity: Quantity::new(10),
                     side: Side::Sell,
@@ -1051,10 +1265,6 @@ mod tests {
                 })
                 .expect("seed ask");
         }
-        // Note: live_book seeds with fresh UUIDs, so `snapshots_match`
-        // compares the structural per-level fields (price, visible/hidden
-        // quantity, order count) rather than order ids. Use the same notional
-        // amount so the residual book state matches.
         let _ = live_book.match_market_order_by_amount(taker_id, 1_500, Side::Buy);
 
         // Replay journal into a fresh book.

--- a/tests/unit/integration_workflow_tests.rs
+++ b/tests/unit/integration_workflow_tests.rs
@@ -133,13 +133,33 @@ fn journal_replay_reconstructs_identical_state() {
         ReplayEngine::<()>::replay_from(&journal, 0, "TEST").expect("replay should succeed");
     assert_eq!(last_seq, 4);
 
-    // Build the same state manually
+    // Build the same state manually — with the exact orders the journal
+    // carries (same ids AND same admission timestamps): since #208 the
+    // `snapshots_match` oracle compares full order identity, so a
+    // clock-stamped `add_limit_order` would legitimately diverge from the
+    // journal's fixed-timestamp orders.
     let manual_book = OrderBook::<()>::new("TEST");
-    let _ = manual_book.add_limit_order(ids[0], 100, 10, Side::Buy, TimeInForce::Gtc, None);
-    let _ = manual_book.add_limit_order(ids[1], 95, 20, Side::Buy, TimeInForce::Gtc, None);
-    let _ = manual_book.add_limit_order(ids[2], 110, 15, Side::Sell, TimeInForce::Gtc, None);
-    let _ = manual_book.add_limit_order(ids[3], 115, 25, Side::Sell, TimeInForce::Gtc, None);
-    let _ = manual_book.add_limit_order(ids[4], 90, 5, Side::Buy, TimeInForce::Gtc, None);
+    let specs = [
+        (ids[0], 100u128, 10u64, Side::Buy),
+        (ids[1], 95, 20, Side::Buy),
+        (ids[2], 110, 15, Side::Sell),
+        (ids[3], 115, 25, Side::Sell),
+        (ids[4], 90, 5, Side::Buy),
+    ];
+    for (id, price, qty, side) in specs {
+        manual_book
+            .add_order(pricelevel::OrderType::Standard {
+                id,
+                price: Price::new(price),
+                quantity: Quantity::new(qty),
+                side,
+                time_in_force: TimeInForce::Gtc,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(0),
+                extra_fields: (),
+            })
+            .expect("manual add");
+    }
 
     let snap_replayed = replayed_book.create_snapshot(usize::MAX);
     let snap_manual = manual_book.create_snapshot(usize::MAX);

--- a/tests/unit/replay_config_tests.rs
+++ b/tests/unit/replay_config_tests.rs
@@ -157,6 +157,12 @@ fn replay_book_config_default_is_all_defaults() {
 
 // ─── lot_size divergence / parity via MarketOrderByAmount rounding ──────────
 
+/// Fixed maker / taker ids shared by the journal and every ground-truth
+/// live book: since #208 `snapshots_match` compares full order identity,
+/// so the live book must rest the exact orders the journal carries.
+const LOT_ASK_ID: u64 = 11;
+const LOT_TAKER_ID: u64 = 9_999;
+
 /// Builds the shared journal: one resting ask wall, then a notional market buy
 /// that rounds differently under `lot_size`.
 ///
@@ -167,12 +173,11 @@ fn lot_size_journal() -> (InMemoryJournal<()>, u64) {
     let journal: InMemoryJournal<()> = InMemoryJournal::new();
     let mut seq = 0u64;
 
-    let ask_id = Id::new_uuid();
     assert!(
         journal
             .append(&make_add_event(
                 seq,
-                ask_id,
+                Id::from_u64(LOT_ASK_ID),
                 100,
                 10,
                 Side::Sell,
@@ -182,10 +187,14 @@ fn lot_size_journal() -> (InMemoryJournal<()>, u64) {
     );
     seq += 1;
 
-    let taker_id = Id::new_uuid();
     assert!(
         journal
-            .append(&make_market_by_amount_event(seq, taker_id, 700, Side::Buy))
+            .append(&make_market_by_amount_event(
+                seq,
+                Id::from_u64(LOT_TAKER_ID),
+                700,
+                Side::Buy
+            ))
             .is_ok()
     );
 
@@ -203,7 +212,7 @@ fn lot_size_replay_without_config_diverges() {
     let mut live = OrderBook::<()>::with_clock("TEST", stub_clock());
     live.set_lot_size(5);
     live.add_order(OrderType::Standard {
-        id: Id::new_uuid(),
+        id: Id::from_u64(LOT_ASK_ID),
         price: Price::new(100),
         quantity: Quantity::new(10),
         side: Side::Sell,
@@ -213,7 +222,7 @@ fn lot_size_replay_without_config_diverges() {
         extra_fields: (),
     })
     .expect("seed ask");
-    let _ = live.match_market_order_by_amount(Id::new_uuid(), 700, Side::Buy);
+    let _ = live.match_market_order_by_amount(Id::from_u64(LOT_TAKER_ID), 700, Side::Buy);
     let live_snap = live.create_snapshot(usize::MAX);
 
     // Replay WITHOUT config — fresh book has no lot_size, so it takes 7 (not 5).
@@ -240,7 +249,7 @@ fn lot_size_replay_with_config_matches() {
     let mut live = OrderBook::<()>::with_clock("TEST", stub_clock());
     live.set_lot_size(5);
     live.add_order(OrderType::Standard {
-        id: Id::new_uuid(),
+        id: Id::from_u64(LOT_ASK_ID),
         price: Price::new(100),
         quantity: Quantity::new(10),
         side: Side::Sell,
@@ -250,7 +259,7 @@ fn lot_size_replay_with_config_matches() {
         extra_fields: (),
     })
     .expect("seed ask");
-    let _ = live.match_market_order_by_amount(Id::new_uuid(), 700, Side::Buy);
+    let _ = live.match_market_order_by_amount(Id::from_u64(LOT_TAKER_ID), 700, Side::Buy);
     let live_snap = live.create_snapshot(usize::MAX);
 
     // Replay WITH the matching config.
@@ -290,7 +299,7 @@ fn stp_prevented_order_recorded_rejected_is_skipped_on_replay() {
     let journal: InMemoryJournal<()> = InMemoryJournal::new();
 
     // Resting ask from user U (succeeds even under STP — nothing to cross).
-    let ask_id = Id::new_uuid();
+    let ask_id = Id::from_u64(21);
     assert!(
         journal
             .append(&make_add_event(0, ask_id, 100, 10, Side::Sell, user))
@@ -299,7 +308,7 @@ fn stp_prevented_order_recorded_rejected_is_skipped_on_replay() {
 
     // Same-user crossing buy: under STP = CancelTaker this was prevented at
     // write time, so the sequencer recorded it as Rejected.
-    let buy_id = Id::new_uuid();
+    let buy_id = Id::from_u64(22);
     let rejected_buy = SequencerEvent::<()> {
         sequence_num: 1,
         timestamp_ns: 0,
@@ -324,7 +333,7 @@ fn stp_prevented_order_recorded_rejected_is_skipped_on_replay() {
     let mut live = OrderBook::<()>::with_clock("TEST", stub_clock());
     live.set_stp_mode(STPMode::CancelTaker);
     live.add_order(OrderType::Standard {
-        id: Id::new_uuid(),
+        id: ask_id,
         price: Price::new(100),
         quantity: Quantity::new(10),
         side: Side::Sell,
@@ -336,7 +345,7 @@ fn stp_prevented_order_recorded_rejected_is_skipped_on_replay() {
     .expect("seed ask");
     // The crossing buy is rejected by STP — tolerate the error, the ask rests.
     let _ = live.add_order(OrderType::Standard {
-        id: Id::new_uuid(),
+        id: buy_id,
         price: Price::new(100),
         quantity: Quantity::new(10),
         side: Side::Buy,
@@ -391,7 +400,7 @@ fn full_config_injection_preserves_lot_size_parity() {
     live.set_min_order_size(1);
     live.set_max_order_size(1_000);
     live.add_order(OrderType::Standard {
-        id: Id::new_uuid(),
+        id: Id::from_u64(LOT_ASK_ID),
         price: Price::new(100),
         quantity: Quantity::new(10),
         side: Side::Sell,
@@ -401,7 +410,7 @@ fn full_config_injection_preserves_lot_size_parity() {
         extra_fields: (),
     })
     .expect("seed ask");
-    let _ = live.match_market_order_by_amount(Id::new_uuid(), 700, Side::Buy);
+    let _ = live.match_market_order_by_amount(Id::from_u64(LOT_TAKER_ID), 700, Side::Buy);
     let live_snap = live.create_snapshot(usize::MAX);
 
     let config = ReplayBookConfig::new(


### PR DESCRIPTION
## Summary

`snapshots_match` — the sole replay equality oracle — compared only
per-level aggregates, so two books with the same aggregates but reversed
maker FIFO (or different maker ids, users, variants, TIF) certified as
replay-equal while emitting different trades on the next sweep. It now
compares the complete per-level state.

## Changes

- Per level, after the aggregate checks: element-wise comparison of the
  full `orders()` vector in queue-consumption order (pricelevel ≥ 0.9
  materializes it that way) via `OrderType` equality — id, variant, side,
  price, quantities, user, admission timestamp, TIF, type-specific fields.
- Deterministic statistics compared: orders added / removed / executed,
  quantity executed, value executed, and the sticky `stats_degraded` flag.
- Documented exclusions with their root causes (verified empirically by the
  determinism audit): `first_arrival_time` (raw `SystemTime::now()` in
  pricelevel, outside the injectable clock), `last_execution_time` /
  `sum_waiting_time` (live ingestion and replay consume different
  clock-tick budgets by design), and the top-level capture timestamp.
- Realigned four test fixtures that relied on the old laxity (journal ids
  minted independently from the "ground truth" book's ids); the remaining
  replay suites were verified safe by construction.

## Technical decisions

- Order admission timestamps participate: the journal carries the admitted
  order verbatim and replay never re-stamps, so a faithful replay
  reproduces them under any clock. This is documented as a contract
  tightening of the public `snapshots_match` / `ReplayEngine::verify`.

## Testing

- New regressions: reversed two-maker FIFO → mismatch, plus a
  restore-and-sweep proof that the previously-accepted snapshots produce
  different first makers; maker-id and TIF divergence with equal
  aggregates → mismatch; `stats_degraded` divergence → mismatch;
  wall-time statistics and capture-timestamp exclusion → still match.
- Reviewed by `architect` (approve) and `determinism-auditor` (replay-safe;
  both doc-accuracy findings addressed, including the corrected exclusion
  rationale).
- Full suite: 810 lib + 486 integration, 0 failed. `make pre-push` clean.

## Stack

- Base branch: `stack/2-207-failure-atomic-restore` (merged as #214)
- Stack: #206 → #207 → **#208 (this)** → #210 → #211 → #209

Closes #208
