### PR TITLE
Preserve quantity conservation for two-tranche orders (#210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Two-tranche quantity conservation (#210).** An aggressive Iceberg /
+  Reserve partial fill assigned the **total** unmatched remainder to the
+  visible tranche while keeping the original hidden tranche — an iceberg
+  `20v/80h` filled by 10 rested `90v/80h`, manufacturing 80 units of
+  liquidity. The residual now rests via the new
+  `OrderQuantity::set_total_remaining` (visible = min(display size,
+  remainder), hidden = remainder − visible; Reserve keeps its
+  visible-first-with-replenish policy), so
+  `executed + resting == submitted` always holds (property-tested).
+  Additionally, a two-tranche total that overflows `u64` (previously
+  silently saturated) is rejected at admission with the new typed
+  `OrderBookError::QuantityOverflow` — on the direct add path before even
+  the risk gate (which would otherwise judge the saturated total), and
+  always before any trade, listener, or book mutation — mapping to the
+  wire code `RejectReason::InvalidQuantity`. `set_quantity` keeps its user-facing
+  visible-tranche semantics for icebergs and is now documented as such.
 - **`snapshots_match` is a full replay oracle (#208).** The replay equality
   check compared only per-level aggregates (price, visible/hidden quantity,
   order count), so two books with the same aggregates but reversed maker

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ This order book engine is built with the following design principles:
   the re-exported pricelevel surface changed —
   `PriceLevel::add_order` returns `Result`, `matchable_quantity` takes
   the taker id, `PriceLevelError` gained `DuplicateOrderId`.
+- **Two-tranche quantity conservation (#210).** An aggressive iceberg's
+  residual rests with exactly the unmatched total distributed across
+  tranches (`visible = min(display, remainder)`, rest hidden) instead of
+  inflating the book, and a `visible + hidden` overflow is rejected at
+  admission with the new typed `OrderBookError::QuantityOverflow`
+  before any trade or mutation. Conservation
+  (`executed + resting == submitted`) is property-tested.
 - **`snapshots_match` compares full maker state and FIFO (#208).** The
   replay oracle now checks every level's order vector in
   queue-consumption order (ids, variants, users, quantities,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,13 @@
 //!   the re-exported pricelevel surface changed —
 //!   `PriceLevel::add_order` returns `Result`, `matchable_quantity` takes
 //!   the taker id, `PriceLevelError` gained `DuplicateOrderId`.
+//! - **Two-tranche quantity conservation (#210).** An aggressive iceberg's
+//!   residual rests with exactly the unmatched total distributed across
+//!   tranches (`visible = min(display, remainder)`, rest hidden) instead of
+//!   inflating the book, and a `visible + hidden` overflow is rejected at
+//!   admission with the new typed `OrderBookError::QuantityOverflow`
+//!   before any trade or mutation. Conservation
+//!   (`executed + resting == submitted`) is property-tested.
 //! - **`snapshots_match` compares full maker state and FIFO (#208).** The
 //!   replay oracle now checks every level's order vector in
 //!   queue-consumption order (ids, variants, users, quantities,

--- a/src/orderbook/error.rs
+++ b/src/orderbook/error.rs
@@ -125,6 +125,20 @@ pub enum OrderBookError {
         order_id: pricelevel::Id,
     },
 
+    /// Order rejected because its two-tranche total (`visible + hidden`)
+    /// overflows `u64` and therefore cannot be represented by the engine's
+    /// quantity arithmetic (#210). On the direct `add_order` path this is
+    /// raised before the risk gate (which would otherwise evaluate the
+    /// saturated total), and always before any match, listener, or book
+    /// mutation. Maps to the stable wire code
+    /// `RejectReason::InvalidQuantity`.
+    QuantityOverflow {
+        /// Visible-tranche quantity of the rejected order.
+        visible: u64,
+        /// Hidden-tranche quantity of the rejected order.
+        hidden: u64,
+    },
+
     /// Order rejected because `user_id` is `Hash32::zero()` while
     /// Self-Trade Prevention is enabled. All orders must carry a non-zero
     /// `user_id` when STP mode is active.
@@ -291,6 +305,12 @@ impl fmt::Display for OrderBookError {
                 write!(
                     f,
                     "missing user_id: order {order_id} rejected because STP is enabled and user_id is zero"
+                )
+            }
+            OrderBookError::QuantityOverflow { visible, hidden } => {
+                write!(
+                    f,
+                    "quantity overflow: visible {visible} + hidden {hidden} exceeds u64"
                 )
             }
             OrderBookError::SelfTradePrevented {
@@ -487,6 +507,12 @@ impl Clone for OrderBookError {
             OrderBookError::MissingUserId { order_id } => OrderBookError::MissingUserId {
                 order_id: *order_id,
             },
+            OrderBookError::QuantityOverflow { visible, hidden } => {
+                OrderBookError::QuantityOverflow {
+                    visible: *visible,
+                    hidden: *hidden,
+                }
+            }
             OrderBookError::SelfTradePrevented {
                 mode,
                 taker_order_id,

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -17,14 +17,54 @@ pub trait OrderQuantity<T = ()> {
     fn quantity(&self) -> u64;
 
     /// Returns the total quantity of the order (e.g., visible + hidden).
+    ///
+    /// Saturates on `visible + hidden` overflow for the two-tranche kinds.
+    /// Every order admitted through `add_order` / the submit APIs / the
+    /// validate-first modify path has already passed
+    /// [`Self::checked_total_quantity`] validation (#210), so the
+    /// saturating arm is unreachable for those book-resident orders; use
+    /// the checked variant at admission boundaries. Snapshot restore
+    /// trusts its (checksummed) source and does not re-validate totals —
+    /// consistent with its existing saturating risk rebuild.
     fn total_quantity(&self) -> u64;
 
+    /// Returns the total quantity, or `None` when `visible + hidden`
+    /// overflows `u64` for a two-tranche order (Iceberg / Reserve). The
+    /// direct add path rejects such orders before the risk gate, and every
+    /// admission path rejects them before any match, listener, or map
+    /// mutation (#210).
+    #[must_use = "a None total means the order is unrepresentable and must be rejected"]
+    fn checked_total_quantity(&self) -> Option<u64>;
+
     /// Sets the new quantity for an order, handling the logic for different types.
-    /// For iceberg orders, it adjusts the visible and hidden parts correctly.
+    ///
+    /// This is the **user-facing quantity update** semantic: for iceberg
+    /// orders the value is applied to the visible tranche (matching
+    /// [`Self::quantity`], which returns the visible quantity), leaving
+    /// the hidden tranche unchanged. For adjusting an aggressive taker's
+    /// **total** remainder before resting, use
+    /// [`Self::set_total_remaining`] instead — applying a total to the
+    /// visible tranche manufactures liquidity (#210).
     fn set_quantity(&mut self, new_total_quantity: u64);
+
+    /// Distributes a **total** remaining quantity across the order's
+    /// tranches before resting an aggressive taker's residual (#210).
+    ///
+    /// - One-tranche kinds: the quantity becomes `remaining_total`.
+    /// - Iceberg: the submitted visible quantity acts as the display
+    ///   size — `visible = min(display, remaining_total)`,
+    ///   `hidden = remaining_total − visible`. A fill smaller than the
+    ///   visible tranche shrinks only the display; a fill past it
+    ///   consumes hidden; conservation always holds:
+    ///   `visible + hidden == remaining_total`.
+    /// - Reserve: reduction is drawn from the visible tranche first, then
+    ///   hidden, with the existing replenish-on-empty behaviour (same
+    ///   policy `set_quantity` already implemented for Reserve).
+    fn set_total_remaining(&mut self, remaining_total: u64);
 }
 
 impl<T> OrderQuantity<T> for OrderType<T> {
+    #[inline]
     fn quantity(&self) -> u64 {
         match self {
             OrderType::Standard { quantity, .. } => quantity.as_u64(),
@@ -41,6 +81,7 @@ impl<T> OrderQuantity<T> for OrderType<T> {
         }
     }
 
+    #[inline]
     fn total_quantity(&self) -> u64 {
         match self {
             OrderType::Standard { quantity, .. } => quantity.as_u64(),
@@ -65,6 +106,26 @@ impl<T> OrderQuantity<T> for OrderType<T> {
         }
     }
 
+    #[inline]
+    fn checked_total_quantity(&self) -> Option<u64> {
+        match self {
+            OrderType::IcebergOrder {
+                visible_quantity,
+                hidden_quantity,
+                ..
+            }
+            | OrderType::ReserveOrder {
+                visible_quantity,
+                hidden_quantity,
+                ..
+            } => visible_quantity
+                .as_u64()
+                .checked_add(hidden_quantity.as_u64()),
+            _ => Some(self.total_quantity()),
+        }
+    }
+
+    #[inline]
     fn set_quantity(&mut self, new_total_quantity: u64) {
         match self {
             OrderType::Standard { quantity, .. }
@@ -83,35 +144,73 @@ impl<T> OrderQuantity<T> for OrderType<T> {
                 *visible_quantity = Quantity::new(new_total_quantity);
                 // Hidden quantity remains unchanged
             }
-            OrderType::ReserveOrder {
+            OrderType::ReserveOrder { .. } => reduce_reserve_to_total(self, new_total_quantity),
+        }
+    }
+
+    #[inline]
+    fn set_total_remaining(&mut self, remaining_total: u64) {
+        match self {
+            OrderType::Standard { quantity, .. }
+            | OrderType::PostOnly { quantity, .. }
+            | OrderType::TrailingStop { quantity, .. }
+            | OrderType::PeggedOrder { quantity, .. }
+            | OrderType::MarketToLimit { quantity, .. } => {
+                *quantity = Quantity::new(remaining_total)
+            }
+
+            OrderType::IcebergOrder {
                 visible_quantity,
                 hidden_quantity,
-                replenish_amount,
                 ..
             } => {
-                let original_total = visible_quantity
-                    .as_u64()
-                    .saturating_add(hidden_quantity.as_u64());
-                let amount_to_reduce = original_total.saturating_sub(new_total_quantity);
-
-                let vis = visible_quantity.as_u64();
-                let filled_from_visible = amount_to_reduce.min(vis);
-                *visible_quantity = Quantity::new(vis.saturating_sub(filled_from_visible));
-
-                let remaining_to_reduce = amount_to_reduce - filled_from_visible;
-                *hidden_quantity =
-                    Quantity::new(hidden_quantity.as_u64().saturating_sub(remaining_to_reduce));
-
-                if visible_quantity.as_u64() == 0 && hidden_quantity.as_u64() > 0 {
-                    let refresh = replenish_amount
-                        .map(|q| q.get())
-                        .unwrap_or(0)
-                        .min(hidden_quantity.as_u64());
-                    *visible_quantity = Quantity::new(refresh);
-                    *hidden_quantity =
-                        Quantity::new(hidden_quantity.as_u64().saturating_sub(refresh));
-                }
+                // The submitted visible quantity is the display size. The
+                // residual rests with at most one display tranche visible
+                // and the rest hidden — conservation by construction:
+                // visible + hidden == remaining_total.
+                let display = visible_quantity.as_u64();
+                let visible = display.min(remaining_total);
+                *visible_quantity = Quantity::new(visible);
+                *hidden_quantity = Quantity::new(remaining_total - visible);
             }
+            OrderType::ReserveOrder { .. } => reduce_reserve_to_total(self, remaining_total),
+        }
+    }
+}
+
+/// Shared Reserve-order reduction: draw the reduction from the visible
+/// tranche first, then hidden, replenishing the visible tranche when it
+/// empties while hidden remains. Used by both the user-facing
+/// `set_quantity` and the residual `set_total_remaining` — Reserve
+/// already treats its input as a total.
+fn reduce_reserve_to_total<T>(order: &mut OrderType<T>, new_total_quantity: u64) {
+    if let OrderType::ReserveOrder {
+        visible_quantity,
+        hidden_quantity,
+        replenish_amount,
+        ..
+    } = order
+    {
+        let original_total = visible_quantity
+            .as_u64()
+            .saturating_add(hidden_quantity.as_u64());
+        let amount_to_reduce = original_total.saturating_sub(new_total_quantity);
+
+        let vis = visible_quantity.as_u64();
+        let filled_from_visible = amount_to_reduce.min(vis);
+        *visible_quantity = Quantity::new(vis.saturating_sub(filled_from_visible));
+
+        let remaining_to_reduce = amount_to_reduce - filled_from_visible;
+        *hidden_quantity =
+            Quantity::new(hidden_quantity.as_u64().saturating_sub(remaining_to_reduce));
+
+        if visible_quantity.as_u64() == 0 && hidden_quantity.as_u64() > 0 {
+            let refresh = replenish_amount
+                .map(|q| q.get())
+                .unwrap_or(0)
+                .min(hidden_quantity.as_u64());
+            *visible_quantity = Quantity::new(refresh);
+            *hidden_quantity = Quantity::new(hidden_quantity.as_u64().saturating_sub(refresh));
         }
     }
 }
@@ -771,6 +870,18 @@ where
     /// # Errors
     /// Returns the first failing check's typed [`OrderBookError`].
     pub(super) fn validate_order_shape(&self, order: &OrderType<T>) -> Result<(), OrderBookError> {
+        // Two-tranche total representability (#210): an Iceberg / Reserve
+        // whose visible + hidden overflows u64 cannot be tracked by any of
+        // the engine's quantity arithmetic — reject it before every other
+        // check so the saturating `total_quantity` below (and everywhere
+        // downstream) is provably unreachable for admitted orders.
+        if order.checked_total_quantity().is_none() {
+            return Err(OrderBookError::QuantityOverflow {
+                visible: order.visible_quantity().as_u64(),
+                hidden: order.hidden_quantity().as_u64(),
+            });
+        }
+
         // STP user_id enforcement: when STP is enabled, all orders must carry
         // a non-zero user_id so that self-trade checks can identify the owner.
         if self.stp_mode != crate::orderbook::stp::STPMode::None
@@ -997,6 +1108,14 @@ where
                     },
                 );
             }
+            OrderBookError::QuantityOverflow { .. } => {
+                self.track_state(
+                    order.id(),
+                    OrderStatus::Rejected {
+                        reason: RejectReason::InvalidQuantity,
+                    },
+                );
+            }
             OrderBookError::InvalidTickSize { .. } => {
                 self.track_state(
                     order.id(),
@@ -1110,6 +1229,20 @@ where
         want_result: bool,
     ) -> Result<(Arc<OrderType<T>>, Option<TradeResult>), OrderBookError> {
         self.check_kill_switch_or_reject(order.id())?;
+        // Representability gate (#210): an unrepresentable two-tranche
+        // total must be rejected before the risk gate below, which would
+        // otherwise evaluate the account's notional against the SATURATED
+        // `u64::MAX` total and reject with a misleading risk-family error.
+        // `validate_order_shape` re-checks this for the shared modify path;
+        // the duplicate check is a single jump-table match + checked_add.
+        if order.checked_total_quantity().is_none() {
+            let err = OrderBookError::QuantityOverflow {
+                visible: order.visible_quantity().as_u64(),
+                hidden: order.hidden_quantity().as_u64(),
+            };
+            self.record_shape_rejection(&order, &err);
+            return Err(err);
+        }
         // Pre-trade risk gate: per-account open-orders / notional /
         // price band. No-op when no `RiskConfig` is installed.
         // Documented order: kill_switch → risk → STP → fees → match.
@@ -1259,10 +1392,15 @@ where
                 });
             }
 
-            // Update the order with the remaining quantity
-            // For iceberg orders, only update if there was actual matching (remaining < total)
+            // Rest the taker's residual. `remaining_quantity` is the TOTAL
+            // unmatched quantity, so distribute it across the tranches with
+            // `set_total_remaining` (#210): for a partially-filled iceberg
+            // the submitted visible quantity acts as the display size and
+            // the rest stays hidden — assigning the total to the visible
+            // tranche (the old `set_quantity` semantics) manufactured
+            // liquidity by keeping the original hidden tranche on top.
             if match_result.remaining_quantity().as_u64() < order.total_quantity() {
-                order.set_quantity(match_result.remaining_quantity().as_u64()); // Now uses the trait method
+                order.set_total_remaining(match_result.remaining_quantity().as_u64());
             }
 
             let price = order.price().as_u128();

--- a/src/orderbook/reject_reason.rs
+++ b/src/orderbook/reject_reason.rs
@@ -221,6 +221,7 @@ impl From<&OrderBookError> for RejectReason {
             OrderBookError::InsufficientLiquidityNotional { .. } => Self::InsufficientLiquidity,
             OrderBookError::InvalidTickSize { .. } => Self::InvalidPrice,
             OrderBookError::InvalidLotSize { .. } => Self::InvalidQuantity,
+            OrderBookError::QuantityOverflow { .. } => Self::InvalidQuantity,
             OrderBookError::OrderSizeOutOfRange { .. } => Self::OrderSizeOutOfRange,
             OrderBookError::DuplicateOrderId { .. } => Self::DuplicateOrderId,
             OrderBookError::MissingUserId { .. } => Self::MissingUserId,

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -35,4 +35,5 @@ mod sequencer_types_tests;
 mod snapshot_restore_tests;
 #[cfg(feature = "special_orders")]
 mod special_order_restore_tests;
+mod two_tranche_conservation_tests;
 mod validation_tests;

--- a/tests/unit/two_tranche_conservation_tests.rs
+++ b/tests/unit/two_tranche_conservation_tests.rs
@@ -1,0 +1,299 @@
+//! #210: two-tranche (Iceberg / Reserve) quantity conservation.
+//!
+//! - An aggressive two-tranche order's residual rests with the exact total
+//!   remainder distributed across tranches — never the old
+//!   "total-into-visible, hidden kept" inflation that manufactured
+//!   liquidity.
+//! - A `visible + hidden` total that overflows `u64` is rejected with the
+//!   typed `QuantityOverflow` before any trade, listener, or book mutation.
+//! - Conservation invariant (property-tested): for every aggressive
+//!   iceberg submit, `executed + resting visible + resting hidden ==
+//!   submitted visible + submitted hidden`.
+
+#[cfg(test)]
+mod tests_two_tranche_conservation {
+    use orderbook_rs::{DefaultOrderBook, OrderBook, OrderBookError};
+    use pricelevel::{Id, Side, TimeInForce};
+    use proptest::prelude::*;
+
+    const PRICE: u128 = 100;
+    const MAKER_ID: u64 = 1;
+    const ICEBERG_ID: u64 = 2;
+
+    /// Rests `contra` sell units at `PRICE`, submits an aggressive iceberg
+    /// buy (`visible`/`hidden`) at the same price, and returns
+    /// `(executed, resting_visible, resting_hidden)`.
+    fn run_iceberg_cross(
+        contra: u64,
+        visible: u64,
+        hidden: u64,
+    ) -> Result<(u64, u64, u64), TestCaseError> {
+        let book: OrderBook<()> = DefaultOrderBook::new("CONS");
+        if contra > 0
+            && let Err(error) = book.add_limit_order(
+                Id::from_u64(MAKER_ID),
+                PRICE,
+                contra,
+                Side::Sell,
+                TimeInForce::Gtc,
+                None,
+            )
+        {
+            return Err(TestCaseError::fail(format!("seed contra failed: {error}")));
+        }
+
+        if let Err(error) = book.add_iceberg_order(
+            Id::from_u64(ICEBERG_ID),
+            PRICE,
+            visible,
+            hidden,
+            Side::Buy,
+            TimeInForce::Gtc,
+            None,
+        ) {
+            return Err(TestCaseError::fail(format!(
+                "iceberg submit failed: {error}"
+            )));
+        }
+
+        let executed = contra.min(visible + hidden);
+        let resting = book.get_order(Id::from_u64(ICEBERG_ID));
+        let (rest_visible, rest_hidden) = match resting {
+            Some(order) => (
+                order.visible_quantity().as_u64(),
+                order.hidden_quantity().as_u64(),
+            ),
+            None => (0, 0),
+        };
+        Ok((executed, rest_visible, rest_hidden))
+    }
+
+    /// The issue's repro: iceberg 20 visible + 80 hidden aggressed by 10
+    /// contra units must rest exactly 90 total (20 visible / 70 hidden) —
+    /// not the pre-#210 `visible=90, hidden=80` inflation.
+    #[test]
+    fn iceberg_partial_fill_rests_exact_total() {
+        let (executed, visible, hidden) = match run_iceberg_cross(10, 20, 80) {
+            Ok(v) => v,
+            Err(e) => panic!("{e}"),
+        };
+        assert_eq!(executed, 10);
+        assert_eq!(visible, 20, "display tranche stays at the submitted size");
+        assert_eq!(hidden, 70, "hidden absorbs the fill");
+        assert_eq!(
+            visible + hidden,
+            90,
+            "exactly the unmatched remainder rests"
+        );
+    }
+
+    /// Fill smaller than, equal to, and larger than the visible tranche.
+    #[test]
+    fn iceberg_residual_covers_all_fill_positions() {
+        // Fill (5) < visible (20): full display remains, hidden shrinks.
+        let (_, v, h) = match run_iceberg_cross(5, 20, 80) {
+            Ok(x) => x,
+            Err(e) => panic!("{e}"),
+        };
+        assert_eq!((v, h), (20, 75));
+
+        // Fill (20) == visible: remainder 80 rests as one display + hidden.
+        let (_, v, h) = match run_iceberg_cross(20, 20, 80) {
+            Ok(x) => x,
+            Err(e) => panic!("{e}"),
+        };
+        assert_eq!((v, h), (20, 60));
+
+        // Fill (50) > visible: remainder 50 rests as display 20 + hidden 30.
+        let (_, v, h) = match run_iceberg_cross(50, 20, 80) {
+            Ok(x) => x,
+            Err(e) => panic!("{e}"),
+        };
+        assert_eq!((v, h), (20, 30));
+
+        // Remainder smaller than the display: everything visible.
+        let (_, v, h) = match run_iceberg_cross(90, 20, 80) {
+            Ok(x) => x,
+            Err(e) => panic!("{e}"),
+        };
+        assert_eq!((v, h), (10, 0));
+    }
+
+    /// An iceberg whose `visible + hidden` overflows `u64` is rejected with
+    /// the typed error BEFORE anything executes: the contra maker is left
+    /// fully intact and no trade is emitted.
+    #[test]
+    fn overflowing_two_tranche_total_rejected_pre_trade() {
+        let book: OrderBook<()> = DefaultOrderBook::new("OVF");
+        book.add_limit_order(
+            Id::from_u64(MAKER_ID),
+            PRICE,
+            10,
+            Side::Sell,
+            TimeInForce::Gtc,
+            None,
+        )
+        .expect("seed contra");
+
+        let err = book
+            .add_iceberg_order(
+                Id::from_u64(ICEBERG_ID),
+                PRICE,
+                u64::MAX,
+                1,
+                Side::Buy,
+                TimeInForce::Gtc,
+                None,
+            )
+            .expect_err("overflowing total must be rejected");
+        match err {
+            OrderBookError::QuantityOverflow { visible, hidden } => {
+                assert_eq!(visible, u64::MAX);
+                assert_eq!(hidden, 1);
+            }
+            other => panic!("expected QuantityOverflow, got {other:?}"),
+        }
+
+        // Nothing executed, nothing mutated.
+        assert!(book.last_trade_price().is_none(), "no trade may be emitted");
+        let maker = book
+            .get_order(Id::from_u64(MAKER_ID))
+            .expect("contra maker still resting");
+        assert_eq!(maker.visible_quantity().as_u64(), 10, "maker untouched");
+        assert!(
+            book.get_order(Id::from_u64(ICEBERG_ID)).is_none(),
+            "rejected order never rests"
+        );
+    }
+
+    /// Snapshot round-trip preserves the corrected residual tranches.
+    #[test]
+    fn corrected_residual_survives_snapshot_round_trip() {
+        let book: OrderBook<()> = DefaultOrderBook::new("RT");
+        book.add_limit_order(
+            Id::from_u64(MAKER_ID),
+            PRICE,
+            10,
+            Side::Sell,
+            TimeInForce::Gtc,
+            None,
+        )
+        .expect("seed contra");
+        book.add_iceberg_order(
+            Id::from_u64(ICEBERG_ID),
+            PRICE,
+            20,
+            80,
+            Side::Buy,
+            TimeInForce::Gtc,
+            None,
+        )
+        .expect("iceberg submit");
+
+        let package = book.create_snapshot_package(10).expect("package");
+        let mut restored: OrderBook<()> = DefaultOrderBook::new("RT");
+        restored
+            .restore_from_snapshot_package(package)
+            .expect("restore");
+
+        let order = restored
+            .get_order(Id::from_u64(ICEBERG_ID))
+            .expect("residual restored");
+        assert_eq!(order.visible_quantity().as_u64(), 20);
+        assert_eq!(order.hidden_quantity().as_u64(), 70);
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 256, max_shrink_iters: 50_000, ..ProptestConfig::default() })]
+
+        /// Conservation: for every aggressive iceberg submit,
+        /// `executed + resting visible + resting hidden` equals the
+        /// submitted `visible + hidden`.
+        #[test]
+        fn test_iceberg_cross_conserves_total_quantity(
+            contra in 0u64..=200,
+            visible in 1u64..=100,
+            hidden in 0u64..=100,
+        ) {
+            let (executed, rest_visible, rest_hidden) =
+                run_iceberg_cross(contra, visible, hidden)?;
+            prop_assert_eq!(
+                executed + rest_visible + rest_hidden,
+                visible + hidden,
+                "executed {} + resting {}v/{}h must equal submitted {}v/{}h",
+                executed, rest_visible, rest_hidden, visible, hidden
+            );
+        }
+    }
+}
+
+/// #210 follow-ups from review: the overflow rejection must win over the
+/// risk gate (which would otherwise judge the saturated total), and the
+/// Reserve residual path conserves quantity like the Iceberg one.
+#[cfg(test)]
+mod tests_two_tranche_review_gaps {
+    use orderbook_rs::orderbook::risk::RiskConfig;
+    use orderbook_rs::{DefaultOrderBook, OrderBook, OrderBookError};
+    use pricelevel::{Hash32, Id, OrderType, Price, Quantity, Side, TimeInForce, TimestampMs};
+
+    /// With a RiskConfig installed, an overflowing iceberg must still be
+    /// rejected as `QuantityOverflow` — not as a risk-family error derived
+    /// from the saturated `u64::MAX` total.
+    #[test]
+    fn overflow_beats_risk_gate() {
+        let mut book: OrderBook<()> = DefaultOrderBook::new("OVR");
+        book.set_risk_config(RiskConfig::new().with_max_notional_per_account(1_000_000));
+
+        let err = book
+            .add_iceberg_order(
+                Id::from_u64(1),
+                100,
+                u64::MAX,
+                1,
+                Side::Buy,
+                TimeInForce::Gtc,
+                None,
+            )
+            .expect_err("overflowing total must be rejected");
+        assert!(
+            matches!(err, OrderBookError::QuantityOverflow { .. }),
+            "expected QuantityOverflow before the risk gate, got {err:?}"
+        );
+    }
+
+    /// Reserve residual conservation: an aggressive reserve partially
+    /// filled rests exactly the unmatched remainder across tranches (the
+    /// visible-first-with-replenish reduction the user-facing update
+    /// already used).
+    #[test]
+    fn reserve_partial_fill_conserves_total() {
+        let book: OrderBook<()> = DefaultOrderBook::new("RSV");
+        book.add_limit_order(Id::from_u64(1), 100, 10, Side::Sell, TimeInForce::Gtc, None)
+            .expect("seed contra");
+
+        let reserve = OrderType::ReserveOrder {
+            id: Id::from_u64(2),
+            price: Price::new(100),
+            visible_quantity: Quantity::new(20),
+            hidden_quantity: Quantity::new(80),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_700_000_000_000),
+            time_in_force: TimeInForce::Gtc,
+            replenish_threshold: Quantity::new(1),
+            replenish_amount: None,
+            auto_replenish: true,
+            extra_fields: (),
+        };
+        book.add_order(reserve).expect("reserve submit");
+
+        let resting = book.get_order(Id::from_u64(2)).expect("residual rests");
+        let visible = resting.visible_quantity().as_u64();
+        let hidden = resting.hidden_quantity().as_u64();
+        assert_eq!(
+            visible + hidden,
+            90,
+            "reserve residual conserves the unmatched total, got {visible}v/{hidden}h"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Two-tranche quantity handling could manufacture liquidity: an aggressive
iceberg's partial fill assigned the **total** unmatched remainder to the
visible tranche while keeping the original hidden tranche (`20v/80h` filled
by 10 rested `90v/80h` — 170 units for a 90-unit remainder). Separately, a
`visible + hidden` total overflowing `u64` silently saturated instead of
being rejected.

## Changes

- New `OrderQuantity::set_total_remaining`: the aggressive-taker residual
  rests with `visible = min(submitted display, remainder)`,
  `hidden = remainder − visible` (conventional iceberg display semantics);
  Reserve keeps its visible-first-with-replenish reduction (extracted into
  a shared helper, byte-identical to the old arm); one-tranche kinds
  unchanged. `set_quantity` keeps its user-facing visible-tranche semantics
  and both are now documented as distinct operations.
- New `OrderQuantity::checked_total_quantity` + typed
  `OrderBookError::QuantityOverflow { visible, hidden }` (wire code
  `RejectReason::InvalidQuantity`): rejected on the direct add path before
  even the risk gate — which would otherwise judge the saturated
  `u64::MAX` total and return a misleading risk-family error — and always
  before any trade, listener, or book mutation. The saturating
  `total_quantity` remains for post-validation paths, documented as
  unreachable for orders admitted through the validated entry points.
- `#[inline]` on the `OrderQuantity` impl methods (per-admission path).

## Testing

- Issue repro: `20v/80h` filled by 10 rests exactly `20v/70h`.
- Fill < / = / > visible tranche, plus remainder-below-display.
- Overflow rejected pre-trade with contra maker untouched; overflow beats
  an installed `RiskConfig` (review finding).
- Reserve residual conservation; snapshot round-trip of corrected
  residual tranches.
- Conservation proptest (256 cases): `executed + resting == submitted`.
- Reviewed by `hotpath-reviewer` (OK to commit; `#[inline]` nit applied)
  and `architect` (approve; risk-gate ordering finding fixed in code, doc
  corrections applied).
- Full suite: 810 lib + 493 integration, 0 failed. `make pre-push` clean.

## Stack

- Base branch: `stack/3-208-full-replay-oracle` (merged as #215)
- Stack: #206 → #207 → #208 → **#210 (this)** → #211 → #209

Closes #210
