### PR TITLE
Make pricelevel 0.9 mutation failures atomic and observable (#211)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **pricelevel 0.9 mutation failures are atomic and observable (#211).**
+  Three gaps closed on the fallible-mutation integration: (1)
+  `OrderUpdate::UpdateQuantity` silently converted every upstream
+  `PriceLevelError` into `Ok(None)` and bypassed book-level validation — it
+  is now validate-first (projected order checked against tick / lot /
+  min-max / two-tranche representability and the modify-aware risk gate
+  before the level is touched), propagates upstream errors as
+  `OrderBookError::PriceLevelError`, reserves `Ok(None)` for a genuinely
+  absent order, and keeps per-account risk counters in lockstep with the
+  applied update (new `on_quantity_update` hook). Routing through the
+  shared validator also means an expired-but-unevicted GTD/DAY maker and
+  a resting post-only maker whose price now crosses are rejected on
+  quantity update — previously both silently succeeded. (2) A non-immediate
+  taker whose residual could not be admitted into its same-side level
+  (checked aggregate at capacity) used to consume contra liquidity and
+  THEN fail — a headroom pre-check now rejects before the sweep emits any
+  trade (conservative: full submitted total; the concurrent-only remainder
+  is still guarded by pricelevel's validated admission). (3) If that racy
+  post-trade admission ever fails, a level created empty by the attempt is
+  removed — `best_bid` / `best_ask`, the cache, and depth gauges never see
+  a phantom level — and the failure is logged at ERROR.
 - **Two-tranche quantity conservation (#210).** An aggressive Iceberg /
   Reserve partial fill assigned the **total** unmatched remainder to the
   visible tranche while keeping the original hidden tranche — an iceberg

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ This order book engine is built with the following design principles:
   the re-exported pricelevel surface changed —
   `PriceLevel::add_order` returns `Result`, `matchable_quantity` takes
   the taker id, `PriceLevelError` gained `DuplicateOrderId`.
+- **Atomic, observable mutation failures (#211).** `UpdateQuantity` is
+  validate-first (projected tick / lot / min-max / representability /
+  risk before touching the level), propagates upstream
+  `PriceLevelError`s instead of returning `Ok(None)`, and updates risk
+  counters on success; a taker whose residual cannot rest is rejected
+  before the sweep trades; a failed racy admission cleans up any empty
+  level it created.
 - **Two-tranche quantity conservation (#210).** An aggressive iceberg's
   residual rests with exactly the unmatched total distributed across
   tranches (`visible = min(display, remainder)`, rest hidden) instead of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,13 @@
 //!   the re-exported pricelevel surface changed —
 //!   `PriceLevel::add_order` returns `Result`, `matchable_quantity` takes
 //!   the taker id, `PriceLevelError` gained `DuplicateOrderId`.
+//! - **Atomic, observable mutation failures (#211).** `UpdateQuantity` is
+//!   validate-first (projected tick / lot / min-max / representability /
+//!   risk before touching the level), propagates upstream
+//!   `PriceLevelError`s instead of returning `Ok(None)`, and updates risk
+//!   counters on success; a taker whose residual cannot rest is rejected
+//!   before the sweep trades; a failed racy admission cleans up any empty
+//!   level it created.
 //! - **Two-tranche quantity conservation (#210).** An aggressive iceberg's
 //!   residual rests with exactly the unmatched total distributed across
 //!   tranches (`visible = min(display, remainder)`, rest hidden) instead of

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -254,6 +254,22 @@ where
     /// is engaged and the update is anything other than
     /// [`OrderUpdate::Cancel`]. Cancels are explicitly allowed so that
     /// operators can drain resting orders while new flow is halted.
+    ///
+    /// [`OrderUpdate::UpdateQuantity`] is validate-first (#211): the
+    /// projected post-update order must pass the shared shape validator
+    /// (tick / lot / min-max / two-tranche representability) and the
+    /// modify-aware risk check, and any upstream
+    /// [`PriceLevelError`](pricelevel::PriceLevelError) from applying the
+    /// update is propagated as [`OrderBookError::PriceLevelError`] — a
+    /// rejected update leaves the maker unchanged, and `Ok(None)` means
+    /// only that the requested order is absent.
+    ///
+    /// Because the shared validator runs on the projected order, two
+    /// previously-accepted shapes are now rejected on `UpdateQuantity`
+    /// like they already were on the #98 modify paths: an
+    /// expired-but-unevicted GTD / DAY maker (`InvalidOperation`, expiry
+    /// is evaluated against the book clock) and a resting post-only maker
+    /// whose price meanwhile crosses the market (`PriceCrossing`).
     pub fn update_order(
         &self,
         update: OrderUpdate,
@@ -370,25 +386,65 @@ where
                     // Get the price level and update it
                     if let Some(entry) = price_levels.get(&price) {
                         let price_level = entry.value();
+
+                        // Validate-first (#211, extending the #98 contract
+                        // to quantity updates): project the exact order
+                        // pricelevel will store (`with_reduced_quantity` —
+                        // the same rewrite `UpdateQuantity` applies
+                        // upstream) and run the shared shape validator
+                        // plus the modify-aware risk check BEFORE mutating
+                        // the level. A rejected update leaves the maker
+                        // untouched. The source order is read off the
+                        // level entry already in hand — no `Arc` churn, no
+                        // second `order_locations` / level lookup.
+                        let Some(current_unit) = price_level
+                            .iter_orders()
+                            .find(|resting| resting.id() == order_id)
+                        else {
+                            return Ok(None); // Order not found
+                        };
+                        let current = self.convert_from_unit_type(current_unit.as_ref());
+                        let projected = current.with_reduced_quantity(new_quantity.as_u64());
+                        self.validate_order_shape(&projected)?;
+                        self.check_risk_modify_admission(
+                            order_id,
+                            projected.user_id(),
+                            price,
+                            projected.total_quantity(),
+                        )?;
+
                         let update = OrderUpdate::UpdateQuantity {
                             order_id,
                             new_quantity,
                         };
 
-                        if let Ok(updated_order) = price_level.update_order(update)
-                            && let Some(order) = updated_order
-                        {
-                            // notify price level changes
-                            if let Some(ref listener) = self.price_level_changed_listener {
-                                let engine_seq = self.next_engine_seq();
-                                listener(PriceLevelChangedEvent {
-                                    side,
-                                    price: price_level.price(),
-                                    quantity: price_level.visible_quantity(),
-                                    engine_seq,
-                                })
+                        // Propagate upstream validation / counter errors
+                        // (#211): `Ok(None)` is reserved for a genuinely
+                        // absent order, never an error swallowed silently.
+                        match price_level.update_order(update) {
+                            Ok(Some(order)) => {
+                                // Keep the per-account risk counters in
+                                // lockstep with the applied update.
+                                self.risk_state.on_quantity_update(
+                                    order_id,
+                                    OrderQuantity::<()>::total_quantity(order.as_ref()),
+                                );
+                                // notify price level changes
+                                if let Some(ref listener) = self.price_level_changed_listener {
+                                    let engine_seq = self.next_engine_seq();
+                                    listener(PriceLevelChangedEvent {
+                                        side,
+                                        price: price_level.price(),
+                                        quantity: price_level.visible_quantity(),
+                                        engine_seq,
+                                    })
+                                }
+                                result = Some(Arc::new(self.convert_from_unit_type(&order)));
                             }
-                            result = Some(Arc::new(self.convert_from_unit_type(&order)));
+                            Ok(None) => {}
+                            Err(err) => {
+                                return Err(OrderBookError::PriceLevelError(err));
+                            }
                         }
 
                         is_empty = price_level.order_count() == 0;
@@ -1302,6 +1358,62 @@ where
             return Err(err);
         }
 
+        // Residual-admission headroom pre-check (#211): a non-immediate
+        // taker may rest its residual at a same-side level whose checked
+        // aggregate counters cannot absorb it. pricelevel would reject
+        // that admission — but only AFTER the sweep has emitted
+        // irreversible trades. Reject up front instead. Gated on
+        // `will_cross_market` (one best-price cache read): a non-crossing
+        // add emits no trades, so its admission failure is already atomic
+        // via the cleanup path below — only a crossing taker needs the
+        // pre-trade guard, and it is about to pay for a full sweep anyway.
+        // The check is conservative (it uses the full submitted total; the
+        // actual residual is never larger) and best-effort under
+        // concurrency — the authoritative, validated admission below still
+        // guards the racy remainder, now with cleanup (#211).
+        if !order.is_immediate() && self.will_cross_market(order.price().as_u128(), order.side()) {
+            let same_side = match order.side() {
+                Side::Buy => &self.bids,
+                Side::Sell => &self.asks,
+            };
+            if let Some(entry) = same_side.get(&order.price().as_u128()) {
+                // A counter-inconsistency error from the level's checked
+                // aggregate is rejected with the same observable
+                // lifecycle/metric surface as the overflow branch below —
+                // both are pre-mutation, so the book is still pristine.
+                let level_total = match entry.value().total_quantity() {
+                    Ok(total) => total,
+                    Err(err) => {
+                        self.track_state(
+                            order.id(),
+                            OrderStatus::Rejected {
+                                reason: RejectReason::InvalidQuantity,
+                            },
+                        );
+                        crate::orderbook::metrics::record_reject(RejectReason::InvalidQuantity);
+                        return Err(OrderBookError::PriceLevelError(err));
+                    }
+                };
+                if level_total.checked_add(order.total_quantity()).is_none() {
+                    let err = OrderBookError::InvalidOperation {
+                        message: format!(
+                            "resting order {} would overflow the aggregate capacity of level {}",
+                            order.id(),
+                            order.price()
+                        ),
+                    };
+                    self.track_state(
+                        order.id(),
+                        OrderStatus::Rejected {
+                            reason: RejectReason::InvalidQuantity,
+                        },
+                    );
+                    crate::orderbook::metrics::record_reject(RejectReason::InvalidQuantity);
+                    return Err(err);
+                }
+            }
+        }
+
         self.cache.invalidate();
         // Attempt to match the order immediately (with STP user_id propagation).
         // The outcome also carries whether STP cancelled the taker (#97).
@@ -1416,11 +1528,31 @@ where
 
             // Convert to unit type for PriceLevel compatibility. Admission
             // into the level is validated upstream since pricelevel 0.9
-            // (duplicate id, counter capacity); a failure here is an
-            // invariant break — the book-level duplicate check already
-            // passed — so propagate it rather than resting a phantom order.
+            // (duplicate id, counter capacity). The pre-sweep headroom
+            // check above makes a failure here concurrent-only; if it
+            // still happens, remove the level when this call created it
+            // empty — `best_bid` / `best_ask`, the cache, and the depth
+            // gauges must never expose a phantom level — and surface the
+            // error loudly: the sweep's trades are already irreversible
+            // (#211).
             let unit_order = self.convert_to_unit_type(&order);
-            let unit_order_arc = price_level.value().add_order(unit_order)?;
+            let unit_order_arc = match price_level.value().add_order(unit_order) {
+                Ok(admitted) => admitted,
+                Err(err) => {
+                    if level.order_count() == 0 {
+                        price_levels.remove(&price);
+                    }
+                    self.cache.invalidate();
+                    self.record_depth_metric();
+                    tracing::error!(
+                        order_id = %order.id(),
+                        price,
+                        error = %err,
+                        "residual admission failed after irreversible trades; level cleaned up"
+                    );
+                    return Err(OrderBookError::PriceLevelError(err));
+                }
+            };
             // notify price level changes
             if let Some(ref listener) = self.price_level_changed_listener {
                 let engine_seq = self.next_engine_seq();

--- a/src/orderbook/risk.rs
+++ b/src/orderbook/risk.rs
@@ -560,6 +560,37 @@ impl RiskState {
         }
     }
 
+    /// Hook per in-place quantity update on a resting maker (#211):
+    /// adjusts the order's tracked remaining quantity and the account's
+    /// resting-notional counter by the signed delta at the entry's
+    /// admission price. No-op when no `RiskConfig` is installed or the
+    /// order is not tracked (e.g. admitted before the config was set).
+    pub(super) fn on_quantity_update(&self, order_id: Id, new_remaining: u64) {
+        if self.config.is_none() {
+            return;
+        }
+        let (account, entry_price, old_remaining) = {
+            let Some(mut entry) = self.orders.get_mut(&order_id) else {
+                return;
+            };
+            let account = entry.account;
+            let entry_price = entry.price;
+            let old_remaining = entry.remaining_qty;
+            entry.remaining_qty = new_remaining;
+            (account, entry_price, old_remaining)
+        };
+
+        if let Some(counters_ref) = self.counters.get(&account) {
+            if new_remaining >= old_remaining {
+                let delta = u128::from(new_remaining - old_remaining).saturating_mul(entry_price);
+                counters_ref.resting_notional.fetch_add(delta);
+            } else {
+                let delta = u128::from(old_remaining - new_remaining).saturating_mul(entry_price);
+                saturating_sub_u128(&counters_ref.resting_notional, delta);
+            }
+        }
+    }
+
     /// Atomically evict an account's [`RiskCounters`] once it has no
     /// resting orders and zero resting notional, so the per-account map
     /// tracks currently-active accounts instead of growing with every

--- a/tests/unit/filejournal_edge_case_tests.rs
+++ b/tests/unit/filejournal_edge_case_tests.rs
@@ -267,26 +267,30 @@ mod tests_filejournal_edge_cases {
 
         let reader_journal = Arc::clone(&journal);
         let reader = thread::spawn(move || {
-            let mut max_seen = 0u64;
-            // Poll multiple times to exercise concurrent reading
-            for _ in 0..20 {
+            let mut entries_seen = 0usize;
+            // Poll to exercise concurrent reading until at least one entry
+            // is observed (bounded, so a starved writer on a loaded CI
+            // runner cannot flake the test; the fixed 20×1ms loop used to
+            // time out under coverage instrumentation, and `max_seen > 0`
+            // also mis-fired when only sequence 0 had been written).
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+            while std::time::Instant::now() < deadline {
                 if let Ok(iter) = reader_journal.read_from(0) {
-                    for entry in iter.flatten() {
-                        if entry.event.sequence_num > max_seen {
-                            max_seen = entry.event.sequence_num;
-                        }
-                    }
+                    entries_seen = entries_seen.max(iter.flatten().count());
+                }
+                if entries_seen > 0 {
+                    break;
                 }
                 thread::sleep(std::time::Duration::from_millis(1));
             }
-            max_seen
+            entries_seen
         });
 
         writer.join().expect("writer thread panicked");
-        let max_seen = reader.join().expect("reader thread panicked");
+        let entries_seen = reader.join().expect("reader thread panicked");
 
         // Reader should have seen at least some entries
-        assert!(max_seen > 0, "reader should have seen entries");
+        assert!(entries_seen > 0, "reader should have seen entries");
 
         // After writer completes, all 100 entries must be readable
         let all_entries: Vec<_> = journal

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -17,6 +17,7 @@ mod matching_coverage_tests;
 mod matching_coverage_tests_extended;
 mod modifications_coverage_tests;
 mod modify_atomic_tests;
+mod mutation_failure_atomicity_tests;
 mod operations_coverage_tests;
 mod operations_coverage_tests_extended;
 mod order_state_tests;

--- a/tests/unit/mutation_failure_atomicity_tests.rs
+++ b/tests/unit/mutation_failure_atomicity_tests.rs
@@ -1,0 +1,385 @@
+//! #211: pricelevel 0.9 mutation failures are atomic and observable.
+//!
+//! - A submit whose residual could not be admitted is rejected BEFORE the
+//!   sweep emits any trade (headroom pre-check).
+//! - `UpdateQuantity` is validate-first: projected tick/lot/min-max/
+//!   two-tranche/risk violations and upstream `PriceLevelError`s surface
+//!   as typed errors with the maker unchanged; `Ok(None)` means only that
+//!   the order is absent.
+//! - Risk counters follow applied quantity updates.
+
+#[cfg(test)]
+mod tests_mutation_failure_atomicity {
+    use orderbook_rs::orderbook::risk::RiskConfig;
+    use orderbook_rs::{DefaultOrderBook, OrderBook, OrderBookError, OrderBookSnapshot};
+    use pricelevel::{
+        Hash32, Id, OrderType, OrderUpdate, Price, PriceLevel, Quantity, Side, TimeInForce,
+        TimestampMs,
+    };
+
+    /// A buy whose residual would overflow the same-side level's aggregate
+    /// is rejected before any trade: the crossing ask stays fully intact.
+    ///
+    /// A live book can never lock (bid and ask at one price), so the repro
+    /// state — a near-capacity bid level AND a crossing ask at the same
+    /// price — is built via snapshot restore, exactly the disaster-recovery
+    /// shape the issue describes.
+    #[test]
+    fn residual_headroom_rejects_before_any_trade() {
+        let make_level = |order_id: u64, qty: u64, side: Side| {
+            let level = PriceLevel::new(100);
+            let admitted = level.add_order(OrderType::Standard {
+                id: Id::from_u64(order_id),
+                price: Price::new(100),
+                quantity: Quantity::new(qty),
+                side,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(1_700_000_000_000),
+                time_in_force: TimeInForce::Gtc,
+                extra_fields: (),
+            });
+            assert!(admitted.is_ok(), "fixture level admits order {order_id}");
+            level.snapshot()
+        };
+
+        let book: OrderBook<()> = DefaultOrderBook::new("HEAD");
+        book.restore_from_snapshot(OrderBookSnapshot {
+            symbol: "HEAD".to_string(),
+            timestamp: 1_700_000_000_000,
+            bids: vec![make_level(1, u64::MAX - 2, Side::Buy)],
+            asks: vec![make_level(2, 5, Side::Sell)],
+        })
+        .expect("restore locked book");
+
+        // Buy 10 @ 100 would fill 5 from the ask, then rest 5 into the
+        // bid level — whose aggregate (u64::MAX - 2) cannot absorb it.
+        // The headroom pre-check must reject BEFORE the fill happens.
+        let err = book
+            .add_limit_order(Id::from_u64(3), 100, 10, Side::Buy, TimeInForce::Gtc, None)
+            .expect_err("residual could not rest; submit must be rejected pre-trade");
+        assert!(
+            matches!(err, OrderBookError::InvalidOperation { .. }),
+            "expected the typed capacity rejection, got {err:?}"
+        );
+
+        // Zero trades: the crossing ask is untouched and no last trade exists.
+        assert!(book.last_trade_price().is_none(), "no trade was emitted");
+        let ask = book.get_order(Id::from_u64(2)).expect("ask still resting");
+        assert_eq!(ask.visible_quantity().as_u64(), 5, "ask fully intact");
+        assert!(
+            book.get_order(Id::from_u64(3)).is_none(),
+            "rejected taker never rests"
+        );
+    }
+
+    /// `UpdateQuantity` enforces the projected lot-size rule and leaves the
+    /// maker unchanged on rejection.
+    #[test]
+    fn update_quantity_enforces_lot_size_on_projected_state() {
+        let mut book: OrderBook<()> = DefaultOrderBook::new("LOTU");
+        book.set_lot_size(5);
+        book.add_limit_order(Id::from_u64(1), 100, 10, Side::Buy, TimeInForce::Gtc, None)
+            .expect("seed maker");
+
+        let err = book
+            .update_order(OrderUpdate::UpdateQuantity {
+                order_id: Id::from_u64(1),
+                new_quantity: Quantity::new(7),
+            })
+            .expect_err("off-lot projected quantity must be rejected");
+        assert!(
+            matches!(err, OrderBookError::InvalidLotSize { .. }),
+            "expected InvalidLotSize, got {err:?}"
+        );
+
+        let maker = book.get_order(Id::from_u64(1)).expect("maker still rests");
+        assert_eq!(
+            maker.visible_quantity().as_u64(),
+            10,
+            "rejected update leaves the maker unchanged"
+        );
+    }
+
+    /// `UpdateQuantity` enforces min/max order size on the projected state.
+    #[test]
+    fn update_quantity_enforces_max_order_size() {
+        let mut book: OrderBook<()> = DefaultOrderBook::new("MAXU");
+        book.set_max_order_size(50);
+        book.add_limit_order(Id::from_u64(1), 100, 10, Side::Buy, TimeInForce::Gtc, None)
+            .expect("seed maker");
+
+        let err = book
+            .update_order(OrderUpdate::UpdateQuantity {
+                order_id: Id::from_u64(1),
+                new_quantity: Quantity::new(60),
+            })
+            .expect_err("oversized projected quantity must be rejected");
+        assert!(
+            matches!(err, OrderBookError::OrderSizeOutOfRange { .. }),
+            "expected OrderSizeOutOfRange, got {err:?}"
+        );
+        let maker = book.get_order(Id::from_u64(1)).expect("maker still rests");
+        assert_eq!(maker.visible_quantity().as_u64(), 10);
+    }
+
+    /// `UpdateQuantity` enforces the modify-aware risk gate on the
+    /// projected notional and leaves the maker unchanged on rejection.
+    #[test]
+    fn update_quantity_enforces_risk_notional() {
+        let mut book: OrderBook<()> = DefaultOrderBook::new("RSKU");
+        book.set_risk_config(RiskConfig::new().with_max_notional_per_account(2_000));
+        let user = pricelevel::Hash32::new([9u8; 32]);
+        book.add_limit_order_with_user(
+            Id::from_u64(1),
+            100,
+            10,
+            Side::Buy,
+            TimeInForce::Gtc,
+            user,
+            None,
+        )
+        .expect("seed maker within notional");
+
+        // Projected notional 100 * 30 = 3000 > 2000.
+        let err = book
+            .update_order(OrderUpdate::UpdateQuantity {
+                order_id: Id::from_u64(1),
+                new_quantity: Quantity::new(30),
+            })
+            .expect_err("projected notional breach must be rejected");
+        assert!(
+            matches!(err, OrderBookError::RiskMaxNotional { .. }),
+            "expected RiskMaxNotional, got {err:?}"
+        );
+        let maker = book.get_order(Id::from_u64(1)).expect("maker still rests");
+        assert_eq!(maker.visible_quantity().as_u64(), 10);
+    }
+
+    /// A successful `UpdateQuantity` updates the account's risk counters:
+    /// a follow-up admission that only fits after the decrease succeeds.
+    #[test]
+    fn update_quantity_releases_risk_notional_on_success() {
+        let mut book: OrderBook<()> = DefaultOrderBook::new("RSKD");
+        book.set_risk_config(RiskConfig::new().with_max_notional_per_account(2_000));
+        let user = pricelevel::Hash32::new([9u8; 32]);
+        book.add_limit_order_with_user(
+            Id::from_u64(1),
+            100,
+            15,
+            Side::Buy,
+            TimeInForce::Gtc,
+            user,
+            None,
+        )
+        .expect("seed maker: notional 1500");
+
+        // 1500 resting + 1000 attempted > 2000 → rejected while unchanged.
+        let attempted = book.add_limit_order_with_user(
+            Id::from_u64(2),
+            100,
+            10,
+            Side::Buy,
+            TimeInForce::Gtc,
+            user,
+            None,
+        );
+        assert!(
+            matches!(attempted, Err(OrderBookError::RiskMaxNotional { .. })),
+            "second order must not fit before the decrease"
+        );
+
+        // Decrease to 5 (notional 500) — the applied update must release
+        // 1000 notional in the account counters.
+        let updated = book
+            .update_order(OrderUpdate::UpdateQuantity {
+                order_id: Id::from_u64(1),
+                new_quantity: Quantity::new(5),
+            })
+            .expect("decrease succeeds");
+        assert!(updated.is_some(), "maker was updated in place");
+
+        // Now 500 resting + 1000 attempted <= 2000 → admitted.
+        book.add_limit_order_with_user(
+            Id::from_u64(2),
+            100,
+            10,
+            Side::Buy,
+            TimeInForce::Gtc,
+            user,
+            None,
+        )
+        .expect("second order fits after the counter release");
+    }
+
+    /// An `UpdateQuantity` whose projected two-tranche total overflows is
+    /// rejected with the typed `QuantityOverflow`.
+    #[test]
+    fn update_quantity_rejects_projected_overflow() {
+        let book: OrderBook<()> = DefaultOrderBook::new("OVFU");
+        book.add_iceberg_order(
+            Id::from_u64(1),
+            100,
+            10,
+            50,
+            Side::Buy,
+            TimeInForce::Gtc,
+            None,
+        )
+        .expect("seed iceberg");
+
+        // Projected: visible = u64::MAX, hidden = 50 → overflow.
+        let err = book
+            .update_order(OrderUpdate::UpdateQuantity {
+                order_id: Id::from_u64(1),
+                new_quantity: Quantity::new(u64::MAX),
+            })
+            .expect_err("projected overflow must be rejected");
+        assert!(
+            matches!(err, OrderBookError::QuantityOverflow { .. }),
+            "expected QuantityOverflow, got {err:?}"
+        );
+        let maker = book.get_order(Id::from_u64(1)).expect("maker still rests");
+        assert_eq!(maker.visible_quantity().as_u64(), 10);
+        assert_eq!(maker.hidden_quantity().as_u64(), 50);
+    }
+
+    /// `Ok(None)` is reserved for a genuinely absent order.
+    #[test]
+    fn update_quantity_absent_order_is_ok_none() {
+        let book: OrderBook<()> = DefaultOrderBook::new("NONE");
+        let result = book
+            .update_order(OrderUpdate::UpdateQuantity {
+                order_id: Id::from_u64(404),
+                new_quantity: Quantity::new(5),
+            })
+            .expect("absent order is not an error");
+        assert!(result.is_none(), "absent order reports Ok(None)");
+    }
+}
+
+/// #211 review follow-ups: upstream error propagation on increase, the
+/// counter-increase branch of the risk hook, and the projected-expiry
+/// rejection that riding on the shared validator introduces.
+#[cfg(test)]
+mod tests_mutation_failure_review_gaps {
+    use orderbook_rs::orderbook::risk::RiskConfig;
+    use orderbook_rs::{Clock, DefaultOrderBook, OrderBook, OrderBookError, StubClock};
+    use pricelevel::{Id, OrderUpdate, Quantity, Side, TimeInForce};
+    use std::sync::Arc;
+
+    /// Book-level validation passes but pricelevel's checked aggregate
+    /// rejects the increase: the upstream `PriceLevelError` must surface
+    /// (not `Ok(None)`) and the maker must be unchanged.
+    #[test]
+    fn update_quantity_propagates_upstream_counter_overflow() {
+        let book: OrderBook<()> = DefaultOrderBook::new("UPST");
+        // Same-side level aggregate: (MAX - 10) + 5 = MAX - 5.
+        book.add_limit_order(
+            Id::from_u64(1),
+            100,
+            u64::MAX - 10,
+            Side::Buy,
+            TimeInForce::Gtc,
+            None,
+        )
+        .expect("seed large maker");
+        book.add_limit_order(Id::from_u64(2), 100, 5, Side::Buy, TimeInForce::Gtc, None)
+            .expect("seed small maker");
+
+        // Projected order (quantity 20) passes every book-level rule, but
+        // the level cannot absorb +15 more units.
+        let err = book
+            .update_order(OrderUpdate::UpdateQuantity {
+                order_id: Id::from_u64(2),
+                new_quantity: Quantity::new(20),
+            })
+            .expect_err("upstream counter overflow must surface");
+        assert!(
+            matches!(err, OrderBookError::PriceLevelError(_)),
+            "expected PriceLevelError, got {err:?}"
+        );
+        let maker = book.get_order(Id::from_u64(2)).expect("maker still rests");
+        assert_eq!(maker.visible_quantity().as_u64(), 5, "maker unchanged");
+    }
+
+    /// The increase branch of `on_quantity_update`: growing a resting
+    /// order books additional notional, so a follow-up admission that fit
+    /// before the increase is now rejected.
+    #[test]
+    fn update_quantity_books_risk_notional_on_increase() {
+        let mut book: OrderBook<()> = DefaultOrderBook::new("RSKI");
+        book.set_risk_config(RiskConfig::new().with_max_notional_per_account(2_000));
+        let user = pricelevel::Hash32::new([9u8; 32]);
+        book.add_limit_order_with_user(
+            Id::from_u64(1),
+            100,
+            5,
+            Side::Buy,
+            TimeInForce::Gtc,
+            user,
+            None,
+        )
+        .expect("seed maker: notional 500");
+
+        // Increase to 15 → notional 1500 booked against the account.
+        book.update_order(OrderUpdate::UpdateQuantity {
+            order_id: Id::from_u64(1),
+            new_quantity: Quantity::new(15),
+        })
+        .expect("increase within limits succeeds");
+
+        // 1500 resting + 1000 attempted > 2000 → rejected only if the
+        // increase was actually booked by the risk hook.
+        let attempted = book.add_limit_order_with_user(
+            Id::from_u64(2),
+            100,
+            10,
+            Side::Buy,
+            TimeInForce::Gtc,
+            user,
+            None,
+        );
+        assert!(
+            matches!(attempted, Err(OrderBookError::RiskMaxNotional { .. })),
+            "the booked increase must gate the next admission, got {attempted:?}"
+        );
+    }
+
+    /// An expired-but-unevicted GTD maker can no longer be resized: the
+    /// projected order fails the shared validator's expiry rule.
+    #[test]
+    fn update_quantity_rejects_expired_gtd_maker() {
+        let clock = Arc::new(StubClock::starting_at(1_000));
+        let shared: Arc<dyn Clock> = clock.clone();
+        let book: OrderBook<()> = OrderBook::with_clock("EXPU", shared.clone());
+
+        // GTD maker expiring at t = 2_000; admitted while valid.
+        book.add_limit_order(
+            Id::from_u64(1),
+            100,
+            10,
+            Side::Buy,
+            TimeInForce::Gtd(2_000),
+            None,
+        )
+        .expect("seed unexpired GTD maker");
+
+        // Advance the stub clock past the deadline (each read ticks 1 ms).
+        while clock.peek() <= 2_000 {
+            let _ = shared.now_millis();
+        }
+
+        let err = book
+            .update_order(OrderUpdate::UpdateQuantity {
+                order_id: Id::from_u64(1),
+                new_quantity: Quantity::new(5),
+            })
+            .expect_err("resizing an expired maker must be rejected");
+        assert!(
+            matches!(err, OrderBookError::InvalidOperation { .. }),
+            "expected the expiry rejection, got {err:?}"
+        );
+        let maker = book.get_order(Id::from_u64(1)).expect("maker still rests");
+        assert_eq!(maker.visible_quantity().as_u64(), 10, "maker unchanged");
+    }
+}


### PR DESCRIPTION
## Summary

pricelevel 0.9's mutation APIs are fallible, but three OrderBook paths did
not preserve failure atomicity or surface the errors: `UpdateQuantity`
converted every upstream error into `Ok(None)` and bypassed book-level
validation, a submit could execute real trades before its residual
admission failed, and a failed admission could leave a published empty
level.

## Changes

- **`UpdateQuantity` is validate-first**: the projected post-update order
  (via pricelevel's own `with_reduced_quantity` rewrite, read off the
  level entry already in hand — no `Arc` churn) must pass the shared shape
  validator (tick / lot / min-max / two-tranche representability, and —
  new on this path — expiry and post-only crossing, documented) plus the
  modify-aware risk gate before the level is touched. Upstream
  `PriceLevelError`s propagate; `Ok(None)` is reserved for a genuinely
  absent order. Applied updates adjust per-account risk counters via the
  new `RiskState::on_quantity_update` (same guard discipline as
  `on_fill`).
- **Residual headroom pre-check**: a crossing, non-immediate taker whose
  same-side level cannot absorb its total is rejected before the sweep
  emits any trade. Gated on `will_cross_market` (one best-price cache
  read) so non-crossing adds pay nothing — their admission failure emits
  no trades by definition and is covered by the cleanup path.
- **Empty-level cleanup**: if the (now concurrent-only) post-sweep
  admission fails, a level created empty by the attempt is removed —
  `best_bid` / `best_ask` / cache / depth gauges never expose a phantom
  level — and the failure logs at ERROR.

## Performance

HDR before/after (1M samples, same host):
- `add_only`: p50 958ns → 958ns, p99 64.8µs → 66.2µs (noise).
- `mixed_70_20_10`: p50 833ns → 833ns, p99 31.4µs → 32.5µs (noise).
The first headroom-check shape cost +8.8% on add p50; the
`will_cross_market` gating removed it entirely.

## Testing

- Headroom reject before any trade (locked book via snapshot restore —
  the disaster-recovery shape from the issue).
- Projected lot / max / risk-notional / overflow rejections leave the
  maker unchanged; upstream counter-overflow on increase propagates as
  `PriceLevelError`; expired-GTD resize rejected; `Ok(None)` for absent.
- Risk counters: decrease releases notional (subsequent admission fits);
  increase books it (subsequent admission rejected).
- Reviewed by `hotpath-reviewer` (OK; P2 Arc-churn finding fixed) and
  `architect` (README regen via pre-push; semantics-change documentation
  and the three missing tests added). The level-capacity error stays
  `InvalidOperation` on both paths per the review's assessment; a
  dedicated variant can follow up if callers need to match it.
- Full suite: 810 lib + 496 integration, 0 failed. `make pre-push` clean.

## Stack

- Base branch: `stack/4-210-two-tranche-conservation` (merged as #216)
- Stack: #206 → #207 → #208 → #210 → **#211 (this)** → #209

Closes #211
