### PR TITLE
Make PostOnly and multi-level FOK decisions atomic at the book boundary (#209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **pricelevel 0.9 mutation failures are atomic and observable (#211).**
+- **PostOnly and multi-level FOK decisions are atomic at the book boundary
+  (#209).** Both policies were checked before the sweep but every per-level
+  match ran as a standard GTC taker, leaving a check-then-act race: a
+  post-only order could take liquidity admitted between its precheck and
+  its sweep, and a multi-level fill-or-kill could partially execute when a
+  later level was cancelled after feasibility. PostOnly now threads
+  `TakerKind::PostOnly` into every per-level match — pricelevel's
+  structural guard makes trading impossible under any interleaving, with
+  the sweep-time refusal surfacing as the same `PriceCrossing` rejection
+  as the precheck. The crossability verdict is resolved BEFORE the STP
+  block (post-only precedence over STP, documented on the submit APIs):
+  a rejected post-only is a pure no-op that never cancels same-user
+  makers as a CancelMaker/CancelBoth side effect. Multi-level FOK
+  acquires a new book-level submit gate (`std::sync::RwLock`, write
+  side) across its feasibility check and sweep; every other mutating
+  entry point (add / update / cancel / mass cancel / evict / market
+  sweeps) takes the read side. **Stated limitation:** while an FOK holds
+  the gate the whole book serializes for that window, and FOK acquisition
+  latency grows with in-flight readers (platform locks are
+  writer-preferring, so FOK does not starve); trade / level listeners
+  fire under the gate and must never re-enter the book on the invoking
+  thread (contract documented on `TradeListener` /
+  `PriceLevelChangedListener`). The matching core itself stays lock-free;
+  HDR benches: add-only p50 958→1042ns (the read acquisition),
+  aggressive-walk and mixed p50/p99 unchanged. Pinned by
+  barrier-synchronized race regressions (contra-admission, later-level
+  cancel, same-user CancelMaker) plus deterministic all-or-nothing tests.
   Three gaps closed on the fallible-mutation integration: (1)
   `OrderUpdate::UpdateQuantity` silently converted every upstream
   `PriceLevelError` into `Ok(None)` and bypassed book-level validation — it

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ This order book engine is built with the following design principles:
   the re-exported pricelevel surface changed —
   `PriceLevel::add_order` returns `Result`, `matchable_quantity` takes
   the taker id, `PriceLevelError` gained `DuplicateOrderId`.
+- **Atomic PostOnly / multi-level FOK (#209).** PostOnly submits thread
+  `TakerKind::PostOnly` into every per-level match, making it
+  structurally impossible for a post-only order to take liquidity under
+  any interleaving; fill-or-kill submits hold a new book-level submit
+  gate exclusively across feasibility + sweep, so multi-level
+  all-or-nothing can no longer partially execute against concurrent
+  cancels. Other mutating entry points take the gate's uncontended read
+  side; the matching core stays lock-free.
 - **Atomic, observable mutation failures (#211).** `UpdateQuantity` is
   validate-first (projected tick / lot / min-max / representability /
   risk before touching the level), propagates upstream

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,14 @@
 //!   the re-exported pricelevel surface changed —
 //!   `PriceLevel::add_order` returns `Result`, `matchable_quantity` takes
 //!   the taker id, `PriceLevelError` gained `DuplicateOrderId`.
+//! - **Atomic PostOnly / multi-level FOK (#209).** PostOnly submits thread
+//!   `TakerKind::PostOnly` into every per-level match, making it
+//!   structurally impossible for a post-only order to take liquidity under
+//!   any interleaving; fill-or-kill submits hold a new book-level submit
+//!   gate exclusively across feasibility + sweep, so multi-level
+//!   all-or-nothing can no longer partially execute against concurrent
+//!   cancels. Other mutating entry points take the gate's uncontended read
+//!   side; the matching core stays lock-free.
 //! - **Atomic, observable mutation failures (#211).** `UpdateQuantity` is
 //!   validate-first (projected tick / lot / min-max / representability /
 //!   risk before touching the level), propagates upstream

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -107,6 +107,20 @@ pub struct OrderBook<T = ()> {
     /// A cache for storing best bid/ask prices to avoid recalculation
     pub(super) cache: PriceLevelCache,
 
+    /// Book-level linearization gate for multi-level fill-or-kill (#209).
+    ///
+    /// Every mutating entry point takes the **read** side (uncontended:
+    /// one atomic RMW pair); a fill-or-kill submit takes the **write**
+    /// side across its feasibility check and sweep, so no concurrent
+    /// add / cancel / update can invalidate the all-or-nothing decision
+    /// between the two. This is deliberately `std::sync::RwLock` — the
+    /// contention case (FOK flow) is rare, and a skiplist / dashmap is
+    /// the wrong shape for an exclusion window (see CLAUDE.md). The
+    /// matching hot path itself stays lock-free; the gate wraps entry
+    /// points only and is never held across `.await` (the core is
+    /// synchronous).
+    pub(super) submit_gate: std::sync::RwLock<()>,
+
     /// listens to possible trades when an order is added
     pub trade_listener: Option<TradeListener>,
 
@@ -435,6 +449,7 @@ where
             risk_state: RiskState::new(),
             last_trade_price: AtomicCell::new(0),
             has_traded: AtomicBool::new(false),
+            submit_gate: std::sync::RwLock::new(()),
             market_close_timestamp: AtomicU64::new(0),
             has_market_close: AtomicBool::new(false),
             cache: PriceLevelCache::new(),
@@ -723,6 +738,51 @@ where
             .check_limit_admission(account, price, quantity, reference)
     }
 
+    /// Acquire the shared (read) side of the submit gate (#209). Poisoning
+    /// can only occur if a panic unwound while a guard was held; the
+    /// protected data is `()` so recovery is always safe — log and
+    /// continue rather than propagating the poison.
+    pub(super) fn submit_gate_read(&self) -> std::sync::RwLockReadGuard<'_, ()> {
+        self.submit_gate.read().unwrap_or_else(|poisoned| {
+            tracing::error!("submit gate poisoned by a prior panic; recovering read guard");
+            poisoned.into_inner()
+        })
+    }
+
+    /// Acquire the exclusive (write) side of the submit gate for a
+    /// fill-or-kill submit (#209). See [`Self::submit_gate_read`] for the
+    /// poisoning policy.
+    pub(super) fn submit_gate_write(&self) -> std::sync::RwLockWriteGuard<'_, ()> {
+        self.submit_gate.write().unwrap_or_else(|poisoned| {
+            tracing::error!("submit gate poisoned by a prior panic; recovering write guard");
+            poisoned.into_inner()
+        })
+    }
+
+    /// Acquire the submit gate in the mode the submit needs: exclusive
+    /// for fill-or-kill (its multi-level all-or-nothing decision must not
+    /// interleave with any other mutation), shared for everything else.
+    ///
+    /// # Invariant: no nested acquisition
+    ///
+    /// `std::sync::RwLock` is not reentrant, and the platform
+    /// implementations are writer-preferring — a nested read acquisition
+    /// deadlocks whenever a writer is queued in between. Gate acquisition
+    /// therefore lives ONLY in the public mutating entry points, which
+    /// call ungated inner variants for any internal composition
+    /// (`add_order_inner`, `cancel_order_with_reason`,
+    /// `match_order_with_user_outcome`). The same rule extends to user
+    /// callbacks: see the re-entrancy contract on
+    /// [`TradeListener`](crate::orderbook::trade::TradeListener) and
+    /// [`PriceLevelChangedListener`](crate::orderbook::book_change_event::PriceLevelChangedListener).
+    pub(super) fn acquire_submit_gate(&self, exclusive: bool) -> SubmitGateGuard<'_> {
+        if exclusive {
+            SubmitGateGuard::Write(self.submit_gate_write())
+        } else {
+            SubmitGateGuard::Read(self.submit_gate_read())
+        }
+    }
+
     /// Apply the pre-trade risk gates to an in-place **modify** of a
     /// resting order (`UpdatePrice` / `UpdatePriceAndQuantity` /
     /// `Replace`).
@@ -808,6 +868,7 @@ where
             risk_state: RiskState::new(),
             last_trade_price: AtomicCell::new(0),
             has_traded: AtomicBool::new(false),
+            submit_gate: std::sync::RwLock::new(()),
             market_close_timestamp: AtomicU64::new(0),
             has_market_close: AtomicBool::new(false),
             cache: PriceLevelCache::new(),
@@ -856,6 +917,7 @@ where
             risk_state: RiskState::new(),
             last_trade_price: AtomicCell::new(0),
             has_traded: AtomicBool::new(false),
+            submit_gate: std::sync::RwLock::new(()),
             market_close_timestamp: AtomicU64::new(0),
             has_market_close: AtomicBool::new(false),
             cache: PriceLevelCache::new(),
@@ -2805,6 +2867,8 @@ where
             "Order book {}: Matching notional market order {} for {} at side {:?}",
             self.symbol, order_id, amount, side
         );
+        // #209: shared submit gate — notional market sweeps mutate the book.
+        let _gate = self.submit_gate_read();
         let match_result =
             OrderBook::<T>::match_order_by_amount_with_user(self, order_id, side, amount, user_id)?;
 
@@ -4088,4 +4152,14 @@ struct PreparedSnapshotLevels {
     bids: Vec<(u128, Arc<PriceLevel>)>,
     /// `(price, level)` pairs for the ask side, ascending by price.
     asks: Vec<(u128, Arc<PriceLevel>)>,
+}
+
+/// Guard over the submit gate (#209) in either mode — held for the length
+/// of one mutating entry-point call. Only the drop timing matters, hence
+/// the unused-field allowances.
+pub(super) enum SubmitGateGuard<'a> {
+    /// Shared mode: every non-FOK mutating entry point.
+    Read(#[allow(dead_code)] std::sync::RwLockReadGuard<'a, ()>),
+    /// Exclusive mode: a fill-or-kill submit's feasibility + sweep window.
+    Write(#[allow(dead_code)] std::sync::RwLockWriteGuard<'a, ()>),
 }

--- a/src/orderbook/book_change_event.rs
+++ b/src/orderbook/book_change_event.rs
@@ -43,6 +43,14 @@ pub struct PriceLevelChangedEvent {
 /// This type alias represents a function that will be called whenever
 /// a price level in the order book changes (e.g., order added, cancelled,
 /// matched, or updated).
+/// Callback invoked with every price-level change event.
+///
+/// # Re-entrancy contract (#209)
+///
+/// Fires while the book's submit gate is held. Like
+/// [`TradeListener`](crate::orderbook::trade::TradeListener), it must
+/// never call back into the same `OrderBook`'s mutating API on the
+/// invoking thread — hand the event off to a queue or channel instead.
 pub type PriceLevelChangedListener = Arc<dyn Fn(PriceLevelChangedEvent) + Send + Sync>;
 
 #[cfg(test)]

--- a/src/orderbook/mass_cancel.rs
+++ b/src/orderbook/mass_cancel.rs
@@ -149,6 +149,9 @@ where
     /// # }
     /// ```
     pub fn cancel_all_orders(&self) -> MassCancelResult {
+        // #209: shared submit gate — the bulk walk must not interleave
+        // with a concurrent FOK's exclusive feasibility + sweep window.
+        let _gate = self.submit_gate_read();
         self.cache.invalidate();
         trace!("Order book {}: Mass cancel ALL orders (bulk)", self.symbol);
 
@@ -300,6 +303,9 @@ where
     /// # }
     /// ```
     pub fn cancel_orders_by_side(&self, side: Side) -> MassCancelResult {
+        // #209: shared submit gate — the bulk walk must not interleave
+        // with a concurrent FOK's exclusive feasibility + sweep window.
+        let _gate = self.submit_gate_read();
         trace!(
             "Order book {}: Mass cancel orders on side {}",
             self.symbol, side
@@ -374,6 +380,9 @@ where
     /// # }
     /// ```
     pub fn cancel_orders_by_user(&self, user_id: Hash32) -> MassCancelResult {
+        // #209: shared submit gate — the bulk walk must not interleave
+        // with a concurrent FOK's exclusive feasibility + sweep window.
+        let _gate = self.submit_gate_read();
         trace!(
             "Order book {}: Mass cancel orders for user {}",
             self.symbol, user_id
@@ -448,6 +457,8 @@ where
         min_price: u128,
         max_price: u128,
     ) -> MassCancelResult {
+        // #209: shared submit gate (see `cancel_all_orders`).
+        let _gate = self.submit_gate_read();
         trace!(
             "Order book {}: Mass cancel orders on side {} in price range [{}, {}]",
             self.symbol, side, min_price, max_price
@@ -561,6 +572,8 @@ where
     /// # }
     /// ```
     pub fn evict_expired_orders(&self, now_ms: TimestampMs) -> Vec<Arc<OrderType<T>>> {
+        // #209: shared submit gate (see `cancel_all_orders`).
+        let _gate = self.submit_gate_read();
         let now = now_ms.as_u64();
         trace!(
             "Order book {}: Evicting expired orders as of {} ms",

--- a/src/orderbook/matching.rs
+++ b/src/orderbook/matching.rs
@@ -56,6 +56,11 @@ pub(crate) struct MatchOutcome {
     pub(crate) result: MatchResult,
     /// `true` when STP cancelled the taker, so any residual must not rest.
     pub(crate) taker_stp_cancelled: bool,
+    /// `true` when a per-level post-only guard refused to trade (#209):
+    /// the taker was submitted as [`TakerKind::PostOnly`] and reached a
+    /// crossable level, so the book must reject it (`PriceCrossing`) —
+    /// structurally zero trades were emitted.
+    pub(crate) taker_post_only_rejected: bool,
 }
 
 impl MatchOutcome {
@@ -65,6 +70,7 @@ impl MatchOutcome {
         Self {
             result,
             taker_stp_cancelled: false,
+            taker_post_only_rejected: false,
         }
     }
 }
@@ -223,7 +229,18 @@ where
         quantity: u64,
         limit_price: Option<u128>,
     ) -> Result<MatchResult, OrderBookError> {
-        self.match_order_with_user(order_id, side, quantity, limit_price, Hash32::zero())
+        // #209: shared submit gate; calls the ungated outcome variant so
+        // the non-reentrant gate is acquired exactly once.
+        let _gate = self.submit_gate_read();
+        self.match_order_with_user_outcome(
+            order_id,
+            side,
+            quantity,
+            limit_price,
+            Hash32::zero(),
+            TakerKind::Standard,
+        )
+        .map(|o| o.result)
     }
 
     /// Internal matching function with Self-Trade Prevention support.
@@ -250,8 +267,17 @@ where
         limit_price: Option<u128>,
         taker_user_id: Hash32,
     ) -> Result<MatchResult, OrderBookError> {
-        self.match_order_with_user_outcome(order_id, side, quantity, limit_price, taker_user_id)
-            .map(|o| o.result)
+        // #209: shared submit gate (see `match_order`).
+        let _gate = self.submit_gate_read();
+        self.match_order_with_user_outcome(
+            order_id,
+            side,
+            quantity,
+            limit_price,
+            taker_user_id,
+            TakerKind::Standard,
+        )
+        .map(|o| o.result)
     }
 
     /// Like [`Self::match_order_with_user`] but returns the full [`MatchOutcome`],
@@ -264,6 +290,7 @@ where
         quantity: u64,
         limit_price: Option<u128>,
         taker_user_id: Hash32,
+        taker_kind: TakerKind,
     ) -> Result<MatchOutcome, OrderBookError> {
         self.match_order_inner(
             order_id,
@@ -273,6 +300,7 @@ where
                 limit_price,
             },
             taker_user_id,
+            taker_kind,
         )
     }
 
@@ -302,6 +330,7 @@ where
             side,
             MatchMode::QuoteAmount { amount },
             taker_user_id,
+            TakerKind::Standard,
         )
         .map(|o| o.result)
     }
@@ -327,6 +356,7 @@ where
         side: Side,
         mode: MatchMode,
         taker_user_id: Hash32,
+        taker_kind: TakerKind,
     ) -> Result<MatchOutcome, OrderBookError> {
         self.cache.invalidate();
         let mut match_result =
@@ -377,6 +407,7 @@ where
 
         // Track whether STP cancelled the taker
         let mut stp_taker_cancelled = false;
+        let mut post_only_rejected = false;
 
         // Iterate through prices in optimal order (already sorted by SkipMap)
         // For buy orders: iterate asks in ascending order (best ask first)
@@ -408,6 +439,37 @@ where
 
             // Get price level value from the entry
             let price_level = entry.value();
+
+            // --- Post-only crossability verdict (#209) ---
+            // Resolved BEFORE the STP block: a post-only taker must be a
+            // pure no-op on rejection, and the CancelMaker / CancelBoth
+            // arms below cancel same-user makers as a side effect. The
+            // probe delegates to pricelevel's structural guard — for a
+            // `TakerKind::PostOnly` taker `match_order` is a guaranteed
+            // zero-mutation dry run: `Rejected` when the level holds
+            // matchable depth (self-id-skips and unmatchable resting
+            // orders excluded), `NotFilled` otherwise. Post-only
+            // therefore always resolves to either a clean walk-on or a
+            // clean `PriceCrossing` rejection — same policy as the
+            // `will_cross_market` precheck, makers untouched, STP never
+            // consulted (post-only precedence over STP is intentional
+            // and documented on `update_order` / `add_post_only_order`).
+            if taker_kind.is_post_only() {
+                let probe = price_level.match_order(
+                    qty_cap,
+                    order_id,
+                    TimeInForce::Gtc,
+                    taker_kind,
+                    taker_ts,
+                    &self.transaction_id_generator,
+                );
+                if probe.outcome().was_rejected() {
+                    post_only_rejected = true;
+                    break;
+                }
+                // No matchable depth at this crossing level; walk on.
+                continue;
+            }
 
             // --- STP pre-processing ---
             // When STP is active, check for self-trade conflicts before matching.
@@ -442,7 +504,7 @@ where
                                     match_qty,
                                     order_id,
                                     TimeInForce::Gtc,
-                                    TakerKind::Standard,
+                                    taker_kind,
                                     taker_ts,
                                     &self.transaction_id_generator,
                                 );
@@ -507,7 +569,7 @@ where
                                     match_qty,
                                     order_id,
                                     TimeInForce::Gtc,
-                                    TakerKind::Standard,
+                                    taker_kind,
                                     taker_ts,
                                     &self.transaction_id_generator,
                                 );
@@ -549,7 +611,7 @@ where
                 qty_cap,
                 order_id,
                 TimeInForce::Gtc,
-                TakerKind::Standard,
+                taker_kind,
                 taker_ts,
                 &self.transaction_id_generator,
             );
@@ -685,6 +747,7 @@ where
         Ok(MatchOutcome {
             result: match_result,
             taker_stp_cancelled: stp_taker_cancelled,
+            taker_post_only_rejected: post_only_rejected,
         })
     }
 

--- a/src/orderbook/modifications.rs
+++ b/src/orderbook/modifications.rs
@@ -6,7 +6,7 @@ use crate::orderbook::order_state::{CancelReason, OrderStatus};
 use crate::orderbook::reject_reason::RejectReason;
 use crate::orderbook::trade::TradeResult;
 use either::Either;
-use pricelevel::{Id, OrderType, OrderUpdate, PriceLevel, Quantity, Side};
+use pricelevel::{Id, OrderType, OrderUpdate, PriceLevel, Quantity, Side, TakerKind};
 use std::sync::Arc;
 use tracing::trace;
 
@@ -274,6 +274,9 @@ where
         &self,
         update: OrderUpdate,
     ) -> Result<Option<Arc<OrderType<T>>>, OrderBookError> {
+        // #209: shared submit gate for the whole modify — its internal
+        // cancel-then-add sequences call the ungated inner variants.
+        let _gate = self.submit_gate_read();
         // Gate non-cancel variants on the kill switch. Cancel passes
         // through unchanged so operators can drain the book. The
         // existing order stays live — only the modification is
@@ -357,8 +360,21 @@ where
                     // updated order. `add_order` re-runs its own checks;
                     // post-cancel the account count is restored so its risk
                     // check passes — consistent with the pre-guard.
-                    self.cancel_order(order_id)?;
-                    let result = self.add_order(new_order)?;
+                    // Ungated inner variants: `update_order` already holds
+                    // the shared submit gate (#209); the public wrappers
+                    // would re-acquire it (std RwLock is not reentrant).
+                    // The re-add runs under the SHARED gate, so it must
+                    // never be a fill-or-kill (whose all-or-nothing window
+                    // requires the exclusive gate). Unreachable today — an
+                    // FOK never rests, so it can never be modified — but
+                    // enforced so a future TIF change cannot silently void
+                    // the #209 guarantee.
+                    debug_assert!(
+                        !new_order.is_fill_or_kill(),
+                        "a resting order can never carry FOK; the shared-gate re-add relies on it"
+                    );
+                    self.cancel_order_with_reason(order_id, CancelReason::UserRequested)?;
+                    let result = self.add_order_inner(new_order, false)?.0;
                     Ok(Some(result))
                 } else {
                     Ok(None) // Order not found
@@ -522,8 +538,21 @@ where
 
                     // Both checks passed: cancel the original and add the
                     // updated order.
-                    self.cancel_order(order_id)?;
-                    let result = self.add_order(new_order)?;
+                    // Ungated inner variants: `update_order` already holds
+                    // the shared submit gate (#209); the public wrappers
+                    // would re-acquire it (std RwLock is not reentrant).
+                    // The re-add runs under the SHARED gate, so it must
+                    // never be a fill-or-kill (whose all-or-nothing window
+                    // requires the exclusive gate). Unreachable today — an
+                    // FOK never rests, so it can never be modified — but
+                    // enforced so a future TIF change cannot silently void
+                    // the #209 guarantee.
+                    debug_assert!(
+                        !new_order.is_fill_or_kill(),
+                        "a resting order can never carry FOK; the shared-gate re-add relies on it"
+                    );
+                    self.cancel_order_with_reason(order_id, CancelReason::UserRequested)?;
+                    let result = self.add_order_inner(new_order, false)?.0;
                     Ok(Some(result))
                 } else {
                     Ok(None) // Order not found
@@ -708,8 +737,21 @@ where
 
                     // Both checks passed: cancel the original and add the
                     // new order.
-                    self.cancel_order(order_id)?;
-                    let result = self.add_order(new_order)?;
+                    // Ungated inner variants: `update_order` already holds
+                    // the shared submit gate (#209); the public wrappers
+                    // would re-acquire it (std RwLock is not reentrant).
+                    // The re-add runs under the SHARED gate, so it must
+                    // never be a fill-or-kill (whose all-or-nothing window
+                    // requires the exclusive gate). Unreachable today — an
+                    // FOK never rests, so it can never be modified — but
+                    // enforced so a future TIF change cannot silently void
+                    // the #209 guarantee.
+                    debug_assert!(
+                        !new_order.is_fill_or_kill(),
+                        "a resting order can never carry FOK; the shared-gate re-add relies on it"
+                    );
+                    self.cancel_order_with_reason(order_id, CancelReason::UserRequested)?;
+                    let result = self.add_order_inner(new_order, false)?.0;
                     Ok(Some(result))
                 } else {
                     Ok(None) // Original order not found
@@ -723,6 +765,9 @@ where
     /// Tracks the cancellation as `CancelReason::UserRequested` in the
     /// order state tracker (if configured).
     pub fn cancel_order(&self, order_id: Id) -> Result<Option<Arc<OrderType<T>>>, OrderBookError> {
+        // #209: shared gate — a concurrent FOK's exclusive window must not
+        // interleave with this cancel.
+        let _gate = self.submit_gate_read();
         self.cancel_order_with_reason(order_id, CancelReason::UserRequested)
     }
 
@@ -1233,6 +1278,9 @@ where
     /// validation, tick/lot validation, or matching work.
     #[inline]
     pub fn add_order(&self, order: OrderType<T>) -> Result<Arc<OrderType<T>>, OrderBookError> {
+        // #209: shared gate for ordinary submits, exclusive for FOK so its
+        // feasibility + sweep window excludes every concurrent mutation.
+        let _gate = self.acquire_submit_gate(order.is_fill_or_kill());
         self.add_order_inner(order, false).map(|(order, _)| order)
     }
 
@@ -1272,6 +1320,8 @@ where
         &self,
         order: OrderType<T>,
     ) -> Result<(Arc<OrderType<T>>, Option<TradeResult>), OrderBookError> {
+        // #209: same gating as `add_order`.
+        let _gate = self.acquire_submit_gate(order.is_fill_or_kill());
         self.add_order_inner(order, true)
     }
 
@@ -1416,17 +1466,56 @@ where
 
         self.cache.invalidate();
         // Attempt to match the order immediately (with STP user_id propagation).
-        // The outcome also carries whether STP cancelled the taker (#97).
+        // The outcome also carries whether STP cancelled the taker (#97) and
+        // whether a per-level post-only guard refused to trade (#209).
+        // Threading the taker's real kind gives post-only its structural
+        // never-trades guarantee under every interleaving — the
+        // `will_cross_market` precheck in `validate_order_shape` remains
+        // only a fast-path reject.
+        // Deliberately total over today's `TakerKind`: everything that is
+        // not post-only — including MarketToLimit, which is MEANT to take
+        // liquidity — sweeps as `Standard`. A future third `TakerKind`
+        // variant must be routed here explicitly.
+        let taker_kind = if order.is_post_only() {
+            TakerKind::PostOnly
+        } else {
+            TakerKind::Standard
+        };
         let MatchOutcome {
             result: match_result,
             taker_stp_cancelled,
+            taker_post_only_rejected,
         } = self.match_order_with_user_outcome(
             order.id(),
             order.side(),
             order.total_quantity(), // Use total quantity for matching
             Some(order.price().as_u128()),
             order.user_id(),
+            taker_kind,
         )?;
+
+        // #209: the sweep reached a crossable level with a post-only taker.
+        // pricelevel structurally refused to trade (zero fills), so reject
+        // exactly like the precheck would have — the race between precheck
+        // and sweep can no longer make a post-only order take liquidity.
+        if taker_post_only_rejected {
+            self.track_state(
+                order.id(),
+                OrderStatus::Rejected {
+                    reason: RejectReason::PostOnlyWouldCross,
+                },
+            );
+            crate::orderbook::metrics::record_reject(RejectReason::PostOnlyWouldCross);
+            return Err(OrderBookError::PriceCrossing {
+                price: order.price().as_u128(),
+                side: order.side(),
+                opposite_price: if order.side() == Side::Buy {
+                    self.best_ask().unwrap_or(0)
+                } else {
+                    self.best_bid().unwrap_or(0)
+                },
+            });
+        }
 
         // Emit trades BEFORE any early return below: the STP taker-cancel and
         // unfillable-IOC paths return `Err` after real (non-self) fills already

--- a/src/orderbook/operations.rs
+++ b/src/orderbook/operations.rs
@@ -308,6 +308,18 @@ where
 
     /// Add a post-only order to the book with an explicit `user_id`.
     ///
+    /// # Crossing policy (#209)
+    ///
+    /// A post-only order that would take liquidity is **rejected**
+    /// (`PriceCrossing`), never re-priced/slid, and the rejection is a
+    /// pure no-op on the book. The guarantee is structural: beyond the
+    /// fast-path precheck, every per-level match runs with
+    /// `TakerKind::PostOnly`, so the order cannot trade under any
+    /// interleaving. Post-only takes precedence over STP — the
+    /// crossability verdict is resolved before the STP block, so a
+    /// rejected post-only never cancels same-user makers as a
+    /// CancelMaker / CancelBoth side effect.
+    ///
     /// # Arguments
     /// * `id` — Unique order identifier.
     /// * `price` — Limit price.
@@ -319,7 +331,9 @@ where
     ///
     /// # Errors
     /// Returns [`OrderBookError::MissingUserId`] when STP is enabled and
-    /// `user_id` is `Hash32::zero()`.
+    /// `user_id` is `Hash32::zero()`, and
+    /// [`OrderBookError::PriceCrossing`] when the order would take
+    /// liquidity.
     #[allow(clippy::too_many_arguments)]
     pub fn add_post_only_order_with_user(
         &self,

--- a/src/orderbook/trade.rs
+++ b/src/orderbook/trade.rs
@@ -147,6 +147,18 @@ fn compute_quote_notional(match_result: &MatchResult) -> u128 {
 }
 
 /// Trade listener specification using Arc for shared ownership
+/// Callback invoked with every emitted [`TradeResult`].
+///
+/// # Re-entrancy contract (#209)
+///
+/// The listener may fire while the book's submit gate is held (the
+/// trade-emitting entry points hold it across the sweep — exclusively for
+/// a fill-or-kill submit). A listener must therefore **never call back
+/// into the same `OrderBook`'s mutating API** (add / submit / cancel /
+/// update / mass cancel / market sweeps) on the invoking thread: the gate
+/// is not reentrant and the nested acquisition can deadlock. Hand the
+/// event off to a queue or channel instead and mutate from another
+/// context.
 pub type TradeListener = Arc<dyn Fn(&TradeResult) + Send + Sync>;
 
 /// A trade event that includes additional metadata for processing

--- a/tests/unit/atomic_postonly_fok_tests.rs
+++ b/tests/unit/atomic_postonly_fok_tests.rs
@@ -1,0 +1,326 @@
+//! #209: PostOnly and multi-level FOK decisions are atomic at the book
+//! boundary.
+//!
+//! - PostOnly threads `TakerKind::PostOnly` into every per-level match, so
+//!   pricelevel's structural guard makes trading impossible under any
+//!   interleaving; the `will_cross_market` precheck is only a fast path.
+//! - A fill-or-kill submit holds the submit gate exclusively across its
+//!   feasibility check and sweep, so concurrent adds/cancels cannot turn
+//!   all-or-nothing into a partial execution.
+//!
+//! The race regressions are barrier-synchronized threaded loops: the
+//! asserted invariants are structural, so they must hold under every
+//! interleaving the loops produce.
+
+#[cfg(test)]
+mod tests_atomic_postonly_fok {
+    use orderbook_rs::{DefaultOrderBook, OrderBook, OrderBookError, TradeResult};
+    use pricelevel::{Hash32, Id, Side, TimeInForce};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Barrier, Mutex};
+    use std::thread;
+
+    /// Deterministic: a post-only submit into a crossed book is rejected
+    /// with `PriceCrossing` and zero trades.
+    #[test]
+    fn post_only_into_crossed_book_rejects_with_zero_trades() {
+        let book: OrderBook<()> = DefaultOrderBook::new("POX");
+        book.add_limit_order(Id::from_u64(1), 100, 10, Side::Sell, TimeInForce::Gtc, None)
+            .expect("seed ask");
+
+        let err = book
+            .add_post_only_order(Id::from_u64(2), 100, 5, Side::Buy, TimeInForce::Gtc, None)
+            .expect_err("crossing post-only must be rejected");
+        assert!(
+            matches!(err, OrderBookError::PriceCrossing { .. }),
+            "expected PriceCrossing, got {err:?}"
+        );
+        assert!(book.last_trade_price().is_none(), "zero trades emitted");
+        assert!(
+            book.get_order(Id::from_u64(2)).is_none(),
+            "rejected post-only never rests"
+        );
+    }
+
+    /// Deterministic: multi-level FOK stays all-or-nothing single-threaded
+    /// (full fill across two levels; kill with zero trades when short).
+    #[test]
+    fn multi_level_fok_all_or_nothing_deterministic() {
+        let book: OrderBook<()> = DefaultOrderBook::new("FOKD");
+        book.add_limit_order(Id::from_u64(1), 100, 5, Side::Sell, TimeInForce::Gtc, None)
+            .expect("seed ask 100");
+        book.add_limit_order(Id::from_u64(2), 101, 5, Side::Sell, TimeInForce::Gtc, None)
+            .expect("seed ask 101");
+
+        // Short by 5 units: killed with zero fills.
+        let err = book
+            .add_limit_order(Id::from_u64(3), 101, 15, Side::Buy, TimeInForce::Fok, None)
+            .expect_err("infeasible FOK must be killed");
+        assert!(
+            matches!(err, OrderBookError::InsufficientLiquidity { .. }),
+            "expected InsufficientLiquidity, got {err:?}"
+        );
+        assert!(book.last_trade_price().is_none(), "kill emits zero trades");
+
+        // Exactly feasible: fills both levels completely.
+        let (_, trade_result) = book
+            .add_order_with_result(pricelevel::OrderType::Standard {
+                id: Id::from_u64(4),
+                price: pricelevel::Price::new(101),
+                quantity: pricelevel::Quantity::new(10),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: pricelevel::TimestampMs::new(0),
+                time_in_force: TimeInForce::Fok,
+                extra_fields: (),
+            })
+            .expect("feasible FOK fills in full");
+        let filled: u64 = trade_result
+            .as_ref()
+            .map(fills_in(Id::from_u64(4)))
+            .unwrap_or(0);
+        assert_eq!(filled, 10, "FOK filled its complete quantity");
+    }
+
+    /// Sums the taker's filled quantity in a `TradeResult`.
+    fn fills_in(taker: Id) -> impl Fn(&TradeResult) -> u64 {
+        move |tr: &TradeResult| {
+            tr.match_result
+                .trades()
+                .as_vec()
+                .iter()
+                .filter(|t| t.taker_order_id() == taker)
+                .map(|t| t.quantity().as_u64())
+                .sum()
+        }
+    }
+
+    /// Race regression (issue repro): a contra maker is admitted while a
+    /// post-only submit is in flight. Under the structural guard the
+    /// post-only order must never appear as taker in any trade, in any
+    /// interleaving.
+    #[test]
+    fn post_only_never_trades_under_concurrent_contra_admission() {
+        const ROUNDS: u64 = 200;
+        let violations = Arc::new(AtomicU64::new(0));
+
+        for round in 0..ROUNDS {
+            let mut book: OrderBook<()> = DefaultOrderBook::new("PORACE");
+            let trades: Arc<Mutex<Vec<(Id, u64)>>> = Arc::new(Mutex::new(Vec::new()));
+            let sink = Arc::clone(&trades);
+            book.trade_listener = Some(Arc::new(move |tr: &TradeResult| {
+                let mut sunk = sink.lock().expect("trade sink lock");
+                for t in tr.match_result.trades().as_vec() {
+                    sunk.push((t.taker_order_id(), t.quantity().as_u64()));
+                }
+            }));
+            let book = Arc::new(book);
+
+            let po_id = Id::from_u64(1_000 + round);
+            let barrier = Arc::new(Barrier::new(2));
+
+            let contra_book = Arc::clone(&book);
+            let contra_barrier = Arc::clone(&barrier);
+            let contra = thread::spawn(move || {
+                contra_barrier.wait();
+                // Crossing ask admitted concurrently with the post-only buy.
+                let _ = contra_book.add_limit_order(
+                    Id::from_u64(500_000 + round),
+                    100,
+                    5,
+                    Side::Sell,
+                    TimeInForce::Gtc,
+                    None,
+                );
+            });
+
+            let po_book = Arc::clone(&book);
+            let po_barrier = Arc::clone(&barrier);
+            let po = thread::spawn(move || {
+                po_barrier.wait();
+                // Either rests (no cross yet) or is rejected (cross seen) —
+                // both fine; trading is the only forbidden outcome.
+                let _ =
+                    po_book.add_post_only_order(po_id, 100, 5, Side::Buy, TimeInForce::Gtc, None);
+            });
+
+            contra.join().expect("contra thread");
+            po.join().expect("post-only thread");
+
+            let taker_fills: u64 = trades
+                .lock()
+                .expect("trade sink lock")
+                .iter()
+                .filter(|(taker, _)| *taker == po_id)
+                .map(|(_, qty)| *qty)
+                .sum();
+            if taker_fills > 0 {
+                violations.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        assert_eq!(
+            violations.load(Ordering::Relaxed),
+            0,
+            "a post-only order took liquidity in some interleaving"
+        );
+    }
+
+    /// Race regression (issue repro): a later-level maker is cancelled
+    /// while a multi-level FOK is in flight. Under the exclusive submit
+    /// gate every FOK outcome is all-or-nothing: its fills are exactly 0
+    /// or exactly the full quantity — never partial.
+    #[test]
+    fn multi_level_fok_never_partial_under_concurrent_cancel() {
+        const ROUNDS: u64 = 200;
+        const FOK_QTY: u64 = 10;
+
+        for round in 0..ROUNDS {
+            let book: Arc<OrderBook<()>> = Arc::new(DefaultOrderBook::new("FOKRACE"));
+            book.add_limit_order(Id::from_u64(1), 100, 5, Side::Sell, TimeInForce::Gtc, None)
+                .expect("seed ask 100");
+            book.add_limit_order(Id::from_u64(2), 101, 5, Side::Sell, TimeInForce::Gtc, None)
+                .expect("seed ask 101");
+
+            let fok_id = Id::from_u64(10_000 + round);
+            let barrier = Arc::new(Barrier::new(2));
+
+            let cancel_book = Arc::clone(&book);
+            let cancel_barrier = Arc::clone(&barrier);
+            let canceller = thread::spawn(move || {
+                cancel_barrier.wait();
+                let _ = cancel_book.cancel_order(Id::from_u64(2));
+            });
+
+            let fok_book = Arc::clone(&book);
+            let fok_barrier = Arc::clone(&barrier);
+            let fok = thread::spawn(move || {
+                fok_barrier.wait();
+                fok_book.add_order_with_result(pricelevel::OrderType::Standard {
+                    id: fok_id,
+                    price: pricelevel::Price::new(101),
+                    quantity: pricelevel::Quantity::new(FOK_QTY),
+                    side: Side::Buy,
+                    user_id: Hash32::zero(),
+                    timestamp: pricelevel::TimestampMs::new(0),
+                    time_in_force: TimeInForce::Fok,
+                    extra_fields: (),
+                })
+            });
+
+            canceller.join().expect("cancel thread");
+            let outcome = fok.join().expect("fok thread");
+
+            let filled = match &outcome {
+                Ok((_, trade_result)) => trade_result.as_ref().map(fills_in(fok_id)).unwrap_or(0),
+                Err(_) => 0,
+            };
+            assert!(
+                filled == 0 || filled == FOK_QTY,
+                "round {round}: FOK filled {filled} of {FOK_QTY} — partial execution leaked"
+            );
+            // An Ok FOK must be a FULL fill, never a resting remainder.
+            if let Ok((_, trade_result)) = &outcome {
+                let filled_ok = trade_result.as_ref().map(fills_in(fok_id)).unwrap_or(0);
+                assert_eq!(
+                    filled_ok, FOK_QTY,
+                    "round {round}: Ok FOK must fill in full"
+                );
+                assert!(
+                    book.get_order(fok_id).is_none(),
+                    "round {round}: FOK never rests"
+                );
+            }
+        }
+    }
+}
+
+/// #209 review follow-up: post-only precedence over STP. The crossability
+/// verdict is resolved BEFORE the STP block, so a rejected post-only is a
+/// pure no-op even when the crossing liquidity belongs to the same user
+/// under CancelMaker — no maker is cancelled as a side effect, and no
+/// trade is ever emitted.
+#[cfg(test)]
+mod tests_post_only_stp_precedence {
+    use orderbook_rs::{DefaultOrderBook, OrderBook, STPMode, TradeResult};
+    use pricelevel::{Hash32, Id, Side, TimeInForce};
+    use std::sync::{Arc, Barrier, Mutex};
+    use std::thread;
+
+    #[test]
+    fn post_only_rejection_never_cancels_same_user_makers() {
+        const ROUNDS: u64 = 200;
+        let user = Hash32::new([7u8; 32]);
+
+        for round in 0..ROUNDS {
+            let mut book: OrderBook<()> = DefaultOrderBook::new("POSTP");
+            book.set_stp_mode(STPMode::CancelMaker);
+            let trades: Arc<Mutex<u64>> = Arc::new(Mutex::new(0));
+            let sink = Arc::clone(&trades);
+            book.trade_listener = Some(Arc::new(move |tr: &TradeResult| {
+                *sink.lock().expect("sink") += tr.match_result.trades().len() as u64;
+            }));
+            let book = Arc::new(book);
+
+            let ask_id = Id::from_u64(500_000 + round);
+            let po_id = Id::from_u64(1_000 + round);
+            let barrier = Arc::new(Barrier::new(2));
+
+            let ask_book = Arc::clone(&book);
+            let ask_barrier = Arc::clone(&barrier);
+            let ask_thread = thread::spawn(move || {
+                ask_barrier.wait();
+                ask_book.add_limit_order_with_user(
+                    ask_id,
+                    100,
+                    5,
+                    Side::Sell,
+                    TimeInForce::Gtc,
+                    user,
+                    None,
+                )
+            });
+
+            let po_book = Arc::clone(&book);
+            let po_barrier = Arc::clone(&barrier);
+            let po_thread = thread::spawn(move || {
+                po_barrier.wait();
+                po_book.add_post_only_order_with_user(
+                    po_id,
+                    100,
+                    5,
+                    Side::Buy,
+                    TimeInForce::Gtc,
+                    user,
+                    None,
+                )
+            });
+
+            let ask_outcome = ask_thread.join().expect("ask thread");
+            let po_outcome = po_thread.join().expect("post-only thread");
+
+            // Same-user post-only vs same-user ask: no interleaving may
+            // produce a trade (post-only never takes; the ask taker is
+            // self-trade-prevented against a resting post-only).
+            assert_eq!(
+                *trades.lock().expect("sink"),
+                0,
+                "round {round}: zero trades under every interleaving"
+            );
+
+            // Post-only precedence over STP: a rejected post-only is a
+            // pure no-op — the same-user ask (when it rested) keeps its
+            // full quantity; CancelMaker must not have fired for it.
+            if po_outcome.is_err() && ask_outcome.is_ok() {
+                let ask = book
+                    .get_order(ask_id)
+                    .expect("round {round}: rejected post-only must leave the ask resting");
+                assert_eq!(
+                    ask.visible_quantity().as_u64(),
+                    5,
+                    "round {round}: rejected post-only must not touch the same-user maker"
+                );
+            }
+        }
+    }
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -1,3 +1,4 @@
+mod atomic_postonly_fok_tests;
 mod book_coverage_tests;
 mod book_manager_cross_cancel_tests;
 mod clock_determinism_tests;


### PR DESCRIPTION
## Summary

PostOnly and fill-or-kill were checked before the sweep but every per-level
match ran as a standard GTC taker, leaving a check-then-act race: a
post-only order could take liquidity admitted between its precheck and
sweep, and a multi-level FOK could partially execute when a later level was
cancelled after feasibility. pricelevel 0.9's atomic per-level guards are
now actually used, plus a book-level gate for the multi-level case.

## Changes

- **PostOnly, structural:** the taker's `TakerKind` threads through
  `match_order_inner`; a post-only taker resolves its crossability verdict
  per level via pricelevel's zero-mutation guard **before the STP block**
  (post-only precedence over STP, documented): rejection is a pure no-op
  (`PriceCrossing`, makers untouched — including same-user makers that
  CancelMaker would otherwise cancel) and trading is impossible under any
  interleaving.
- **Multi-level FOK, exclusive gate:** new `submit_gate: RwLock<()>` on
  `OrderBook`; FOK submits hold the write side across feasibility + sweep,
  every other mutating entry point (add / update / cancel / mass cancel /
  evict / market sweeps) takes the read side via gated public wrappers
  calling ungated inner variants (no nested acquisition — enumerated and
  verified by the hot-path review, including replay and repricing paths).
- Re-entrancy contract documented on `TradeListener` /
  `PriceLevelChangedListener` (listeners fire under the gate and must not
  re-enter the book on the invoking thread) and on `acquire_submit_gate`;
  `debug_assert!(!is_fill_or_kill())` guards the shared-gate re-add arms.

## Technical decisions

- Post-only rejection maps to the same `PriceCrossing` as the precheck —
  reject-not-slide policy documented on `add_post_only_order_with_user`.
- MarketToLimit deliberately sweeps as `TakerKind::Standard` (it is meant
  to take liquidity); the kind computation is documented as total.
- **Stated limitation:** an FOK write window serializes the book, and FOK
  acquisition latency grows with in-flight readers (platform rwlocks are
  writer-preferring, so FOK does not starve).

## Performance

HDR before/after (1M samples, same host):
- `add_only`: p50 958 → 1042ns (+84ns — the read acquisition), p99 66.8µs → 68.0µs.
- `aggressive_walk`: p50 83 → 42ns, p99 8.9µs → 7.9µs (≤ noise).
- `mixed_70_20_10`: p50 875 → 834ns, p99 33.2µs → 32.5µs (≤ noise).

## Testing

- Deterministic: crossed-book post-only rejects with zero trades;
  multi-level FOK full-fill and zero-fill kill.
- Barrier-synchronized race regressions (200 rounds each): concurrent
  contra admission never lets a post-only trade; concurrent later-level
  cancel never yields a partial FOK; same-user CancelMaker interleavings
  emit zero trades and never cancel the maker on a rejected post-only.
- Reviewed by `hotpath-reviewer` (OK; P2 listener-reentrancy contract and
  P3s addressed) and `microstructure-critic` (its top finding — STP side
  effects on post-only rejection — fixed by hoisting the verdict above the
  STP block; docs corrected accordingly).
- Full suite: 810 lib + 508 integration, 0 failed. `make pre-push` clean.

## Stack

- Base branch: `stack/5-211-atomic-mutation-failures` (merged as #217)
- Stack: #206 → #207 → #208 → #210 → #211 → **#209 (this, last)**

Closes #209
